### PR TITLE
fix: Don't require _every_ message to contain procedure information

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@replit/river",
   "sideEffects": false,
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "type": "module",
   "exports": {
     ".": "./dist/router/index.js",

--- a/transport/impls/ws/ws.test.ts
+++ b/transport/impls/ws/ws.test.ts
@@ -38,9 +38,16 @@ describe('sending and receiving across websockets works', async () => {
 
   test('sending respects to/from fields', async () => {
     const makeDummyMessage = (from: string, to: string, message: string) => {
-      return msg(from, to, 'service', 'proc', 'stream', {
-        msg: message,
-      });
+      return msg(
+        from,
+        to,
+        'stream',
+        {
+          msg: message,
+        },
+        'service',
+        'proc',
+      );
     };
 
     const clientId1 = 'client1';

--- a/transport/message.test.ts
+++ b/transport/message.test.ts
@@ -10,7 +10,7 @@ import { describe, test, expect } from 'vitest';
 
 describe('message helpers', () => {
   test('ack', () => {
-    const m = msg('a', 'b', 'svc', 'proc', 'stream', { test: 1 });
+    const m = msg('a', 'b', 'stream', { test: 1 }, 'svc', 'proc');
     m.controlFlags |= ControlFlags.AckBit;
     expect(m).toHaveProperty('controlFlags');
     expect(isAck(m.controlFlags)).toBe(true);
@@ -19,7 +19,7 @@ describe('message helpers', () => {
   });
 
   test('streamOpen', () => {
-    const m = msg('a', 'b', 'svc', 'proc', 'stream', { test: 1 });
+    const m = msg('a', 'b', 'stream', { test: 1 }, 'svc', 'proc');
     m.controlFlags |= ControlFlags.StreamOpenBit;
     expect(m).toHaveProperty('controlFlags');
     expect(isAck(m.controlFlags)).toBe(false);
@@ -28,7 +28,7 @@ describe('message helpers', () => {
   });
 
   test('streamClose', () => {
-    const m = msg('a', 'b', 'svc', 'proc', 'stream', { test: 1 });
+    const m = msg('a', 'b', 'stream', { test: 1 }, 'svc', 'proc');
     m.controlFlags |= ControlFlags.StreamClosedBit;
     expect(m).toHaveProperty('controlFlags');
     expect(isAck(m.controlFlags)).toBe(false);
@@ -37,7 +37,7 @@ describe('message helpers', () => {
   });
 
   test('reply', () => {
-    const m = msg('a', 'b', 'svc', 'proc', 'stream', { test: 1 });
+    const m = msg('a', 'b', 'stream', { test: 1 }, 'svc', 'proc');
     const payload = { cool: 2 };
     const resp = reply(m, payload);
     expect(resp.id).not.toBe(m.id);
@@ -47,14 +47,14 @@ describe('message helpers', () => {
   });
 
   test('default message has no control flags set', () => {
-    const m = msg('a', 'b', 'svc', 'proc', 'stream', { test: 1 });
+    const m = msg('a', 'b', 'stream', { test: 1 }, 'svc', 'proc');
     expect(isAck(m.controlFlags)).toBe(false);
     expect(isStreamOpen(m.controlFlags)).toBe(false);
     expect(isStreamClose(m.controlFlags)).toBe(false);
   });
 
   test('combining control flags works', () => {
-    const m = msg('a', 'b', 'svc', 'proc', 'stream', { test: 1 });
+    const m = msg('a', 'b', 'stream', { test: 1 }, 'svc', 'proc');
     m.controlFlags |= ControlFlags.StreamOpenBit;
     expect(isStreamOpen(m.controlFlags)).toBe(true);
     expect(isStreamClose(m.controlFlags)).toBe(false);

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -210,10 +210,21 @@ export abstract class Transport<ConnType extends Connection> {
     }
 
     if (Value.Check(OpaqueTransportMessageSchema, parsedMsg)) {
-      return parsedMsg;
+      // JSON can't express the difference between `undefined` and `null`, so we need to patch that.
+      return {
+        ...parsedMsg,
+        serviceName:
+          parsedMsg.serviceName === null ? undefined : parsedMsg.serviceName,
+        procedureName:
+          parsedMsg.procedureName === null
+            ? undefined
+            : parsedMsg.procedureName,
+      };
     } else {
       log?.warn(
-        `${this.clientId} -- received invalid msg: ${JSON.stringify(msg)}`,
+        `${this.clientId} -- received invalid msg: ${JSON.stringify(
+          parsedMsg,
+        )}`,
       );
       return null;
     }

--- a/util/testHelpers.ts
+++ b/util/testHelpers.ts
@@ -483,7 +483,7 @@ export function payloadToTransportMessage<Payload extends object>(
   from: TransportClientId = 'client',
   to: TransportClientId = 'SERVER',
 ): TransportMessage<Payload> {
-  return msg(from, to, 'service', 'procedure', streamId ?? 'stream', payload);
+  return msg(from, to, streamId ?? 'stream', payload, 'service', 'procedure');
 }
 
 /**


### PR DESCRIPTION
Previously we had the requirement that every single message in a stream had to have the service name + procedure. But that's very wasteful and also kind of awkward to be saving in other implementations.

This change does a little refactor so that the server no longer relies on having this information in every message in a stream. In doing this refactor, we also now can reason about what the first message is, and can now correctly validate that the initialization message is received first and then all future messages only comply with the regular input type. Also fixed a bug where an overly zealous listener would incorrectly close all streams upon the first close message.

Do yourself a favor and [review this with whitespace turned off](https://github.com/replit/river/pull/32/files?diff=split&w=1).