### PR TITLE
[WS-2010] ergonomics: `Transport<T>` -> `T`

### DIFF
--- a/__tests__/disconnects.test.ts
+++ b/__tests__/disconnects.test.ts
@@ -56,7 +56,6 @@ describe('procedures should handle unexpected disconnects', async () => {
 
     // start procedure
     await client.test.add.rpc({ n: 3 });
-
     expect(clientTransport.connections.size).toEqual(1);
     expect(serverTransport.connections.size).toEqual(1);
 
@@ -76,8 +75,8 @@ describe('procedures should handle unexpected disconnects', async () => {
       }),
     );
 
-    expect(clientTransport.connections.size).toEqual(0);
-    expect(serverTransport.connections.size).toEqual(0);
+    waitFor(() => expect(clientTransport.connections.size).toEqual(0));
+    waitFor(() => expect(serverTransport.connections.size).toEqual(0));
     await ensureServerIsClean(server);
   });
 
@@ -112,8 +111,8 @@ describe('procedures should handle unexpected disconnects', async () => {
       }),
     );
 
-    expect(clientTransport.connections.size).toEqual(0);
-    expect(serverTransport.connections.size).toEqual(0);
+    waitFor(() => expect(clientTransport.connections.size).toEqual(0));
+    waitFor(() => expect(serverTransport.connections.size).toEqual(0));
     await ensureServerIsClean(server);
   });
 
@@ -238,8 +237,8 @@ describe('procedures should handle unexpected disconnects', async () => {
       }),
     );
 
-    expect(clientTransport.connections.size).toEqual(0);
-    expect(serverTransport.connections.size).toEqual(0);
+    waitFor(() => expect(clientTransport.connections.size).toEqual(0));
+    waitFor(() => expect(serverTransport.connections.size).toEqual(0));
     await ensureServerIsClean(server);
   });
 });

--- a/__tests__/handler.test.ts
+++ b/__tests__/handler.test.ts
@@ -1,10 +1,8 @@
 import {
   asClientRpc,
   asClientStream,
-  asClientStreamWithInitialization,
   asClientSubscription,
   asClientUpload,
-  asClientUploadWithInitialization,
   iterNext,
 } from '../util/testHelpers';
 import { assert, describe, expect, test } from 'vitest';
@@ -21,10 +19,9 @@ import { Observable } from './fixtures/observable';
 
 describe('server-side test', () => {
   const service = TestServiceConstructor();
-  const initialState = { count: 0 };
 
   test('rpc basic', async () => {
-    const add = asClientRpc(initialState, service.procedures.add);
+    const add = asClientRpc({ count: 0 }, service.procedures.add);
     const result = await add({ n: 3 });
     assert(result.ok);
     expect(result.payload).toStrictEqual({ result: 3 });
@@ -57,7 +54,7 @@ describe('server-side test', () => {
 
   test('stream basic', async () => {
     const [input, output] = asClientStream(
-      initialState,
+      { count: 0 },
       service.procedures.echo,
     );
 
@@ -78,8 +75,8 @@ describe('server-side test', () => {
   });
 
   test('stream with initialization', async () => {
-    const [input, output] = asClientStreamWithInitialization(
-      initialState,
+    const [input, output] = asClientStream(
+      { count: 0 },
       service.procedures.echoWithPrefix,
       { prefix: 'test' },
     );
@@ -148,7 +145,10 @@ describe('server-side test', () => {
 
   test('uploads', async () => {
     const service = UploadableServiceConstructor();
-    const [input, result] = asClientUpload({}, service.procedures.addMultiple);
+    const [input, result] = await asClientUpload(
+      {},
+      service.procedures.addMultiple,
+    );
 
     input.push({ n: 1 });
     input.push({ n: 2 });
@@ -158,7 +158,7 @@ describe('server-side test', () => {
 
   test('uploads with initialization', async () => {
     const service = UploadableServiceConstructor();
-    const [input, result] = asClientUploadWithInitialization(
+    const [input, result] = await asClientUpload(
       {},
       service.procedures.addMultipleWithPrefix,
       { prefix: 'test' },

--- a/__tests__/typescript-stress.test.ts
+++ b/__tests__/typescript-stress.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import { Procedure, ServiceBuilder, serializeService } from '../router/builder';
 import { Type } from '@sinclair/typebox';
-import { MessageId, OpaqueTransportMessage, reply } from '../transport/message';
+import { MessageId, OpaqueTransportMessage } from '../transport/message';
 import { createServer } from '../router/server';
 import { Connection, Transport } from '../transport/transport';
 import { NaiveJsonCodec } from '../codec/json';
@@ -32,10 +32,10 @@ const fnBody: Procedure<{}, 'rpc', typeof input, typeof output, typeof errors> =
     output,
     errors,
     async handler(_state, msg) {
-      if ('c' in msg.payload) {
-        return reply(msg, Ok({ b: msg.payload.c }));
+      if ('c' in msg) {
+        return Ok({ b: msg.c });
       } else {
-        return reply(msg, Ok({ b: msg.payload.a }));
+        return Ok({ b: msg.a });
       }
     },
   };

--- a/router/builder.ts
+++ b/router/builder.ts
@@ -1,6 +1,5 @@
 import { TObject, Static, Type, TUnion } from '@sinclair/typebox';
 import type { Pushable } from 'it-pushable';
-import { TransportMessage } from '../transport/message';
 import { ServiceContextWithState } from './context';
 import { Result, RiverError, RiverUncaughtSchema } from './result';
 
@@ -176,8 +175,8 @@ export type Procedure<
         errors: E;
         handler: (
           context: ServiceContextWithState<State>,
-          input: TransportMessage<Static<I>>,
-        ) => Promise<TransportMessage<Result<Static<O>, Static<E>>>>;
+          input: Static<I>,
+        ) => Promise<Result<Static<O>, Static<E>>>;
         type: Ty;
       }
     : never
@@ -190,9 +189,9 @@ export type Procedure<
         errors: E;
         handler: (
           context: ServiceContextWithState<State>,
-          init: TransportMessage<Static<Init>>,
-          input: AsyncIterable<TransportMessage<Static<I>>>,
-        ) => Promise<TransportMessage<Result<Static<O>, Static<E>>>>;
+          init: Static<Init>,
+          input: AsyncIterableIterator<Static<I>>,
+        ) => Promise<Result<Static<O>, Static<E>>>;
         type: Ty;
       }
     : {
@@ -201,8 +200,8 @@ export type Procedure<
         errors: E;
         handler: (
           context: ServiceContextWithState<State>,
-          input: AsyncIterable<TransportMessage<Static<I>>>,
-        ) => Promise<TransportMessage<Result<Static<O>, Static<E>>>>;
+          input: AsyncIterableIterator<Static<I>>,
+        ) => Promise<Result<Static<O>, Static<E>>>;
         type: Ty;
       }
   : Ty extends 'subscription'
@@ -213,8 +212,8 @@ export type Procedure<
         errors: E;
         handler: (
           context: ServiceContextWithState<State>,
-          input: TransportMessage<Static<I>>,
-          output: Pushable<TransportMessage<Result<Static<O>, Static<E>>>>,
+          input: Static<I>,
+          output: Pushable<Result<Static<O>, Static<E>>>,
         ) => Promise<void>;
         type: Ty;
       }
@@ -228,9 +227,9 @@ export type Procedure<
         errors: E;
         handler: (
           context: ServiceContextWithState<State>,
-          init: TransportMessage<Static<Init>>,
-          input: AsyncIterable<TransportMessage<Static<I>>>,
-          output: Pushable<TransportMessage<Result<Static<O>, Static<E>>>>,
+          init: Static<Init>,
+          input: AsyncIterableIterator<Static<I>>,
+          output: Pushable<Result<Static<O>, Static<E>>>,
         ) => Promise<void>;
         type: Ty;
       }
@@ -240,8 +239,8 @@ export type Procedure<
         errors: E;
         handler: (
           context: ServiceContextWithState<State>,
-          input: AsyncIterable<TransportMessage<Static<I>>>,
-          output: Pushable<TransportMessage<Result<Static<O>, Static<E>>>>,
+          input: AsyncIterableIterator<Static<I>>,
+          output: Pushable<Result<Static<O>, Static<E>>>,
         ) => Promise<void>;
         type: Ty;
       }

--- a/router/client.ts
+++ b/router/client.ts
@@ -26,7 +26,7 @@ import { EventMap } from '../transport/events';
 import { ServiceDefs } from './defs';
 
 // helper to make next, yield, and return all the same type
-type AsyncIter<T> = AsyncGenerator<T, T, unknown>;
+export type AsyncIter<T> = AsyncGenerator<T, T, unknown>;
 
 /**
  * A helper type to transform an actual service type into a type


### PR DESCRIPTION
- Now that we no longer need the handler to be responsible to sending people, we can now avoid the service writer from reasoning about transport level messages (and possible sending invalid transport messages)
- The send-to-multiple-people thing can be achieved with the combination of subscriptions + observables