### PR TITLE
fix: Fix stdio, again

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "type": "module",
   "exports": {
     ".": {
@@ -64,7 +64,7 @@
   "scripts": {
     "check": "tsc --noEmit && npx prettier . --check",
     "format": "npx prettier . --write",
-    "build": "tsup && du -sh dist",
+    "build": "rm -rf dist && tsup && du -sh dist",
     "prepack": "npm run build",
     "release": "npm publish --access public",
     "test:ui": "echo \"remember to go to /__vitest__ in the webview\" && vitest --ui --api.host 0.0.0.0 --api.port 3000",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     'transport/index.ts',
     'transport/impls/ws/client.ts',
     'transport/impls/ws/server.ts',
-    'transport/stdio.ts',
+    'transport/impls/stdio/stdio.ts',
   ],
   format: ['esm', 'cjs'],
   sourcemap: false,


### PR DESCRIPTION
A previous fix added tsup, but missed the full path of stdio.

This change adds stdio back into tsup.config.ts and now ensures that `__tests__` are not added to the bundle and that `dist` is clean to begin with.

# Test

```shell
~/river$ pnpm run build && find dist/transport/impls/stdio/

> @replit/river@0.10.4 build /home/lhchavez/river
> rm -rf dist && tsup && du -sh dist

CLI Building entry: router/index.ts, logging/index.ts, codec/index.ts, util/testHelpers.ts, transport/index.ts, transport/impls/ws/client.ts, transport/impls/ws/server.ts, transport/impls/stdio/stdio.ts
...
400K    dist
dist/transport/impls/stdio/
dist/transport/impls/stdio/stdio.d.cts
dist/transport/impls/stdio/stdio.js
dist/transport/impls/stdio/stdio.d.ts
dist/transport/impls/stdio/stdio.cjs
```