### PR TITLE
feat: abstract payload type into own type, support union type

### DIFF
--- a/router/builder.ts
+++ b/router/builder.ts
@@ -110,6 +110,8 @@ export type ProcType<
   ProcName extends keyof S['procedures'],
 > = S['procedures'][ProcName]['type'];
 
+export type PayloadType = TObject | TUnion<TObject[]>;
+
 /**
  * Defines a Procedure type that can be either an RPC or a stream procedure.
  * @template State - The TypeBox schema of the state object.
@@ -120,8 +122,8 @@ export type ProcType<
 export type Procedure<
   State extends object | unknown,
   Ty extends ValidProcType,
-  I extends TObject,
-  O extends TObject,
+  I extends PayloadType,
+  O extends PayloadType,
   E extends RiverError,
 > = Ty extends 'rpc'
   ? {
@@ -162,8 +164,8 @@ export type Procedure<
 export type AnyProcedure = Procedure<
   object,
   ValidProcType,
-  TObject,
-  TObject,
+  PayloadType,
+  PayloadType,
   RiverError
 >;
 
@@ -214,8 +216,8 @@ export class ServiceBuilder<T extends Service<string, object, ProcListing>> {
   defineProcedure<
     ProcName extends string,
     Ty extends ValidProcType,
-    I extends TObject,
-    O extends TObject,
+    I extends PayloadType,
+    O extends PayloadType,
     E extends RiverError,
   >(
     procName: ProcName,

--- a/router/index.ts
+++ b/router/index.ts
@@ -8,6 +8,7 @@ export type {
   ProcOutput,
   ProcType,
   Procedure,
+  PayloadType,
 } from './builder';
 export { createClient } from './client';
 export type { ServerClient } from './client';

--- a/router/server.ts
+++ b/router/server.ts
@@ -1,6 +1,6 @@
-import { Static, TObject } from '@sinclair/typebox';
+import { Static } from '@sinclair/typebox';
 import { Connection, Transport } from '../transport/transport';
-import { AnyProcedure, AnyService } from './builder';
+import { AnyProcedure, AnyService, PayloadType } from './builder';
 import { pushable } from 'it-pushable';
 import type { Pushable } from 'it-pushable';
 import {
@@ -36,7 +36,7 @@ export interface Server<Services> {
 interface ProcStream {
   incoming: Pushable<TransportMessage>;
   outgoing: Pushable<
-    TransportMessage<Result<Static<TObject>, Static<RiverError>>>
+    TransportMessage<Result<Static<PayloadType>, Static<RiverError>>>
   >;
   promises: {
     outputHandler: Promise<unknown>;

--- a/util/testHelpers.ts
+++ b/util/testHelpers.ts
@@ -2,7 +2,7 @@ import WebSocket from 'isomorphic-ws';
 import { WebSocketServer } from 'ws';
 import http from 'http';
 import { WebSocketClientTransport } from '../transport/impls/ws/client';
-import { Static, TObject } from '@sinclair/typebox';
+import { Static } from '@sinclair/typebox';
 import { Procedure, ServiceContext } from '../router';
 import {
   OpaqueTransportMessage,
@@ -21,6 +21,7 @@ import {
 } from '../router/result';
 import { Codec } from '../codec';
 import { WebSocketServerTransport } from '../transport/impls/ws/server';
+import { PayloadType } from '../router/builder';
 
 /**
  * Creates a WebSocket server instance using the provided HTTP server.
@@ -100,8 +101,8 @@ export function createWsTransports(
  */
 export function asClientRpc<
   State extends object | unknown,
-  I extends TObject,
-  O extends TObject,
+  I extends PayloadType,
+  O extends PayloadType,
   E extends RiverError,
 >(
   state: State,
@@ -140,8 +141,8 @@ export function asClientRpc<
  */
 export function asClientStream<
   State extends object | unknown,
-  I extends TObject,
-  O extends TObject,
+  I extends PayloadType,
+  O extends PayloadType,
   E extends RiverError,
 >(
   state: State,
@@ -221,8 +222,8 @@ export function asClientStream<
  */
 export function asClientSubscription<
   State extends object | unknown,
-  I extends TObject,
-  O extends TObject,
+  I extends PayloadType,
+  O extends PayloadType,
   E extends RiverError,
 >(
   state: State,


### PR DESCRIPTION
river currently only supports object types, let's support unions too :)