### PR TITLE
fix: Fix stdio transport path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@replit/river",
   "sideEffects": false,
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "type": "module",
   "exports": {
     ".": "./dist/router/index.js",
@@ -12,7 +12,7 @@
     "./transport": "./dist/transport/index.js",
     "./transport/ws/client": "./dist/transport/impls/ws/client.js",
     "./transport/ws/server": "./dist/transport/impls/ws/server.js",
-    "./transport/stdio": "./dist/transport/impls/stdio.js"
+    "./transport/stdio": "./dist/transport/impls/stdio/stdio.js"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Turns out that this is in the wrong path.

proof:

```shell
~/river$ pnpm build && ls ./dist/transport/impls/stdio/stdio.js

> @replit/river@0.9.3 build /home/lhchavez/river
> rm -rf ./dist && tsc

./dist/transport/impls/stdio/stdio.js
```