### PR TITLE
feat: support server-stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It's like tRPC but...
 ## Developing
 
 - `npm i` -- install dependencies
-- `npm check` -- lint
-- `npm format` -- format
-- `npm test` -- run tests
+- `npm run check` -- lint
+- `npm run format` -- format
+- `npm run test` -- run tests
 - `npm publish` -- cut a new release (should bump version in package.json first)

--- a/__tests__/handler.test.ts
+++ b/__tests__/handler.test.ts
@@ -5,12 +5,13 @@ import {
   FallibleServiceConstructor,
   STREAM_ERROR,
   TestServiceConstructor,
+  NumberEmitter,
 } from './fixtures';
 import { UNCAUGHT_ERROR } from '../router/result';
 
 describe('server-side test', () => {
   const service = TestServiceConstructor();
-  const initialState = { count: 0 };
+  const initialState = { count: 0, emitter: new NumberEmitter() };
 
   test('rpc basic', async () => {
     const add = asClientRpc(initialState, service.procedures.add);
@@ -20,7 +21,10 @@ describe('server-side test', () => {
   });
 
   test('rpc initial state', async () => {
-    const add = asClientRpc({ count: 5 }, service.procedures.add);
+    const add = asClientRpc(
+      { count: 5, emitter: new NumberEmitter() },
+      service.procedures.add,
+    );
     const result = await add({ n: 6 });
     assert(result.ok);
     expect(result.payload).toStrictEqual({ result: 11 });

--- a/__tests__/serialize.test.ts
+++ b/__tests__/serialize.test.ts
@@ -4,6 +4,7 @@ import {
   BinaryFileServiceConstructor,
   FallibleServiceConstructor,
   TestServiceConstructor,
+  NumberEmitter,
 } from './fixtures';
 
 describe('serialize service to jsonschema', () => {
@@ -11,7 +12,10 @@ describe('serialize service to jsonschema', () => {
     const service = TestServiceConstructor();
     expect(serializeService(service)).toStrictEqual({
       name: 'test',
-      state: { count: 0 },
+      state: {
+        count: 0,
+        emitter: new NumberEmitter(),
+      },
       procedures: {
         add: {
           input: {
@@ -30,6 +34,21 @@ describe('serialize service to jsonschema', () => {
           },
           errors: { not: {} },
           type: 'rpc',
+        },
+        events: {
+          input: {
+            properties: {},
+            type: 'object',
+          },
+          output: {
+            properties: {
+              value: { type: 'number' },
+            },
+            required: ['value'],
+            type: 'object',
+          },
+          errors: { not: {} },
+          type: 'server-stream',
         },
         echo: {
           input: {

--- a/router/builder.ts
+++ b/router/builder.ts
@@ -7,7 +7,7 @@ import { Result, RiverError, RiverUncaughtSchema } from './result';
 /**
  * The valid {@link Procedure} types.
  */
-export type ValidProcType = 'stream' | 'rpc';
+export type ValidProcType = 'stream' | 'server-stream' | 'rpc';
 
 /**
  * A generic procedure listing where the keys are the names of the procedures
@@ -111,9 +111,9 @@ export type ProcType<
 > = S['procedures'][ProcName]['type'];
 
 /**
- * Defines a Procedure type that can be either an RPC or a stream procedure.
+ * Defines a Procedure type that can be either an RPC, server-stream, or a stream procedure.
  * @template State - The TypeBox schema of the state object.
- * @template Ty - The type of the procedure, either 'rpc' or 'stream'.
+ * @template Ty - The type of the procedure, either 'rpc', 'server-stream', or 'stream'.
  * @template I - The TypeBox schema of the input object.
  * @template O - The TypeBox schema of the output object.
  */
@@ -132,6 +132,18 @@ export type Procedure<
         context: ServiceContextWithState<State>,
         input: TransportMessage<Static<I>>,
       ) => Promise<TransportMessage<Result<Static<O>, Static<E>>>>;
+      type: Ty;
+    }
+  : Ty extends 'server-stream'
+  ? {
+      input: I;
+      output: O;
+      errors: E;
+      handler: (
+        context: ServiceContextWithState<State>,
+        input: TransportMessage<Static<I>>,
+        output: Pushable<TransportMessage<Result<Static<O>, Static<E>>>>,
+      ) => Promise<void>;
       type: Ty;
     }
   : {

--- a/router/client.ts
+++ b/router/client.ts
@@ -41,6 +41,21 @@ type ServiceClient<Router extends AnyService> = {
           Static<ProcErrors<Router, ProcName>>
         >
       >
+    : ProcType<Router, ProcName> extends 'server-stream'
+    ? // server-stream case
+      // TODO: This should have a single input
+      () => Promise<
+        [
+          Pushable<Static<ProcInput<Router, ProcName>>>, // input
+          AsyncIter<
+            Result<
+              Static<ProcOutput<Router, ProcName>>,
+              Static<ProcErrors<Router, ProcName>>
+            >
+          >, // output
+          () => void, // close handle
+        ]
+      >
     : // get stream case
       () => Promise<
         [
@@ -172,6 +187,7 @@ export const createClient = <Srv extends Server<Record<string, AnyService>>>(
 
       return [inputStream, outputStream, closeHandler];
     } else {
+      // TODO: how do we support server-stream?
       // rpc case
       const m = msg(
         transport.clientId,

--- a/router/server.ts
+++ b/router/server.ts
@@ -144,6 +144,18 @@ export async function createServer<Services extends Record<string, AnyService>>(
             .handler(serviceContext, incoming, outgoing)
             .catch(errorHandler),
         );
+      } else if (procedure.type === 'server-stream') {
+        openPromises.push(
+          (async () => {
+            for await (const inputMessage of incoming) {
+              openPromises.push(
+                procedure
+                  .handler(serviceContext, inputMessage, outgoing)
+                  .catch(errorHandler),
+              );
+            }
+          })(),
+        );
       } else if (procedure.type === 'rpc') {
         openPromises.push(
           (async () => {


### PR DESCRIPTION
gRPC supports four kinds of RPCs: unary, client-stream, server-stream and bidirectional. We want to support them all too.

This change adds support for server-stream RPCs (one message from the client, a stream of messages from the server).