### PR TITLE
feat: Complete all RPC kinds

### DIFF
--- a/__tests__/serialize.test.ts
+++ b/__tests__/serialize.test.ts
@@ -51,6 +51,45 @@ describe('serialize service to jsonschema', () => {
           errors: { not: {} },
           type: 'stream',
         },
+        echoWithPrefix: {
+          errors: {
+            not: {},
+          },
+          init: {
+            properties: {
+              prefix: {
+                type: 'string',
+              },
+            },
+            required: ['prefix'],
+            type: 'object',
+          },
+          input: {
+            properties: {
+              end: {
+                type: 'boolean',
+              },
+              ignore: {
+                type: 'boolean',
+              },
+              msg: {
+                type: 'string',
+              },
+            },
+            required: ['msg', 'ignore'],
+            type: 'object',
+          },
+          output: {
+            properties: {
+              response: {
+                type: 'string',
+              },
+            },
+            required: ['response'],
+            type: 'object',
+          },
+          type: 'stream',
+        },
       },
     });
   });

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@replit/river",
   "sideEffects": false,
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "type": "module",
   "exports": {
     ".": "./dist/router/index.js",


### PR DESCRIPTION
We have three of the four gRPC RPC kinds (rpc, stream, subscription).

This change adds the final RPC kind: upload (client-stream, single
message response). It also adds the option of adding an `init` type
to an RPC, where we can send a message of another schema before the main
stream, which is a very common pattern used in filesystem (i.e. open
file for writing, where the first message is the path and the other
messages are the chunks) and collaboration (i.e. first message is the
channel name and the rest of the bidirectional messages are the actual
stream).