### PR TITLE
docs: fix websocketUrl in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ import WebSocket from 'isomorphic-ws';
 import { WebSocketClientTransport } from '@replit/river/transport/ws/client';
 import { createClient } from '@replit/river';
 
-const websocketUrl = `wss://localhost:3000`;
+const websocketUrl = `ws://localhost:3000`;
 const transport = new WebSocketClientTransport(
   async () => new WebSocket(websocketUrl),
   'my-client-id',


### PR DESCRIPTION
Turned `wss://localhost:3000` into `ws://localhost:3000` since the example server provided doesn't do ssl.