### PR TITLE
[protocol] Pre-session handshake

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,10 +3,10 @@ name: Build and Test
 on:
   pull_request:
     branches:
-      - *
+      - '**'
   push:
     branches:
-      - *
+      - '**'
 
 jobs:
   build-and-test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
       - '**'
   push:
     branches:
-      - '**'
+      - main
 
 jobs:
   build-and-test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,10 +3,10 @@ name: Build and Test
 on:
   pull_request:
     branches:
-      - main
+      - *
   push:
     branches:
-      - main
+      - *
 
 jobs:
   build-and-test:

--- a/__tests__/fixtures/cleanup.ts
+++ b/__tests__/fixtures/cleanup.ts
@@ -117,7 +117,6 @@ export async function testFinishesCleanly({
 
   // server sits on top of server transport so we clean it up first
   if (server) {
-    await advanceFakeTimersByDisconnectGrace();
     await ensureServerIsClean(server);
     await server.close();
   }

--- a/__tests__/fixtures/transports.ts
+++ b/__tests__/fixtures/transports.ts
@@ -1,4 +1,4 @@
-import { Connection, Transport } from '../../transport';
+import { ClientTransport, Connection, ServerTransport } from '../../transport';
 import http from 'node:http';
 import net from 'node:net';
 import {
@@ -14,8 +14,10 @@ import { UnixDomainSocketServerTransport } from '../../transport/impls/uds/serve
 export const transports: Array<{
   name: string;
   setup: () => Promise<{
-    // client, server
-    getTransports: () => [Transport<Connection>, Transport<Connection>];
+    getTransports: () => [
+      ClientTransport<Connection>,
+      ServerTransport<Connection>,
+    ];
     cleanup: () => Promise<void>;
   }>;
 }> = [

--- a/__tests__/typescript-stress.test.ts
+++ b/__tests__/typescript-stress.test.ts
@@ -3,7 +3,7 @@ import { Procedure, ServiceBuilder, serializeService } from '../router/builder';
 import { Type } from '@sinclair/typebox';
 import { OpaqueTransportMessage } from '../transport/message';
 import { createServer } from '../router/server';
-import { Transport, Connection } from '../transport';
+import { Transport, Connection, Session } from '../transport';
 import { createClient } from '../router/client';
 import { Ok } from '../router/result';
 import { buildServiceDefs } from '../router/defs';
@@ -97,6 +97,13 @@ export const StupidlyLargeService = <Name extends string>(name: Name) =>
 
 // mock transport
 export class MockTransport extends Transport<Connection> {
+  receiveWithBootSequence(
+    _conn: Connection,
+    _sessionCb: (sess: Session<Connection>) => void,
+  ): (data: Uint8Array) => void {
+    throw new Error('Method not implemented.');
+  }
+
   constructor(clientId: string) {
     super(clientId);
   }

--- a/__tests__/typescript-stress.test.ts
+++ b/__tests__/typescript-stress.test.ts
@@ -112,6 +112,8 @@ export class MockTransport extends Transport<Connection> {
     return true;
   }
 
+  protected handleConnection(_conn: Connection, _to: string): void {}
+
   async createNewOutgoingConnection(): Promise<Connection> {
     throw new Error('unimplemented');
   }

--- a/router/context.ts
+++ b/router/context.ts
@@ -18,9 +18,7 @@
  * }
  * ```
  */
-export interface ServiceContext {
-  state: object | unknown;
-}
+export interface ServiceContext {}
 
 /**
  * The {@link ServiceContext} with state. This is what is passed to procedures.

--- a/transport/impls/stdio/client.ts
+++ b/transport/impls/stdio/client.ts
@@ -36,14 +36,7 @@ export class StdioClientTransport extends ClientTransport<StreamConnection> {
   async createNewOutgoingConnection(to: TransportClientId) {
     log?.info(`${this.clientId} -- establishing a new stream to ${to}`);
     const conn = new StreamConnection(this.input, this.output);
-    conn.addDataListener(this.receiveWithBootSequence(conn));
-    const cleanup = () => {
-      this.onDisconnect(conn, to);
-      this.connect(to);
-    };
-
-    this.input.addListener('close', cleanup);
-    this.output.addListener('close', cleanup);
+    this.handleConnection(conn, to);
     return conn;
   }
 }

--- a/transport/impls/stdio/client.ts
+++ b/transport/impls/stdio/client.ts
@@ -1,6 +1,6 @@
 import { log } from '../../../logging';
 import { TransportClientId } from '../../message';
-import { Transport, TransportOptions } from '../../transport';
+import { ClientTransport, TransportOptions } from '../../transport';
 import { StreamConnection } from './connection';
 
 /**
@@ -8,7 +8,7 @@ import { StreamConnection } from './connection';
  * Will eagerly connect as soon as it's initialized.
  * @extends Transport
  */
-export class StdioClientTransport extends Transport<StreamConnection> {
+export class StdioClientTransport extends ClientTransport<StreamConnection> {
   input: NodeJS.ReadableStream = process.stdin;
   output: NodeJS.WritableStream = process.stdout;
   serverId: TransportClientId;

--- a/transport/impls/stdio/client.ts
+++ b/transport/impls/stdio/client.ts
@@ -36,7 +36,7 @@ export class StdioClientTransport extends ClientTransport<StreamConnection> {
   async createNewOutgoingConnection(to: TransportClientId) {
     log?.info(`${this.clientId} -- establishing a new stream to ${to}`);
     const conn = new StreamConnection(this.input, this.output);
-    conn.addDataListener((data) => this.handleMsg(this.parseMsg(data)));
+    conn.addDataListener(this.receiveWithBootSequence(conn));
     const cleanup = () => {
       this.onDisconnect(conn, to);
       this.connect(to);
@@ -44,7 +44,6 @@ export class StdioClientTransport extends ClientTransport<StreamConnection> {
 
     this.input.addListener('close', cleanup);
     this.output.addListener('close', cleanup);
-    this.onConnect(conn, to);
     return conn;
   }
 }

--- a/transport/impls/stdio/connection.ts
+++ b/transport/impls/stdio/connection.ts
@@ -20,6 +20,10 @@ export class StreamConnection extends Connection {
     this.input.on('data', cb);
   }
 
+  removeDataListener(cb: (msg: Uint8Array) => void): void {
+    this.input.off('data', cb);
+  }
+
   addCloseListener(cb: () => void): void {
     this.input.on('close', cb);
     this.output.on('close', cb);

--- a/transport/impls/stdio/connection.ts
+++ b/transport/impls/stdio/connection.ts
@@ -20,11 +20,20 @@ export class StreamConnection extends Connection {
     this.input.on('data', cb);
   }
 
+  addCloseListener(cb: () => void): void {
+    this.input.on('close', cb);
+    this.output.on('close', cb);
+  }
+
+  addErrorListener(cb: (err: Error) => void): void {
+    this.input.on('error', cb);
+    this.output.on('error', cb);
+  }
+
   send(payload: Uint8Array) {
     return this.output.write(MessageFramer.write(payload));
   }
 
-  // doesn't touch the underlying connection
   async close() {
     this.output.end();
     this.input.unpipe(this.framer);

--- a/transport/impls/stdio/server.ts
+++ b/transport/impls/stdio/server.ts
@@ -62,10 +62,4 @@ export class StdioServerTransport extends ServerTransport<StreamConnection> {
       cleanup(session);
     });
   }
-
-  async createNewOutgoingConnection(to: string): Promise<StreamConnection> {
-    const err = `${this.clientId} -- failed to send msg to ${to}, client probably dropped`;
-    log?.warn(err);
-    throw new Error(err);
-  }
 }

--- a/transport/impls/stdio/server.ts
+++ b/transport/impls/stdio/server.ts
@@ -34,7 +34,7 @@ export class StdioServerTransport extends ServerTransport<StreamConnection> {
 
     const conn = new StreamConnection(this.input, this.output);
     conn.addDataListener(
-      this.receiveBootSequence(conn, (establishedSession) => {
+      this.receiveWithBootSequence(conn, (establishedSession) => {
         session = establishedSession;
       }),
     );

--- a/transport/impls/uds/client.ts
+++ b/transport/impls/uds/client.ts
@@ -20,7 +20,7 @@ export class UnixDomainSocketClientTransport extends ClientTransport<UdsConnecti
     this.connect(serverId);
   }
 
-  async createNewOutgoingConnection(to: string) {
+  async createNewOutgoingConnection(to: TransportClientId) {
     const oldConnection = this.connections.get(to);
     if (oldConnection) {
       oldConnection.close();
@@ -35,19 +35,7 @@ export class UnixDomainSocketClientTransport extends ClientTransport<UdsConnecti
     });
 
     const conn = new UdsConnection(sock);
-    conn.addDataListener(this.receiveWithBootSequence(conn));
-    const cleanup = () => {
-      this.onDisconnect(conn, to);
-      this.connect(to);
-    };
-
-    sock.on('close', cleanup);
-    sock.on('error', (err) => {
-      log?.warn(
-        `${this.clientId} -- socket error in connection (id: ${conn.debugId}) to ${to}: ${err}`,
-      );
-    });
-
+    this.handleConnection(conn, to);
     return conn;
   }
 }

--- a/transport/impls/uds/client.ts
+++ b/transport/impls/uds/client.ts
@@ -35,7 +35,7 @@ export class UnixDomainSocketClientTransport extends ClientTransport<UdsConnecti
     });
 
     const conn = new UdsConnection(sock);
-    conn.addDataListener((data) => this.handleMsg(this.parseMsg(data)));
+    conn.addDataListener(this.receiveWithBootSequence(conn));
     const cleanup = () => {
       this.onDisconnect(conn, to);
       this.connect(to);
@@ -48,7 +48,6 @@ export class UnixDomainSocketClientTransport extends ClientTransport<UdsConnecti
       );
     });
 
-    this.onConnect(conn, to);
     return conn;
   }
 }

--- a/transport/impls/uds/client.ts
+++ b/transport/impls/uds/client.ts
@@ -1,10 +1,10 @@
-import { Transport, TransportClientId } from '../..';
+import { TransportClientId } from '../..';
 import { Socket } from 'node:net';
 import { log } from '../../../logging';
 import { UdsConnection } from './connection';
-import { TransportOptions } from '../../transport';
+import { ClientTransport, TransportOptions } from '../../transport';
 
-export class UnixDomainSocketClientTransport extends Transport<UdsConnection> {
+export class UnixDomainSocketClientTransport extends ClientTransport<UdsConnection> {
   path: string;
   serverId: TransportClientId;
 

--- a/transport/impls/uds/connection.ts
+++ b/transport/impls/uds/connection.ts
@@ -21,6 +21,14 @@ export class UdsConnection extends Connection {
     this.input.on('data', cb);
   }
 
+  addCloseListener(cb: () => void): void {
+    this.sock.on('close', cb);
+  }
+
+  addErrorListener(cb: (err: Error) => void): void {
+    this.sock.on('error', cb);
+  }
+
   send(payload: Uint8Array) {
     return this.sock.write(MessageFramer.write(payload));
   }

--- a/transport/impls/uds/connection.ts
+++ b/transport/impls/uds/connection.ts
@@ -21,6 +21,10 @@ export class UdsConnection extends Connection {
     this.input.on('data', cb);
   }
 
+  removeDataListener(cb: (msg: Uint8Array) => void): void {
+    this.input.off('data', cb);
+  }
+
   addCloseListener(cb: () => void): void {
     this.sock.on('close', cb);
   }

--- a/transport/impls/uds/server.ts
+++ b/transport/impls/uds/server.ts
@@ -54,12 +54,6 @@ export class UnixDomainSocketServerTransport extends ServerTransport<UdsConnecti
     });
   };
 
-  async createNewOutgoingConnection(to: string): Promise<UdsConnection> {
-    const err = `${this.clientId} -- failed to send msg to ${to}, client probably dropped`;
-    log?.warn(err);
-    throw new Error(err);
-  }
-
   async close() {
     super.close();
     this.server.removeListener('connection', this.connectionHandler);

--- a/transport/impls/uds/server.ts
+++ b/transport/impls/uds/server.ts
@@ -30,7 +30,7 @@ export class UnixDomainSocketServerTransport extends ServerTransport<UdsConnecti
 
     const client = () => session?.connectedTo ?? 'unknown';
     conn.addDataListener(
-      this.receiveBootSequence(conn, (establishedSession) => {
+      this.receiveWithBootSequence(conn, (establishedSession) => {
         session = establishedSession;
       }),
     );

--- a/transport/impls/ws/client.ts
+++ b/transport/impls/ws/client.ts
@@ -82,11 +82,8 @@ export class WebSocketClientTransport extends ClientTransport<WebSocketConnectio
 
     if ('ws' in wsRes) {
       const conn = new WebSocketConnection(wsRes.ws);
-      log?.info(
-        `${this.clientId} -- websocket (id: ${conn.debugId}) to ${to} ok`,
-      );
-      this.onConnect(conn, to);
-      conn.addDataListener((data) => this.handleMsg(this.parseMsg(data)));
+      log?.info(`${this.clientId} -- websocket (id: ${conn.debugId}) to ${to} ok`);
+      conn.addDataListener(this.receiveWithBootSequence(conn));
       wsRes.ws.onclose = () => {
         log?.info(
           `${this.clientId} -- websocket (id: ${conn.debugId}) to ${to} disconnected`,

--- a/transport/impls/ws/client.ts
+++ b/transport/impls/ws/client.ts
@@ -82,7 +82,9 @@ export class WebSocketClientTransport extends ClientTransport<WebSocketConnectio
 
     if ('ws' in wsRes) {
       const conn = new WebSocketConnection(wsRes.ws);
-      log?.info(`${this.clientId} -- websocket (id: ${conn.debugId}) to ${to} ok`);
+      log?.info(
+        `${this.clientId} -- websocket (id: ${conn.debugId}) to ${to} ok`,
+      );
       conn.addDataListener(this.receiveWithBootSequence(conn));
       wsRes.ws.onclose = () => {
         log?.info(

--- a/transport/impls/ws/client.ts
+++ b/transport/impls/ws/client.ts
@@ -1,5 +1,5 @@
 import WebSocket from 'isomorphic-ws';
-import { Transport, TransportOptions } from '../../transport';
+import { ClientTransport, TransportOptions } from '../../transport';
 import { TransportClientId } from '../../message';
 import { log } from '../../../logging';
 import { WebSocketConnection } from './connection';
@@ -11,7 +11,7 @@ type WebSocketResult = { ws: WebSocket } | { err: string };
  * @class
  * @extends Transport
  */
-export class WebSocketClientTransport extends Transport<WebSocketConnection> {
+export class WebSocketClientTransport extends ClientTransport<WebSocketConnection> {
   /**
    * A function that returns a Promise that resolves to a WebSocket instance.
    */
@@ -34,7 +34,6 @@ export class WebSocketClientTransport extends Transport<WebSocketConnection> {
     super(sessionId, providedOptions);
     this.wsGetter = wsGetter;
     this.serverId = serverId;
-    this.inflightConnectionPromises = new Map();
 
     // eagerly connect as soon as we initialize
     this.connect(this.serverId);
@@ -110,11 +109,9 @@ export class WebSocketClientTransport extends Transport<WebSocketConnection> {
 
   async close() {
     super.close();
-    this.inflightConnectionPromises.clear();
   }
 
   async destroy() {
     super.destroy();
-    this.inflightConnectionPromises.clear();
   }
 }

--- a/transport/impls/ws/client.ts
+++ b/transport/impls/ws/client.ts
@@ -85,21 +85,7 @@ export class WebSocketClientTransport extends ClientTransport<WebSocketConnectio
       log?.info(
         `${this.clientId} -- websocket (id: ${conn.debugId}) to ${to} ok`,
       );
-      conn.addDataListener(this.receiveWithBootSequence(conn));
-      wsRes.ws.onclose = () => {
-        log?.info(
-          `${this.clientId} -- websocket (id: ${conn.debugId}) to ${to} disconnected`,
-        );
-        this.onDisconnect(conn, to);
-        this.connect(to);
-      };
-
-      wsRes.ws.onerror = (msg) => {
-        log?.warn(
-          `${this.clientId} -- websocket (id: ${conn.debugId}) to ${to} had an error: ${msg}`,
-        );
-      };
-
+      this.handleConnection(conn, to);
       return conn;
     } else {
       throw new Error(wsRes.err);

--- a/transport/impls/ws/connection.ts
+++ b/transport/impls/ws/connection.ts
@@ -14,6 +14,14 @@ export class WebSocketConnection extends Connection {
     this.ws.onmessage = (msg) => cb(msg.data as Uint8Array);
   }
 
+  addCloseListener(cb: () => void): void {
+    this.ws.onclose = cb;
+  }
+
+  addErrorListener(cb: (err: Error) => void): void {
+    this.ws.onerror = (err) => cb(new Error(err.message));
+  }
+
   send(payload: Uint8Array) {
     if (this.ws.readyState === this.ws.OPEN) {
       this.ws.send(payload);

--- a/transport/impls/ws/connection.ts
+++ b/transport/impls/ws/connection.ts
@@ -14,6 +14,10 @@ export class WebSocketConnection extends Connection {
     this.ws.onmessage = (msg) => cb(msg.data as Uint8Array);
   }
 
+  removeDataListener(_cb: (msg: Uint8Array) => void): void {
+    this.ws.onmessage = null;
+  }
+
   addCloseListener(cb: () => void): void {
     this.ws.onclose = cb;
   }

--- a/transport/impls/ws/server.ts
+++ b/transport/impls/ws/server.ts
@@ -53,12 +53,6 @@ export class WebSocketServerTransport extends ServerTransport<WebSocketConnectio
     };
   };
 
-  async createNewOutgoingConnection(to: string): Promise<WebSocketConnection> {
-    const err = `${this.clientId} -- failed to send msg to ${to}, client probably dropped`;
-    log?.warn(err);
-    throw new Error(err);
-  }
-
   async close() {
     super.close();
     this.wss.off('connection', this.connectionHandler);

--- a/transport/impls/ws/server.ts
+++ b/transport/impls/ws/server.ts
@@ -27,7 +27,7 @@ export class WebSocketServerTransport extends ServerTransport<WebSocketConnectio
     let session: Session<WebSocketConnection> | undefined = undefined;
     const client = () => session?.connectedTo ?? 'unknown';
     conn.addDataListener(
-      this.receiveBootSequence(conn, (establishedSession) => {
+      this.receiveWithBootSequence(conn, (establishedSession) => {
         session = establishedSession;
       }),
     );

--- a/transport/impls/ws/server.ts
+++ b/transport/impls/ws/server.ts
@@ -4,7 +4,6 @@ import { ServerTransport, TransportOptions } from '../../transport';
 import { WebSocketServer } from 'ws';
 import { WebSocket } from 'isomorphic-ws';
 import { WebSocketConnection } from './connection';
-import { Session } from '../../session';
 
 export class WebSocketServerTransport extends ServerTransport<WebSocketConnection> {
   wss: WebSocketServer;
@@ -24,33 +23,7 @@ export class WebSocketServerTransport extends ServerTransport<WebSocketConnectio
     log?.info(
       `${this.clientId} -- new incoming ws connection (id: ${conn.debugId})`,
     );
-    let session: Session<WebSocketConnection> | undefined = undefined;
-    const client = () => session?.connectedTo ?? 'unknown';
-    conn.addDataListener(
-      this.receiveWithBootSequence(conn, (establishedSession) => {
-        session = establishedSession;
-      }),
-    );
-
-    // close is always emitted, even on error, ok to do cleanup here
-    ws.onclose = () => {
-      if (!session) return;
-      log?.info(
-        `${this.clientId} -- websocket (id: ${
-          conn.debugId
-        }) to ${client()} disconnected`,
-      );
-      this.onDisconnect(conn, session?.connectedTo);
-    };
-
-    ws.onerror = (msg) => {
-      if (!session) return;
-      log?.warn(
-        `${this.clientId} -- websocket (id: ${
-          conn.debugId
-        }) to ${client()} got an error: ${msg}`,
-      );
-    };
+    this.handleConnection(conn);
   };
 
   async close() {

--- a/transport/index.ts
+++ b/transport/index.ts
@@ -1,4 +1,4 @@
-export { Transport } from './transport';
+export { Transport, ClientTransport, ServerTransport } from './transport';
 export { Connection, Session } from './session';
 export {
   TransportMessageSchema,

--- a/transport/message.ts
+++ b/transport/message.ts
@@ -51,9 +51,10 @@ export const ControlMessageCloseSchema = Type.Object({
   type: Type.Literal('CLOSE'),
 });
 
+export const PROTOCOL_VERSION = 'v1';
 export const ControlMessageHandshakeRequestSchema = Type.Object({
   type: Type.Literal('HANDSHAKE_REQ'),
-  protocolVersion: Type.Literal('v1'),
+  protocolVersion: Type.Literal(PROTOCOL_VERSION),
 });
 
 export const ControlMessageHandshakeResponseSchema = Type.Object({

--- a/transport/message.ts
+++ b/transport/message.ts
@@ -12,7 +12,6 @@ export const enum ControlFlags {
   AckBit = 0b0001,
   StreamOpenBit = 0b0010,
   StreamClosedBit = 0b0100,
-  HandshakeBit = 0b1000,
 }
 
 /**

--- a/transport/session.ts
+++ b/transport/session.ts
@@ -25,6 +25,7 @@ export abstract class Connection {
    * @param msg The message that was received.
    */
   abstract addDataListener(cb: (msg: Uint8Array) => void): void;
+  abstract removeDataListener(cb: (msg: Uint8Array) => void): void;
 
   /**
    * Handle adding a callback for when the connection is closed.

--- a/transport/session.ts
+++ b/transport/session.ts
@@ -27,6 +27,21 @@ export abstract class Connection {
   abstract addDataListener(cb: (msg: Uint8Array) => void): void;
 
   /**
+   * Handle adding a callback for when the connection is closed.
+   * This should also be called if an error happens.
+   * @param cb The callback to call when the connection is closed.
+   */
+  abstract addCloseListener(cb: () => void): void;
+
+  /**
+   * Handle adding a callback for when an error is received.
+   * This should only be used for logging errors, all cleanup
+   * should be delegated to addCloseListener.
+   * @param cb The callback to call when an error is received.
+   */
+  abstract addErrorListener(cb: (err: Error) => void): void;
+
+  /**
    * Sends a message over the connection.
    * @param msg The message to send.
    * @returns true if the message was sent, false otherwise.

--- a/transport/session.ts
+++ b/transport/session.ts
@@ -38,6 +38,11 @@ export abstract class Connection {
    * Handle adding a callback for when an error is received.
    * This should only be used for logging errors, all cleanup
    * should be delegated to addCloseListener.
+   *
+   * The implementer should take care such that the implemented
+   * connection will call both the close and error callbacks
+   * on an error.
+   *
    * @param cb The callback to call when an error is received.
    */
   abstract addErrorListener(cb: (err: Error) => void): void;

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -11,7 +11,7 @@ import {
   waitFor,
 } from '../__tests__/fixtures/cleanup';
 
-describe.each([transports[0]])('transport -- $name', async ({ setup }) => {
+describe.each(transports)('transport -- $name', async ({ setup }) => {
   const { getTransports, cleanup } = await setup();
   afterAll(cleanup);
 

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -11,7 +11,7 @@ import {
   waitFor,
 } from '../__tests__/fixtures/cleanup';
 
-describe.each(transports)('transport -- $name', async ({ setup }) => {
+describe.each([transports[0]])('transport -- $name', async ({ setup }) => {
   const { getTransports, cleanup } = await setup();
   afterAll(cleanup);
 
@@ -107,13 +107,13 @@ describe.each(transports)('transport -- $name', async ({ setup }) => {
     // session    >  c--| (connected)
     // connection >  c--| (connected)
     expect(clientConnConnect).toHaveBeenCalledTimes(1);
-    expect(clientConnDisconnect).toHaveBeenCalledTimes(0);
     expect(serverConnConnect).toHaveBeenCalledTimes(1);
+    expect(clientConnDisconnect).toHaveBeenCalledTimes(0);
     expect(serverConnDisconnect).toHaveBeenCalledTimes(0);
 
     expect(clientSessConnect).toHaveBeenCalledTimes(1);
-    expect(clientSessDisconnect).toHaveBeenCalledTimes(0);
     expect(serverSessConnect).toHaveBeenCalledTimes(1);
+    expect(clientSessDisconnect).toHaveBeenCalledTimes(0);
     expect(serverSessDisconnect).toHaveBeenCalledTimes(0);
 
     // clean disconnect + reconnect within grace period
@@ -123,13 +123,13 @@ describe.each(transports)('transport -- $name', async ({ setup }) => {
     // session    >  c------| (connected)
     // connection >  c--x   | (disconnected)
     await waitFor(() => expect(clientConnConnect).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(clientConnDisconnect).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(serverConnConnect).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(clientConnDisconnect).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(serverConnDisconnect).toHaveBeenCalledTimes(1));
 
     await waitFor(() => expect(clientSessConnect).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(clientSessDisconnect).toHaveBeenCalledTimes(0));
     await waitFor(() => expect(serverSessConnect).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(clientSessDisconnect).toHaveBeenCalledTimes(0));
     await waitFor(() => expect(serverSessDisconnect).toHaveBeenCalledTimes(0));
 
     const msg2Promise = waitForMessage(
@@ -143,8 +143,8 @@ describe.each(transports)('transport -- $name', async ({ setup }) => {
     clientTransport.send(msg2);
     await expect(msg2Promise).resolves.toStrictEqual(msg2.payload);
     expect(clientConnConnect).toHaveBeenCalledTimes(2);
-    expect(clientConnDisconnect).toHaveBeenCalledTimes(1);
     expect(serverConnConnect).toHaveBeenCalledTimes(2);
+    expect(clientConnDisconnect).toHaveBeenCalledTimes(1);
     expect(serverConnDisconnect).toHaveBeenCalledTimes(1);
 
     expect(clientSessConnect).toHaveBeenCalledTimes(1);
@@ -159,14 +159,14 @@ describe.each(transports)('transport -- $name', async ({ setup }) => {
     clientTransport.tryReconnecting = false;
     clientTransport.connections.forEach((conn) => conn.close());
     await waitFor(() => expect(clientConnConnect).toHaveBeenCalledTimes(2));
-    await waitFor(() => expect(clientConnDisconnect).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(serverConnConnect).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(clientConnDisconnect).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(serverConnDisconnect).toHaveBeenCalledTimes(2));
 
     await advanceFakeTimersByDisconnectGrace();
     await waitFor(() => expect(clientSessConnect).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(clientSessDisconnect).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(serverSessConnect).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(clientSessDisconnect).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(serverSessDisconnect).toHaveBeenCalledTimes(1));
 
     // teardown

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -4,7 +4,7 @@ import {
   ControlFlags,
   OpaqueTransportMessage,
   OpaqueTransportMessageSchema,
-  TransportAckSchema,
+  ControlMessageAckSchema,
   TransportClientId,
   isAck,
   reply,
@@ -13,6 +13,7 @@ import { log } from '../logging';
 import { EventDispatcher, EventHandler, EventTypes } from './events';
 import { Connection, DISCONNECT_GRACE_MS, Session } from './session';
 import { NaiveJsonCodec } from '../codec';
+import { Static } from '@sinclair/typebox';
 
 /**
  * Represents the possible states of a transport.
@@ -116,13 +117,6 @@ export abstract class Transport<ConnType extends Connection> {
    * The event dispatcher for handling events of type EventTypes.
    */
   eventDispatcher: EventDispatcher<EventTypes>;
-
-  /**
-   * The map of reconnect promises for each client ID.
-   */
-  inflightConnectionPromises: Map<TransportClientId, Promise<ConnType>>;
-  tryReconnecting: boolean = true;
-
   /**
    * The options for this transport.
    */
@@ -144,75 +138,6 @@ export abstract class Transport<ConnType extends Connection> {
     this.codec = this.options.codec;
     this.clientId = clientId;
     this.state = 'open';
-    this.inflightConnectionPromises = new Map();
-  }
-
-  /**
-   * Abstract method that creates a new {@link Connection} object.
-   * This should call {@link onConnect} when the connection is established
-   * and {@link onDisconnect} when the connection is closed.
-   *
-   * The downstream implementation needs to implement this. If the downstream
-   * transport cannot make new outgoing connections (e.g. a server transport),
-   * it is ok to log an error and return.
-   *
-   * You should never need to call this directly.
-   * Instead, look for a `reopen` method on the transport.
-   *
-   * @param to The client ID of the node to connect to.
-   * @returns The new connection object.
-   */
-  protected abstract createNewOutgoingConnection(
-    to: TransportClientId,
-  ): Promise<ConnType>;
-
-  /**
-   * Manually attempts to connect to a client.
-   * @param to The client ID of the node to connect to.
-   */
-  async connect(to: TransportClientId, attempt = 0) {
-    if (this.state !== 'open' || !this.tryReconnecting) {
-      log?.info(
-        `${this.clientId} -- transport state is no longer open, not attempting connection`,
-      );
-      return;
-    }
-
-    let reconnectPromise = this.inflightConnectionPromises.get(to);
-    if (!reconnectPromise) {
-      reconnectPromise = this.createNewOutgoingConnection(to);
-      this.inflightConnectionPromises.set(to, reconnectPromise);
-    }
-
-    try {
-      const conn = await reconnectPromise;
-      if (this.state !== 'open') {
-        // we only delete on open here as this allows us to cache successful
-        // connection requests so that subsequent connect calls can reuse it until
-        // it we know for sure that it is unhealthy
-        this.inflightConnectionPromises.delete(to);
-        conn.close();
-        return;
-      }
-
-      this.state = 'open';
-    } catch (err: unknown) {
-      // retry on failure
-      this.inflightConnectionPromises.delete(to);
-      if (attempt >= this.options.retryAttemptsMax) {
-        throw new Error(
-          `${this.clientId} -- connection to ${to} failed after ${attempt} attempts (${err}), giving up`,
-        );
-      } else {
-        // exponential backoff + jitter
-        const jitter = Math.floor(Math.random() * this.options.retryJitterMs);
-        const backoffMs = this.options.retryIntervalMs * 2 ** attempt + jitter;
-        log?.warn(
-          `${this.clientId} -- connection to ${to} failed (${err}), trying again in ${backoffMs}ms`,
-        );
-        setTimeout(() => this.connect(to, attempt + 1), backoffMs);
-      }
-    }
   }
 
   private sessionByClientId(clientId: TransportClientId): Session<ConnType> {
@@ -308,7 +233,6 @@ export abstract class Transport<ConnType extends Connection> {
    * @param conn The connection object.
    */
   onDisconnect(conn: ConnType, connectedTo: TransportClientId | undefined) {
-    if (connectedTo) this.inflightConnectionPromises.delete(connectedTo);
     this.eventDispatcher.dispatchEvent('connectionStatus', {
       status: 'disconnect',
       conn,
@@ -340,7 +264,7 @@ export abstract class Transport<ConnType extends Connection> {
    * @param msg The message to parse.
    * @returns The parsed message, or null if the message is malformed or invalid.
    */
-  protected parseMsg(msg: Uint8Array): OpaqueTransportMessage | null {
+  parseMsg(msg: Uint8Array): OpaqueTransportMessage | null {
     const parsedMsg = this.codec.fromBuffer(msg);
 
     if (parsedMsg === null) {
@@ -373,7 +297,7 @@ export abstract class Transport<ConnType extends Connection> {
    * You generally shouldn't need to override this in downstream transport implementations.
    * @param msg The received message.
    */
-  protected handleMsg(msg: OpaqueTransportMessage | null) {
+  handleMsg(msg: OpaqueTransportMessage | null) {
     if (!msg) {
       return;
     }
@@ -382,7 +306,10 @@ export abstract class Transport<ConnType extends Connection> {
     const session = this.sessionByClientId(msg.from);
     session.cancelGrace();
 
-    if (isAck(msg.controlFlags) && Value.Check(TransportAckSchema, msg)) {
+    if (
+      isAck(msg.controlFlags) &&
+      Value.Check(ControlMessageAckSchema, msg.payload)
+    ) {
       // process ack
       log?.debug(`${this.clientId} -- received ack: ${JSON.stringify(msg)}`);
       if (session.sendBuffer.has(msg.payload.ack)) {
@@ -394,7 +321,10 @@ export abstract class Transport<ConnType extends Connection> {
       this.eventDispatcher.dispatchEvent('message', msg);
 
       if (!isAck(msg.controlFlags)) {
-        const ackMsg = reply(msg, { ack: msg.id });
+        const ackMsg = reply(msg, {
+          type: 'ACK',
+          ack: msg.id,
+        } satisfies Static<typeof ControlMessageAckSchema>);
         ackMsg.controlFlags = ControlFlags.AckBit;
         ackMsg.from = this.clientId;
 
@@ -514,4 +444,147 @@ export abstract class Transport<ConnType extends Connection> {
     this.state = 'destroyed';
     log?.info(`${this.clientId} -- manually destroyed transport`);
   }
+}
+
+export abstract class ClientTransport<
+  ConnType extends Connection,
+> extends Transport<ConnType> {
+  /**
+   * The map of reconnect promises for each client ID.
+   */
+  inflightConnectionPromises: Map<TransportClientId, Promise<ConnType>>;
+  tryReconnecting: boolean = true;
+
+  constructor(
+    clientId: TransportClientId,
+    providedOptions?: Partial<TransportOptions>,
+  ) {
+    super(clientId, providedOptions);
+    this.inflightConnectionPromises = new Map();
+  }
+
+  /**
+   * Abstract method that creates a new {@link Connection} object.
+   * This should call {@link onConnect} when the connection is established
+   * and {@link onDisconnect} when the connection is closed.
+   *
+   * The downstream implementation needs to implement this. If the downstream
+   * transport cannot make new outgoing connections (e.g. a server transport),
+   * it is ok to log an error and return.
+   *
+   * You should never need to call this directly.
+   * Instead, look for a `reopen` method on the transport.
+   *
+   * @param to The client ID of the node to connect to.
+   * @returns The new connection object.
+   */
+  protected abstract createNewOutgoingConnection(
+    to: TransportClientId,
+  ): Promise<ConnType>;
+
+  /**
+   * Manually attempts to connect to a client.
+   * @param to The client ID of the node to connect to.
+   */
+  async connect(to: TransportClientId, attempt = 0) {
+    if (this.state !== 'open' || !this.tryReconnecting) {
+      log?.info(
+        `${this.clientId} -- transport state is no longer open, not attempting connection`,
+      );
+      return;
+    }
+
+    let reconnectPromise = this.inflightConnectionPromises.get(to);
+    if (!reconnectPromise) {
+      reconnectPromise = this.createNewOutgoingConnection(to);
+      this.inflightConnectionPromises.set(to, reconnectPromise);
+    }
+
+    try {
+      const conn = await reconnectPromise;
+      if (this.state !== 'open') {
+        // we only delete on open here as this allows us to cache successful
+        // connection requests so that subsequent connect calls can reuse it until
+        // it we know for sure that it is unhealthy
+        this.inflightConnectionPromises.delete(to);
+        conn.close();
+        return;
+      }
+
+      this.state = 'open';
+    } catch (err: unknown) {
+      // retry on failure
+      this.inflightConnectionPromises.delete(to);
+      if (attempt >= this.options.retryAttemptsMax) {
+        throw new Error(
+          `${this.clientId} -- connection to ${to} failed after ${attempt} attempts (${err}), giving up`,
+        );
+      } else {
+        // exponential backoff + jitter
+        const jitter = Math.floor(Math.random() * this.options.retryJitterMs);
+        const backoffMs = this.options.retryIntervalMs * 2 ** attempt + jitter;
+        log?.warn(
+          `${this.clientId} -- connection to ${to} failed (${err}), trying again in ${backoffMs}ms`,
+        );
+        setTimeout(() => this.connect(to, attempt + 1), backoffMs);
+      }
+    }
+  }
+
+  onDisconnect(conn: ConnType, connectedTo: string | undefined): void {
+    if (connectedTo) this.inflightConnectionPromises.delete(connectedTo);
+    super.onDisconnect(conn, connectedTo);
+  }
+}
+
+export abstract class ServerTransport<
+  ConnType extends Connection,
+> extends Transport<ConnType> {
+  receiveBootSequence = <Conn extends ConnType>(
+    conn: Conn,
+    sessionCb: (sess: Session<ConnType>) => void,
+  ) => {
+    let session: Session<ConnType> | undefined = undefined;
+    let firstMessage: boolean = true;
+    return (data: Uint8Array) => {
+      const parsed = this.parseMsg(data);
+      if (!parsed) return;
+
+      if (firstMessage) {
+        // // double check protocol version here
+        // if (!Value.Check(ControlMessageHandshakeRequestSchema, parsed)) {
+        //   const responseMsg = reply(parsed, {
+        //     type: 'HANDSHAKE_RESP',
+        //     status: {
+        //       ok: false,
+        //       reason: 'VERSION_MISMATCH',
+        //     },
+        //   } satisfies Static<typeof ControlMessageHandshakeResponseSchema>);
+        //   conn.send(this.codec.toBuffer(responseMsg));
+        //   log?.warn(
+        //     `${
+        //       this.clientId
+        //     } -- received invalid handshake msg: ${JSON.stringify(parsed)}`,
+        //   );
+        //   return;
+        // }
+
+        // firstMessage = false;
+        // const responseMsg = reply(parsed, {
+        //   type: 'HANDSHAKE_RESP',
+        //   status: {
+        //     ok: true,
+        //   },
+        // } satisfies Static<typeof ControlMessageHandshakeResponseSchema>);
+        // conn.send(this.codec.toBuffer(responseMsg));
+
+        // everything is ok, tell the other side and start the session
+        session ||= this.onConnect(conn, parsed.from);
+        sessionCb(session);
+        // return;
+      }
+
+      this.handleMsg(parsed);
+    };
+  };
 }

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -510,15 +510,8 @@ export abstract class ClientTransport<
 
   /**
    * Abstract method that creates a new {@link Connection} object.
-   * This should call {@link onConnect} when the connection is established
-   * and {@link onDisconnect} when the connection is closed.
-   *
-   * The downstream implementation needs to implement this. If the downstream
-   * transport cannot make new outgoing connections (e.g. a server transport),
-   * it is ok to log an error and return.
-   *
-   * You should never need to call this directly.
-   * Instead, look for a `reopen` method on the transport.
+   * This should call {@link handleConnection} when the connection is created.
+   * The downstream client implementation needs to implement this.
    *
    * @param to The client ID of the node to connect to.
    * @returns The new connection object.


### PR DESCRIPTION
## Why

Having a pre-session handshake to exchange information is useful! Currently, we do this implicitly on the first message of the connection but explicit good 👍 

## What changed

- Separated out client/server transport into sub-abstract classes of transport to reduce boilerplate in sending/receiving handshake sequence
- Implement the pre-session handshake (connection isn't turned into session until the handshake is completed)