### PR TITLE
Add ping/pong to close unhealthy connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@replit/river",
   "sideEffects": false,
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.8.1",
+  "version": "0.8.2-1",
   "type": "module",
   "exports": {
     ".": "./dist/router/index.js",


### PR DESCRIPTION
There are likely to be situations where we don't receive the necessary close information from a client (they just power off their computer, for example). But we want to eventually be able to clean up these connections on the server. We can establish a ping-pong protocol every 30s to check if a client connection is still healthy.

## How it works:

Healthy connection case:
* server sends a "ping" message to client, marks the connection as "unhealthy", and sets a timer for 30s
* client receives "ping" message and sends a "pong" message
* server receives "pong" message and marks client as "healthy"
* server's 30s timer expires, it sees that the client connection is marked as "healthy", and repeats step 1

Unhealthy connection case:
* server sends a "ping" message to client, marks the connection as "unhealthy", and sets a timer for 30s
* client is dead, it never receives the message, and sends nothing back
* server's 30s timer expires, it sees that the client connection is marked as "unhealthy", and deletes it from the connection map


## Other thoughts:

The "bit" setup seems like it could get out of hand pretty quickly if we end up having a couple more control messages. We might want to change "control flags" to be something like a KV map. I don't think the few extra bytes would really make a difference, and it might simplify the code.


## Tests
```
~/replit/river [ping-pong] 
> npm run test             

> @replit/river@0.8.2-1 test
> vitest --test-timeout=500


 DEV  v0.34.6 /Users/brady/replit/river

 ✓ __tests__/serialize.test.ts (3)
 ✓ transport/impls/stdio/stdio.test.ts (1)
 ✓ transport/impls/ws/ws.test.ts (5)
 ✓ __tests__/invariants.test.ts (5)
 ❯ __tests__/e2e.test.ts (32)
   ✓ codec -- 'naive' (5)
 ✓ __tests__/serialize.test.ts (3)
 ✓ transport/impls/stdio/stdio.test.ts (1)
 ✓ transport/impls/ws/ws.test.ts (5)
 ✓ __tests__/invariants.test.ts (5)
 ✓ __tests__/serialize.test.ts (3)
 ✓ transport/impls/stdio/stdio.test.ts (1)
 ✓ transport/impls/ws/ws.test.ts (5)
 ✓ __tests__/invariants.test.ts (5)
 ✓ __tests__/e2e.test.ts (32)
 ✓ codec/codec.test.ts (10)
 ✓ __tests__/handler.test.ts (6)
 ✓ transport/message.test.ts (6)
 ✓ __tests__/typescript-stress.test.ts (2)
 ✓ __tests__/fixtures/observable.test.ts (4)

 Test Files  10 passed (10)
      Tests  74 passed (74)
   Start at  12:53:54
   Duration  859ms (transform 423ms, setup 1ms, collect 1.15s, tests 426ms, environment 1ms, prepare 663ms)


 PASS  Waiting for file changes...
```


