### PR TITLE
deps: Lockdown typebox peer dependency to patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "nanoid": "^4.0.2"
       },
       "devDependencies": {
-        "@sinclair/typebox": "~0.31.28",
         "@types/ws": "^8.5.5",
         "@vitest/ui": "^1.1.0",
         "prettier": "^3.0.0",
@@ -687,7 +686,7 @@
       "version": "0.31.28",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.31.28.tgz",
       "integrity": "sha512-/s55Jujywdw/Jpan+vsy6JZs1z2ZTGxTmbZTPiuSL2wz9mfzA2gN1zzaqmvfi4pq+uOt7Du85fkiwv5ymW84aQ==",
-      "dev": true
+      "peer": true
     },
     "node_modules/@types/node": {
       "version": "20.5.7",
@@ -3366,7 +3365,7 @@
       "version": "0.31.28",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.31.28.tgz",
       "integrity": "sha512-/s55Jujywdw/Jpan+vsy6JZs1z2ZTGxTmbZTPiuSL2wz9mfzA2gN1zzaqmvfi4pq+uOt7Du85fkiwv5ymW84aQ==",
-      "dev": true
+      "peer": true
     },
     "@types/node": {
       "version": "20.5.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "nanoid": "^4.0.2"
       },
       "devDependencies": {
+        "@sinclair/typebox": "~0.31.28",
         "@types/ws": "^8.5.5",
         "@vitest/ui": "^1.1.0",
         "prettier": "^3.0.0",
@@ -25,7 +26,7 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@sinclair/typebox": "^0.31.28",
+        "@sinclair/typebox": "~0.31.28",
         "isomorphic-ws": "^5.0.0",
         "ws": "^8.13.0"
       }
@@ -686,7 +687,7 @@
       "version": "0.31.28",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.31.28.tgz",
       "integrity": "sha512-/s55Jujywdw/Jpan+vsy6JZs1z2ZTGxTmbZTPiuSL2wz9mfzA2gN1zzaqmvfi4pq+uOt7Du85fkiwv5ymW84aQ==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "20.5.7",
@@ -3365,7 +3366,7 @@
       "version": "0.31.28",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.31.28.tgz",
       "integrity": "sha512-/s55Jujywdw/Jpan+vsy6JZs1z2ZTGxTmbZTPiuSL2wz9mfzA2gN1zzaqmvfi4pq+uOt7Du85fkiwv5ymW84aQ==",
-      "peer": true
+      "dev": true
     },
     "@types/node": {
       "version": "20.5.7",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "ws": "^8.13.0"
   },
   "devDependencies": {
-    "@sinclair/typebox": "~0.31.28",
     "@types/ws": "^8.5.5",
     "@vitest/ui": "^1.1.0",
     "prettier": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -57,11 +57,12 @@
     "nanoid": "^4.0.2"
   },
   "peerDependencies": {
-    "@sinclair/typebox": "^0.31.28",
+    "@sinclair/typebox": "~0.31.28",
     "isomorphic-ws": "^5.0.0",
     "ws": "^8.13.0"
   },
   "devDependencies": {
+    "@sinclair/typebox": "~0.31.28",
     "@types/ws": "^8.5.5",
     "@vitest/ui": "^1.1.0",
     "prettier": "^3.0.0",


### PR DESCRIPTION
Typebox is a peer dependency because we want people to author their own types. Typebox is v0.x.x which means it can break at any change.

https://github.com/sinclairzx81/typebox/pull/689 0.32.0 seems to be a breaking change.

I chose to just lock down minor changes since that seems to match what typebox maintainer abides by..

If locking down the version becomes an issue we can make typebox a direct dependency and re-export it for consumers (but that kinda sucks)