### PR TITLE
protocol: frame messages with length-prefix instead of newlines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.10.13",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.10.13",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.10.13",
+  "version": "0.11.0",
   "type": "module",
   "exports": {
     ".": {

--- a/transport/impls/stdio/connection.ts
+++ b/transport/impls/stdio/connection.ts
@@ -1,5 +1,5 @@
 import { Connection, Transport, TransportClientId } from '../..';
-import { defaultDelimiter } from '../../transforms/delim';
+import { Delimiter } from '../../transforms/delim';
 
 export class StreamConnection extends Connection {
   output: NodeJS.WritableStream;
@@ -18,7 +18,7 @@ export class StreamConnection extends Connection {
       return false;
     }
 
-    return this.output.write(Buffer.concat([payload, defaultDelimiter]));
+    return this.output.write(Delimiter.writeDelimited(payload));
   }
 
   async close() {

--- a/transport/impls/stdio/connection.ts
+++ b/transport/impls/stdio/connection.ts
@@ -1,5 +1,5 @@
 import { Connection, Transport, TransportClientId } from '../..';
-import { Delimiter } from '../../transforms/delim';
+import { MessageFramer } from '../../transforms/messageFraming';
 
 export class StreamConnection extends Connection {
   output: NodeJS.WritableStream;
@@ -18,7 +18,7 @@ export class StreamConnection extends Connection {
       return false;
     }
 
-    return this.output.write(Delimiter.writeDelimited(payload));
+    return this.output.write(MessageFramer.write(payload));
   }
 
   async close() {

--- a/transport/impls/stdio/stdio.ts
+++ b/transport/impls/stdio/stdio.ts
@@ -2,7 +2,7 @@ import { Codec } from '../../../codec';
 import { NaiveJsonCodec } from '../../../codec/json';
 import { log } from '../../../logging';
 import { TransportClientId } from '../../message';
-import { Delimiter } from '../../transforms/delim';
+import { MessageFramer } from '../../transforms/messageFraming';
 import { Transport } from '../../transport';
 import { StreamConnection } from './connection';
 
@@ -37,8 +37,8 @@ export class StdioTransport extends Transport<StreamConnection> {
     const options = { ...defaultOptions, ...providedOptions };
     super(options.codec, clientId);
 
-    const delimStream = Delimiter.createDelimitedStream();
-    this.input = input.pipe(delimStream);
+    const framedMessageStream = MessageFramer.createFramedStream();
+    this.input = input.pipe(framedMessageStream);
     this.output = output;
 
     let conn: StreamConnection | undefined = undefined;
@@ -53,7 +53,7 @@ export class StdioTransport extends Transport<StreamConnection> {
     });
 
     const cleanup = () => {
-      delimStream.destroy();
+      framedMessageStream.destroy();
       if (conn) {
         this.onDisconnect(conn);
       }

--- a/transport/impls/stdio/stdio.ts
+++ b/transport/impls/stdio/stdio.ts
@@ -2,7 +2,7 @@ import { Codec } from '../../../codec';
 import { NaiveJsonCodec } from '../../../codec/json';
 import { log } from '../../../logging';
 import { TransportClientId } from '../../message';
-import { createDelimitedStream } from '../../transforms/delim';
+import { Delimiter } from '../../transforms/delim';
 import { Transport } from '../../transport';
 import { StreamConnection } from './connection';
 
@@ -37,7 +37,7 @@ export class StdioTransport extends Transport<StreamConnection> {
     const options = { ...defaultOptions, ...providedOptions };
     super(options.codec, clientId);
 
-    const delimStream = createDelimitedStream();
+    const delimStream = Delimiter.createDelimitedStream();
     this.input = input.pipe(delimStream);
     this.output = output;
 

--- a/transport/impls/unixsocket/client.ts
+++ b/transport/impls/unixsocket/client.ts
@@ -1,6 +1,6 @@
 import { Transport, TransportClientId } from '../..';
 import { Codec, NaiveJsonCodec } from '../../../codec';
-import { createDelimitedStream } from '../../transforms/delim';
+import { Delimiter } from '../../transforms/delim';
 import { createConnection } from 'node:net';
 import { StreamConnection } from '../stdio/connection';
 import { log } from '../../../logging';
@@ -40,7 +40,7 @@ export class UnixDomainSocketClientTransport extends Transport<StreamConnection>
 
     const sock = createConnection(this.path);
     const conn = new StreamConnection(this, to, sock);
-    const delimStream = createDelimitedStream();
+    const delimStream = Delimiter.createDelimitedStream();
     sock.pipe(delimStream).on('data', (data) => {
       const parsedMsg = this.parseMsg(data);
       if (parsedMsg) {

--- a/transport/impls/unixsocket/server.ts
+++ b/transport/impls/unixsocket/server.ts
@@ -1,7 +1,7 @@
 import { Transport, TransportClientId } from '../..';
 import { Codec, NaiveJsonCodec } from '../../../codec';
 import { log } from '../../../logging';
-import { createDelimitedStream } from '../../transforms/delim';
+import { Delimiter } from '../../transforms/delim';
 import { type Server, type Socket } from 'node:net';
 import { StreamConnection } from '../stdio/connection';
 
@@ -33,7 +33,7 @@ export class UnixDomainSocketServerTransport extends Transport<StreamConnection>
   connectionListener = (sock: Socket) => {
     let conn: StreamConnection | undefined = undefined;
 
-    const delimStream = createDelimitedStream();
+    const delimStream = Delimiter.createDelimitedStream();
     sock.pipe(delimStream).on('data', (data) => {
       const parsedMsg = this.parseMsg(data);
       if (!parsedMsg) {

--- a/transport/impls/unixsocket/unixsocket.test.ts
+++ b/transport/impls/unixsocket/unixsocket.test.ts
@@ -93,7 +93,7 @@ describe('sending and receiving across unix sockets works', async () => {
       );
 
       // client to server
-      const initMsg = makeDummyMessage(id, serverId, 'hello server');
+      const initMsg = makeDummyMessage(id, serverId, 'hello\nserver');
       const initMsgPromise = waitForMessage(
         serverTransport,
         (recv) => recv.id === initMsg.id,
@@ -107,8 +107,8 @@ describe('sending and receiving across unix sockets works', async () => {
     const client2Transport = await initClient(clientId2);
 
     // sending messages from server to client shouldn't leak between clients
-    const msg1 = makeDummyMessage(serverId, clientId1, 'hello client1');
-    const msg2 = makeDummyMessage(serverId, clientId2, 'hello client2');
+    const msg1 = makeDummyMessage(serverId, clientId1, 'hello\nclient1');
+    const msg2 = makeDummyMessage(serverId, clientId2, 'hello\nclient2');
     const promises = Promise.all([
       // true means reject if we receive any message that isn't the one we are expecting
       waitForMessage(client2Transport, (recv) => recv.id === msg2.id, true),

--- a/transport/transforms/delim.test.ts
+++ b/transport/transforms/delim.test.ts
@@ -1,16 +1,20 @@
-import { createDelimitedStream } from './delim';
+import { Delimiter } from './delim';
 import { describe, test, expect, vi } from 'vitest';
 
-describe('DelimiterParser', () => {
+describe('Uint32LengthEncodedDelimiter', () => {
+  const encodeMessage = (message: string) => {
+    return Delimiter.writeDelimited(Buffer.from(message));
+  };
+
   test('basic transform', () => {
     const spy = vi.fn();
-    const parser = createDelimitedStream();
+    const parser = Delimiter.createDelimitedStream();
 
     parser.on('data', spy);
-    parser.write(Buffer.from('content 1\ncontent'));
-    parser.write(Buffer.from(' 2\n'));
-    parser.write(Buffer.from('content 3\ncontent 4'));
-    parser.write(Buffer.from('\n\n'));
+    parser.write(encodeMessage('content 1'));
+    parser.write(encodeMessage('content 2'));
+    parser.write(encodeMessage('content 3'));
+    parser.write(encodeMessage('content 4'));
     parser.end();
 
     expect(spy).toHaveBeenNthCalledWith(1, Buffer.from('content 1'));
@@ -20,46 +24,101 @@ describe('DelimiterParser', () => {
     expect(spy).toHaveBeenCalledTimes(4);
   });
 
-  test('flushes remaining data when stream ends even with no delimiter', () => {
-    const parser = createDelimitedStream({ delimiter: Buffer.from([0]) });
+  test('handles partial messages across chunks', () => {
     const spy = vi.fn();
-    parser.on('data', spy);
-    parser.write(Buffer.from([1]));
-    expect(spy).toHaveBeenCalledTimes(0);
-    parser.end();
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenNthCalledWith(1, Buffer.from([1]));
-  });
+    const parser = Delimiter.createDelimitedStream();
 
-  test('multibyte delimiter crosses a chunk boundary', () => {
-    const parser = createDelimitedStream({ delimiter: Buffer.from([0, 1]) });
-    const spy = vi.fn();
+    const msg = encodeMessage('content 1');
+    const part1 = msg.subarray(0, 5); // Split the encoded message
+    const part2 = msg.subarray(5);
+
     parser.on('data', spy);
-    parser.write(Buffer.from([1, 2, 3, 0]));
-    parser.write(Buffer.from([1, 4, 5]));
+    parser.write(part1);
+    parser.write(part2); // Complete the first message
+    parser.write(encodeMessage('content 2')); // Second message
     parser.end();
 
+    expect(spy).toHaveBeenNthCalledWith(1, Buffer.from('content 1'));
+    expect(spy).toHaveBeenNthCalledWith(2, Buffer.from('content 2'));
     expect(spy).toHaveBeenCalledTimes(2);
-    expect(spy).toHaveBeenNthCalledWith(1, Buffer.from([1, 2, 3]));
-    expect(spy).toHaveBeenNthCalledWith(2, Buffer.from([4, 5]));
   });
 
-  test('max buffer size', () => {
-    const parser = createDelimitedStream({
-      maxBufferSizeBytes: 5,
+  test('multiple messages in a single chunk', () => {
+    const spy = vi.fn();
+    const parser = Delimiter.createDelimitedStream();
+
+    const message1 = encodeMessage('first message');
+    const message2 = encodeMessage('second message');
+    const combinedMessages = Buffer.concat([message1, message2]);
+
+    parser.on('data', spy);
+    parser.write(combinedMessages); // Writing both messages in a single write operation
+    parser.end();
+
+    expect(spy).toHaveBeenNthCalledWith(1, Buffer.from('first message'));
+    expect(spy).toHaveBeenNthCalledWith(2, Buffer.from('second message'));
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  test('max buffer size exceeded', () => {
+    const parser = Delimiter.createDelimitedStream({
+      maxBufferSizeBytes: 8, // Set a small max buffer size
     });
 
     const spy = vi.fn();
     const err = vi.fn();
     parser.on('data', spy);
     parser.on('error', err);
-    parser.write(Buffer.from([1, 2, 3, 4, 5]));
-    expect(spy).toHaveBeenCalledTimes(0);
-    expect(err).toHaveBeenCalledTimes(0);
 
-    parser.write(Buffer.from([6]));
+    const msg = encodeMessage('long content');
+    expect(msg.byteLength > 10);
+    parser.write(msg);
     expect(spy).toHaveBeenCalledTimes(0);
     expect(err).toHaveBeenCalledTimes(1);
     parser.end();
+  });
+
+  test('incomplete message at stream end', () => {
+    const spy = vi.fn();
+    const err = vi.fn();
+    const parser = Delimiter.createDelimitedStream();
+
+    parser.on('data', spy);
+    parser.on('error', err);
+
+    // say this is a 256B message
+    const lengthPrefix = Buffer.alloc(4);
+    lengthPrefix.writeUInt32BE(256, 0);
+
+    // write a message that is clearly not 256B
+    const incompleteMessage = Buffer.concat([
+      lengthPrefix,
+      Buffer.from('incomplete'),
+    ]);
+    parser.write(incompleteMessage);
+
+    expect(spy).toHaveBeenCalledTimes(0);
+    expect(err).toHaveBeenCalledTimes(0);
+
+    parser.end();
+    expect(spy).toHaveBeenCalledTimes(0);
+    expect(err).toHaveBeenCalledTimes(1);
+  });
+
+  test('consistent byte length calculation with emojis and unicode', () => {
+    const parser = Delimiter.createDelimitedStream();
+    const spy = vi.fn();
+    parser.on('data', spy);
+
+    const emojiMessage = '🇧🇪🇨🇦👨‍👩‍👧‍👦';
+    const unicodeMessage = '你好，世界'; // "Hello, World" in Chinese
+
+    parser.write(encodeMessage(emojiMessage));
+    parser.write(encodeMessage(unicodeMessage));
+    parser.end();
+
+    expect(spy).toHaveBeenNthCalledWith(1, Buffer.from(emojiMessage));
+    expect(spy).toHaveBeenNthCalledWith(2, Buffer.from(unicodeMessage));
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 });

--- a/transport/transforms/messageFraming.test.ts
+++ b/transport/transforms/messageFraming.test.ts
@@ -1,14 +1,14 @@
-import { Delimiter } from './delim';
+import { MessageFramer } from './messageFraming';
 import { describe, test, expect, vi } from 'vitest';
 
-describe('Uint32LengthEncodedDelimiter', () => {
+describe('MessageFramer', () => {
   const encodeMessage = (message: string) => {
-    return Delimiter.writeDelimited(Buffer.from(message));
+    return MessageFramer.write(Buffer.from(message));
   };
 
   test('basic transform', () => {
     const spy = vi.fn();
-    const parser = Delimiter.createDelimitedStream();
+    const parser = MessageFramer.createFramedStream();
 
     parser.on('data', spy);
     parser.write(encodeMessage('content 1'));
@@ -26,7 +26,7 @@ describe('Uint32LengthEncodedDelimiter', () => {
 
   test('handles partial messages across chunks', () => {
     const spy = vi.fn();
-    const parser = Delimiter.createDelimitedStream();
+    const parser = MessageFramer.createFramedStream();
 
     const msg = encodeMessage('content 1');
     const part1 = msg.subarray(0, 5); // Split the encoded message
@@ -45,7 +45,7 @@ describe('Uint32LengthEncodedDelimiter', () => {
 
   test('multiple messages in a single chunk', () => {
     const spy = vi.fn();
-    const parser = Delimiter.createDelimitedStream();
+    const parser = MessageFramer.createFramedStream();
 
     const message1 = encodeMessage('first message');
     const message2 = encodeMessage('second message');
@@ -61,7 +61,7 @@ describe('Uint32LengthEncodedDelimiter', () => {
   });
 
   test('max buffer size exceeded', () => {
-    const parser = Delimiter.createDelimitedStream({
+    const parser = MessageFramer.createFramedStream({
       maxBufferSizeBytes: 8, // Set a small max buffer size
     });
 
@@ -81,7 +81,7 @@ describe('Uint32LengthEncodedDelimiter', () => {
   test('incomplete message at stream end', () => {
     const spy = vi.fn();
     const err = vi.fn();
-    const parser = Delimiter.createDelimitedStream();
+    const parser = MessageFramer.createFramedStream();
 
     parser.on('data', spy);
     parser.on('error', err);
@@ -106,7 +106,7 @@ describe('Uint32LengthEncodedDelimiter', () => {
   });
 
   test('consistent byte length calculation with emojis and unicode', () => {
-    const parser = Delimiter.createDelimitedStream();
+    const parser = MessageFramer.createFramedStream();
     const spy = vi.fn();
     parser.on('data', spy);
 

--- a/transport/transforms/messageFraming.ts
+++ b/transport/transforms/messageFraming.ts
@@ -10,7 +10,7 @@ export interface LengthEncodedOptions extends TransformOptions {
  * A transform stream that emits data each time a message with a uint32 length prefix is received.
  * @extends Transform
  */
-export class Uint32LengthEncodedDelimiter extends Transform {
+export class Uint32LengthPrefixFraming extends Transform {
   receivedBuffer: Buffer;
   maxBufferSizeBytes: number;
 
@@ -75,15 +75,15 @@ export class Uint32LengthEncodedDelimiter extends Transform {
 }
 
 function createLengthEncodedStream(options?: Partial<LengthEncodedOptions>) {
-  return new Uint32LengthEncodedDelimiter({
+  return new Uint32LengthPrefixFraming({
     maxBufferSizeBytes: options?.maxBufferSizeBytes ?? 16 * 1024 * 1024, // 16MB
     preAllocatedBufferSize: options?.preAllocatedBufferSize ?? 16 * 1024, // 16KB
   });
 }
 
-export const Delimiter = {
-  createDelimitedStream: createLengthEncodedStream,
-  writeDelimited: (buf: Uint8Array) => {
+export const MessageFramer = {
+  createFramedStream: createLengthEncodedStream,
+  write: (buf: Uint8Array) => {
     const lengthPrefix = Buffer.alloc(4);
     lengthPrefix.writeUInt32BE(buf.length, 0);
     return Buffer.concat([lengthPrefix, buf]);

--- a/transport/transforms/messageFraming.ts
+++ b/transport/transforms/messageFraming.ts
@@ -7,7 +7,7 @@ export interface LengthEncodedOptions extends TransformOptions {
 }
 
 /**
- * A transform stream that emits data each time a message with a uint32 length prefix is received.
+ * A transform stream that emits data each time a message with a network/BigEndian uint32 length prefix is received.
  * @extends Transform
  */
 export class Uint32LengthPrefixFraming extends Transform {


### PR DESCRIPTION
## Why

We want to have newlines in our messages :) The old approach failed when we used the binary codec with a string or Uint8Array that contained a newline in it. This is because we framed our messages with newlines so we would get cases where a single message would be split in two.

## What changed

Use `uint32`-prefix framing instead.