### PR TITLE
fix: Send a close stream message when the `stream` input ends

### DIFF
--- a/router/client.ts
+++ b/router/client.ts
@@ -233,6 +233,8 @@ export const createClient = <Srv extends Server<Record<string, AnyService>>>(
 
           transport.send(m);
         }
+
+        transport.send(closeStream(transport.clientId, serverId, streamId));
       })();
 
       // transport -> output
@@ -243,6 +245,7 @@ export const createClient = <Srv extends Server<Record<string, AnyService>>>(
 
         if (isStreamClose(msg.controlFlags)) {
           outputStream.end();
+          transport.removeEventListener('message', listener);
         } else {
           outputStream.push(msg.payload);
         }
@@ -293,6 +296,7 @@ export const createClient = <Srv extends Server<Record<string, AnyService>>>(
 
         if (isStreamClose(msg.controlFlags)) {
           outputStream.end();
+          transport.removeEventListener('message', listener);
         } else {
           outputStream.push(msg.payload);
         }

--- a/util/testHelpers.ts
+++ b/util/testHelpers.ts
@@ -179,6 +179,7 @@ export function asClientStream<
     for await (const transportRes of transportOutput) {
       rawOutput.push(transportRes.payload);
     }
+    rawOutput.end();
   })();
 
   // handle
@@ -262,6 +263,7 @@ export function asClientStreamWithInitialization<
     for await (const transportRes of transportOutput) {
       rawOutput.push(transportRes.payload);
     }
+    rawOutput.end();
   })();
 
   // handle
@@ -328,6 +330,7 @@ export function asClientSubscription<
     for await (const transportRes of transportOutput) {
       rawOutput.push(transportRes.payload);
     }
+    rawOutput.end();
   })();
 
   return async (


### PR DESCRIPTION
We currently don't send one of these messages when the `stream` input ends, so the server can't know that the client is done!

This change now correctly sends the end-of-stream message.