### PR TITLE
[protocol] refactor acks

### DIFF
--- a/__tests__/bandwidth.bench.ts
+++ b/__tests__/bandwidth.bench.ts
@@ -6,18 +6,13 @@ import { createClient } from '../router/client';
 import { buildServiceDefs } from '../router/defs';
 import { transports } from './fixtures/transports';
 
-let smallId = 0;
+let n = 0;
 const dummyPayloadSmall = () => ({
-  id: `${smallId++}`,
-  from: 'client',
-  to: 'SERVER',
-  serviceName: 'test',
-  procedureName: 'test',
   streamId: 'test',
   controlFlags: 0,
   payload: {
     msg: 'cool',
-    n: smallId * 1.5,
+    n: n++,
   },
 });
 
@@ -37,8 +32,7 @@ describe('bandwidth', async () => {
       `${name} -- raw transport send and recv`,
       async () => {
         const msg = dummyPayloadSmall();
-        const id = msg.id;
-        clientTransport.send(msg);
+        const id = clientTransport.send(serverTransport.clientId, msg);
         await waitForMessage(serverTransport, (msg) => msg.id === id);
         return;
       },

--- a/__tests__/cleanup.test.ts
+++ b/__tests__/cleanup.test.ts
@@ -13,7 +13,7 @@ import {
 } from './fixtures/services';
 import { createClient, createServer } from '../router';
 import {
-  ensureTransportQueuesAreEventuallyEmpty,
+  ensureTransportBuffersAreEventuallyEmpty,
   testFinishesCleanly,
   waitFor,
   waitForTransportToFinish,
@@ -54,8 +54,8 @@ describe('procedures should leave no trace after finishing', async () => {
     await clientTransport.close();
 
     await waitForTransportToFinish(clientTransport);
-    await ensureTransportQueuesAreEventuallyEmpty(clientTransport);
-    await ensureTransportQueuesAreEventuallyEmpty(serverTransport);
+    await ensureTransportBuffersAreEventuallyEmpty(clientTransport);
+    await ensureTransportBuffersAreEventuallyEmpty(serverTransport);
 
     await testFinishesCleanly({
       clientTransports: [clientTransport],
@@ -86,8 +86,8 @@ describe('procedures should leave no trace after finishing', async () => {
     await serverTransport.close();
 
     await waitForTransportToFinish(serverTransport);
-    await ensureTransportQueuesAreEventuallyEmpty(clientTransport);
-    await ensureTransportQueuesAreEventuallyEmpty(serverTransport);
+    await ensureTransportBuffersAreEventuallyEmpty(clientTransport);
+    await ensureTransportBuffersAreEventuallyEmpty(serverTransport);
     await testFinishesCleanly({
       clientTransports: [clientTransport],
       serverTransport,
@@ -121,8 +121,8 @@ describe('procedures should leave no trace after finishing', async () => {
     // check number of connections
     expect(serverTransport.connections.size).toEqual(1);
     expect(clientTransport.connections.size).toEqual(1);
-    await ensureTransportQueuesAreEventuallyEmpty(clientTransport);
-    await ensureTransportQueuesAreEventuallyEmpty(serverTransport);
+    await ensureTransportBuffersAreEventuallyEmpty(clientTransport);
+    await ensureTransportBuffersAreEventuallyEmpty(serverTransport);
     await testFinishesCleanly({
       clientTransports: [clientTransport],
       serverTransport,
@@ -177,8 +177,8 @@ describe('procedures should leave no trace after finishing', async () => {
     // check number of connections
     expect(serverTransport.connections.size).toEqual(1);
     expect(clientTransport.connections.size).toEqual(1);
-    await ensureTransportQueuesAreEventuallyEmpty(clientTransport);
-    await ensureTransportQueuesAreEventuallyEmpty(serverTransport);
+    await ensureTransportBuffersAreEventuallyEmpty(clientTransport);
+    await ensureTransportBuffersAreEventuallyEmpty(serverTransport);
     await testFinishesCleanly({
       clientTransports: [clientTransport],
       serverTransport,
@@ -221,8 +221,8 @@ describe('procedures should leave no trace after finishing', async () => {
     // check number of connections
     expect(serverTransport.connections.size).toEqual(1);
     expect(clientTransport.connections.size).toEqual(1);
-    await ensureTransportQueuesAreEventuallyEmpty(clientTransport);
-    await ensureTransportQueuesAreEventuallyEmpty(serverTransport);
+    await ensureTransportBuffersAreEventuallyEmpty(clientTransport);
+    await ensureTransportBuffersAreEventuallyEmpty(serverTransport);
     await testFinishesCleanly({
       clientTransports: [clientTransport],
       serverTransport,
@@ -263,8 +263,8 @@ describe('procedures should leave no trace after finishing', async () => {
     // check number of connections
     expect(serverTransport.connections.size).toEqual(1);
     expect(clientTransport.connections.size).toEqual(1);
-    await ensureTransportQueuesAreEventuallyEmpty(clientTransport);
-    await ensureTransportQueuesAreEventuallyEmpty(serverTransport);
+    await ensureTransportBuffersAreEventuallyEmpty(clientTransport);
+    await ensureTransportBuffersAreEventuallyEmpty(serverTransport);
     await testFinishesCleanly({
       clientTransports: [clientTransport],
       serverTransport,

--- a/__tests__/disconnects.test.ts
+++ b/__tests__/disconnects.test.ts
@@ -22,6 +22,7 @@ import { Err, UNEXPECTED_DISCONNECT } from '../router/result';
 import { WebSocketServerTransport } from '../transport/impls/ws/server';
 import { WebSocketClientTransport } from '../transport/impls/ws/client';
 import { buildServiceDefs } from '../router/defs';
+import { bindLogger } from '../logging';
 
 // TODO matrix this with all the transports
 describe('procedures should handle unexpected disconnects', async () => {

--- a/__tests__/disconnects.test.ts
+++ b/__tests__/disconnects.test.ts
@@ -22,7 +22,6 @@ import { Err, UNEXPECTED_DISCONNECT } from '../router/result';
 import { WebSocketServerTransport } from '../transport/impls/ws/server';
 import { WebSocketClientTransport } from '../transport/impls/ws/client';
 import { buildServiceDefs } from '../router/defs';
-import { bindLogger } from '../logging';
 
 // TODO matrix this with all the transports
 describe('procedures should handle unexpected disconnects', async () => {

--- a/__tests__/disconnects.test.ts
+++ b/__tests__/disconnects.test.ts
@@ -193,9 +193,9 @@ describe('procedures should handle unexpected disconnects', async () => {
     expect(result.payload).toStrictEqual({ result: 3 });
 
     // at this point, only client1 is connected
-    expect(client1Transport.connections.size).toEqual(1);
-    expect(client2Transport.connections.size).toEqual(0);
-    expect(serverTransport.connections.size).toEqual(1);
+    waitFor(() => expect(client1Transport.connections.size).toEqual(1));
+    waitFor(() => expect(client2Transport.connections.size).toEqual(0));
+    waitFor(() => expect(serverTransport.connections.size).toEqual(1));
 
     // cleanup client1 (client2 is already disconnected)
     close1();

--- a/__tests__/fixtures/cleanup.ts
+++ b/__tests__/fixtures/cleanup.ts
@@ -63,9 +63,9 @@ export async function ensureTransportQueuesAreEventuallyEmpty(
         [...t.sessions]
           .map(
             ([client, sess]) =>
-              [client, sess.sendBuffer] as [
+              [client, sess.inspectSendBuffer()] as [
                 string,
-                Array<OpaqueTransportMessage>,
+                readonly OpaqueTransportMessage[],
               ],
           )
           .filter((entry) => entry[1].length > 0),

--- a/__tests__/fixtures/cleanup.ts
+++ b/__tests__/fixtures/cleanup.ts
@@ -2,7 +2,7 @@ import { expect, vi } from 'vitest';
 import { Connection, OpaqueTransportMessage, Transport } from '../../transport';
 import { Server } from '../../router';
 import {
-  DISCONNECT_GRACE_MS,
+  SESSION_DISCONNECT_GRACE_MS,
   HEARTBEAT_INTERVAL_MS,
 } from '../../transport/session';
 import { log } from '../../logging';
@@ -30,7 +30,7 @@ export async function advanceFakeTimersByDisconnectGrace() {
   await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS + 1);
 
   // then, disconnect timer
-  await vi.advanceTimersByTimeAsync(DISCONNECT_GRACE_MS + 1);
+  await vi.advanceTimersByTimeAsync(SESSION_DISCONNECT_GRACE_MS + 1);
 }
 
 async function ensureTransportIsClean(t: Transport<Connection>) {

--- a/__tests__/fixtures/cleanup.ts
+++ b/__tests__/fixtures/cleanup.ts
@@ -38,7 +38,7 @@ async function ensureTransportIsClean(t: Transport<Connection>) {
     t.state,
     `transport ${t.clientId} should be closed after the test`,
   ).to.not.equal('open');
-  await ensureTransportQueuesAreEventuallyEmpty(t);
+  await ensureTransportBuffersAreEventuallyEmpty(t);
   await waitFor(() =>
     expect(
       t.sessions,
@@ -63,7 +63,7 @@ export function waitFor<T>(cb: () => T | Promise<T>) {
   return vi.waitFor(cb, waitUntilOptions);
 }
 
-export async function ensureTransportQueuesAreEventuallyEmpty(
+export async function ensureTransportBuffersAreEventuallyEmpty(
   t: Transport<Connection>,
 ) {
   await waitFor(() =>

--- a/__tests__/typescript-stress.test.ts
+++ b/__tests__/typescript-stress.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, test } from 'vitest';
 import { Procedure, ServiceBuilder, serializeService } from '../router/builder';
 import { Type } from '@sinclair/typebox';
-import { OpaqueTransportMessage } from '../transport/message';
+import {
+  PartialTransportMessage,
+  TransportClientId,
+} from '../transport/message';
 import { createServer } from '../router/server';
 import { Transport, Connection, Session } from '../transport';
 import { createClient } from '../router/client';
 import { Ok } from '../router/result';
 import { buildServiceDefs } from '../router/defs';
 import { TestServiceConstructor } from './fixtures/services';
+import { nanoid } from 'nanoid';
 
 const input = Type.Union([
   Type.Object({ a: Type.Number() }),
@@ -108,8 +112,11 @@ export class MockTransport extends Transport<Connection> {
     super(clientId);
   }
 
-  send(_msg: OpaqueTransportMessage): boolean {
-    return true;
+  send(
+    _to: TransportClientId,
+    _msg: PartialTransportMessage,
+  ): string | undefined {
+    return nanoid();
   }
 
   protected handleConnection(_conn: Connection, _to: string): void {}

--- a/transport/impls/stdio/connection.ts
+++ b/transport/impls/stdio/connection.ts
@@ -35,15 +35,7 @@ export class StreamConnection extends Connection {
   }
 
   send(payload: Uint8Array) {
-    // many of our tests are structured in a way that is roughly
-    // 1. const msg = {...}
-    // 2. const msgId = clientTransport.send(serverTransport.clientId, msg)
-    // 3. await waitForMessage(serverTransport, (msg) => msg.id === msgId)
-    //
-    // however, because we pipe two streams into each other, the stream transport
-    // actually receives the message before we even attach the listener in L3.
-    // we use setImmediate() here to schedule it for the next check phase of the event loop
-    setImmediate(() => this.output.write(MessageFramer.write(payload)));
+    this.output.write(MessageFramer.write(payload));
     return true;
   }
 

--- a/transport/impls/stdio/connection.ts
+++ b/transport/impls/stdio/connection.ts
@@ -35,6 +35,14 @@ export class StreamConnection extends Connection {
   }
 
   send(payload: Uint8Array) {
+    // many of our tests are structured in a way that is roughly
+    // 1. const msg = {...}
+    // 2. const msgId = clientTransport.send(serverTransport.clientId, msg)
+    // 3. await waitForMessage(serverTransport, (msg) => msg.id === msgId)
+    //
+    // however, because we pipe two streams into each other, the stream transport
+    // actually receives the message before we even attach the listener in L3.
+    // we use setImmediate() here to schedule it for the next check phase of the event loop
     setImmediate(() => this.output.write(MessageFramer.write(payload)));
     return true;
   }

--- a/transport/impls/stdio/connection.ts
+++ b/transport/impls/stdio/connection.ts
@@ -35,7 +35,8 @@ export class StreamConnection extends Connection {
   }
 
   send(payload: Uint8Array) {
-    return this.output.write(MessageFramer.write(payload));
+    setImmediate(() => this.output.write(MessageFramer.write(payload)));
+    return true;
   }
 
   async close() {

--- a/transport/impls/stdio/stdio.test.ts
+++ b/transport/impls/stdio/stdio.test.ts
@@ -37,13 +37,9 @@ describe('sending and receiving across node streams works', () => {
 
     for (const msg of messages) {
       const transportMessage = payloadToTransportMessage(msg);
-      const msgId = clientTransport.send(
-        serverTransport.clientId,
-        transportMessage,
-      );
-      await expect(
-        waitForMessage(serverTransport, (incoming) => incoming.id === msgId),
-      ).resolves.toStrictEqual(transportMessage.payload);
+      const msgPromise = waitForMessage(serverTransport);
+      clientTransport.send(serverTransport.clientId, transportMessage);
+      await expect(msgPromise).resolves.toStrictEqual(transportMessage.payload);
     }
 
     await testFinishesCleanly({

--- a/transport/impls/stdio/stdio.test.ts
+++ b/transport/impls/stdio/stdio.test.ts
@@ -36,19 +36,14 @@ describe('sending and receiving across node streams works', () => {
     ];
 
     for (const msg of messages) {
-      const transportMessage = payloadToTransportMessage(
-        msg,
-        'stream',
-        clientTransport.clientId,
+      const transportMessage = payloadToTransportMessage(msg);
+      const msgId = clientTransport.send(
         serverTransport.clientId,
+        transportMessage,
       );
-
-      const p = waitForMessage(
-        serverTransport,
-        (incoming) => incoming.id === transportMessage.id,
-      );
-      clientTransport.send(transportMessage);
-      await expect(p).resolves.toStrictEqual(transportMessage.payload);
+      await expect(
+        waitForMessage(serverTransport, (incoming) => incoming.id === msgId),
+      ).resolves.toStrictEqual(transportMessage.payload);
     }
 
     await testFinishesCleanly({

--- a/transport/impls/ws/ws.test.ts
+++ b/transport/impls/ws/ws.test.ts
@@ -13,6 +13,7 @@ import { WebSocketServerTransport } from './server';
 import { WebSocketClientTransport } from './client';
 import { testFinishesCleanly } from '../../../__tests__/fixtures/cleanup';
 import { PartialTransportMessage } from '../../message';
+import { bindLogger, setLevel } from '../../../logging';
 
 describe('sending and receiving across websockets works', async () => {
   const server = http.createServer();
@@ -24,7 +25,9 @@ describe('sending and receiving across websockets works', async () => {
     server.close();
   });
 
-  test('basic send/receive', async () => {
+  bindLogger(console.log);
+  setLevel('debug');
+  test.only('basic send/receive', async () => {
     const [clientTransport, serverTransport] = createWsTransports(port, wss);
     const msg = createDummyTransportMessage();
     const msgId = clientTransport.send(serverTransport.clientId, msg);

--- a/transport/impls/ws/ws.test.ts
+++ b/transport/impls/ws/ws.test.ts
@@ -13,7 +13,6 @@ import { WebSocketServerTransport } from './server';
 import { WebSocketClientTransport } from './client';
 import { testFinishesCleanly } from '../../../__tests__/fixtures/cleanup';
 import { PartialTransportMessage } from '../../message';
-import { bindLogger, setLevel } from '../../../logging';
 
 describe('sending and receiving across websockets works', async () => {
   const server = http.createServer();
@@ -25,9 +24,7 @@ describe('sending and receiving across websockets works', async () => {
     server.close();
   });
 
-  bindLogger(console.log);
-  setLevel('debug');
-  test.only('basic send/receive', async () => {
+  test('basic send/receive', async () => {
     const [clientTransport, serverTransport] = createWsTransports(port, wss);
     const msg = createDummyTransportMessage();
     const msgId = clientTransport.send(serverTransport.clientId, msg);

--- a/transport/impls/ws/ws.test.ts
+++ b/transport/impls/ws/ws.test.ts
@@ -6,10 +6,13 @@ import {
   onWsServerReady,
   createLocalWebSocketClient,
   waitForMessage,
+  createDummyTransportMessage,
+  payloadToTransportMessage,
 } from '../../../util/testHelpers';
 import { WebSocketServerTransport } from './server';
 import { WebSocketClientTransport } from './client';
 import { testFinishesCleanly } from '../../../__tests__/fixtures/cleanup';
+import { PartialTransportMessage } from '../../message';
 
 describe('sending and receiving across websockets works', async () => {
   const server = http.createServer();
@@ -24,12 +27,10 @@ describe('sending and receiving across websockets works', async () => {
   test('basic send/receive', async () => {
     const [clientTransport, serverTransport] = createWsTransports(port, wss);
     const msg = createDummyTransportMessage();
-    const msgPromise = waitForMessage(
-      serverTransport,
-      (recv) => recv.id === msg.id,
-    );
-    clientTransport.send(serverTransport.clientId, msg);
-    await expect(msgPromise).resolves.toStrictEqual(msg.payload);
+    const msgId = clientTransport.send(serverTransport.clientId, msg);
+    await expect(
+      waitForMessage(serverTransport, (recv) => recv.id === msgId),
+    ).resolves.toStrictEqual(msg.payload);
 
     await testFinishesCleanly({
       clientTransports: [clientTransport],
@@ -38,17 +39,8 @@ describe('sending and receiving across websockets works', async () => {
   });
 
   test('sending respects to/from fields', async () => {
-    const makeDummyMessage = (from: string, to: string, message: string) => {
-      return msg(
-        from,
-        to,
-        'stream',
-        {
-          msg: message,
-        },
-        'service',
-        'proc',
-      );
+    const makeDummyMessage = (message: string): PartialTransportMessage => {
+      return payloadToTransportMessage({ message });
     };
 
     const clientId1 = 'client1';
@@ -64,13 +56,11 @@ describe('sending and receiving across websockets works', async () => {
       );
 
       // client to server
-      const initMsg = makeDummyMessage(id, serverId, 'hello server');
-      const initMsgPromise = waitForMessage(
-        serverTransport,
-        (recv) => recv.id === initMsg.id,
-      );
-      client.send(initMsg);
-      await expect(initMsgPromise).resolves.toStrictEqual(initMsg.payload);
+      const initMsg = makeDummyMessage('hello server');
+      const initMsgId = client.send(serverId, initMsg);
+      await expect(
+        waitForMessage(serverTransport, (recv) => recv.id === initMsgId),
+      ).resolves.toStrictEqual(initMsg.payload);
       return client;
     };
 
@@ -78,15 +68,15 @@ describe('sending and receiving across websockets works', async () => {
     const client2 = await initClient(clientId2);
 
     // sending messages from server to client shouldn't leak between clients
-    const msg1 = makeDummyMessage(serverId, clientId1, 'hello client1');
-    const msg2 = makeDummyMessage(serverId, clientId2, 'hello client2');
+    const msg1 = makeDummyMessage('hello client1');
+    const msg2 = makeDummyMessage('hello client2');
+    const msg1Id = serverTransport.send(clientId1, msg1);
+    const msg2Id = serverTransport.send(clientId2, msg2);
     const promises = Promise.all([
       // true means reject if we receive any message that isn't the one we are expecting
-      waitForMessage(client2, (recv) => recv.id === msg2.id, true),
-      waitForMessage(client1, (recv) => recv.id === msg1.id, true),
+      waitForMessage(client2, (recv) => recv.id === msg2Id, true),
+      waitForMessage(client1, (recv) => recv.id === msg1Id, true),
     ]);
-    serverTransport.send(msg1);
-    serverTransport.send(msg2);
     await expect(promises).resolves.toStrictEqual(
       expect.arrayContaining([msg1.payload, msg2.payload]),
     );
@@ -113,25 +103,22 @@ describe('reconnect', async () => {
     const msg1 = createDummyTransportMessage();
     const msg2 = createDummyTransportMessage();
 
-    const msg1Promise = waitForMessage(
-      serverTransport,
-      (recv) => recv.id === msg1.id,
-    );
-    clientTransport.send(msg1);
-    await expect(msg1Promise).resolves.toStrictEqual(msg1.payload);
+    const msg1Id = clientTransport.send(serverTransport.clientId, msg1);
+    await expect(
+      waitForMessage(serverTransport, (recv) => recv.id === msg1Id),
+    ).resolves.toStrictEqual(msg1.payload);
 
     // unclean disconnect
     clientTransport.sessions.forEach(
       (session) => session.connection?.ws.terminate(),
     );
-    const msg2Promise = waitForMessage(
-      serverTransport,
-      (recv) => recv.id === msg2.id,
-    );
 
     // by this point the client should have reconnected
-    clientTransport.send(msg2);
-    await expect(msg2Promise).resolves.toStrictEqual(msg2.payload);
+    const msg2Id = clientTransport.send(serverTransport.clientId, msg2);
+    await expect(
+      waitForMessage(serverTransport, (recv) => recv.id === msg2Id),
+    ).resolves.toStrictEqual(msg2.payload);
+
     await testFinishesCleanly({
       clientTransports: [clientTransport],
       serverTransport,

--- a/transport/impls/ws/ws.test.ts
+++ b/transport/impls/ws/ws.test.ts
@@ -3,12 +3,10 @@ import { describe, test, expect, afterAll } from 'vitest';
 import {
   createWebSocketServer,
   createWsTransports,
-  createDummyTransportMessage,
   onWsServerReady,
   createLocalWebSocketClient,
   waitForMessage,
 } from '../../../util/testHelpers';
-import { msg } from '../..';
 import { WebSocketServerTransport } from './server';
 import { WebSocketClientTransport } from './client';
 import { testFinishesCleanly } from '../../../__tests__/fixtures/cleanup';
@@ -30,7 +28,7 @@ describe('sending and receiving across websockets works', async () => {
       serverTransport,
       (recv) => recv.id === msg.id,
     );
-    clientTransport.send(msg);
+    clientTransport.send(serverTransport.clientId, msg);
     await expect(msgPromise).resolves.toStrictEqual(msg.payload);
 
     await testFinishesCleanly({

--- a/transport/index.ts
+++ b/transport/index.ts
@@ -3,14 +3,12 @@ export { Connection, Session } from './session';
 export {
   TransportMessageSchema,
   OpaqueTransportMessageSchema,
-  msg,
-  reply,
 } from './message';
 export type {
   TransportMessage,
-  MessageId,
   OpaqueTransportMessage,
   TransportClientId,
   isStreamOpen,
   isStreamClose,
 } from './message';
+export { EventMap, EventTypes, EventHandler } from './events';

--- a/transport/message.test.ts
+++ b/transport/message.test.ts
@@ -4,7 +4,6 @@ import {
   bootRequestMessage,
   bootResponseMessage,
   isAck,
-  isHandshakeRequest,
   isStreamClose,
   isStreamOpen,
 } from './message';
@@ -63,7 +62,6 @@ describe('message helpers', () => {
 
     expect(m.from).toBe('a');
     expect(m.to).toBe('b');
-    expect(isHandshakeRequest(m.controlFlags)).toBe(true);
   });
 
   test('bootResponseMessage', () => {
@@ -72,12 +70,10 @@ describe('message helpers', () => {
 
     expect(mSuccess.from).toBe('a');
     expect(mSuccess.to).toBe('b');
-    expect(isHandshakeRequest(mSuccess.controlFlags)).toBe(true);
     expect(mSuccess.payload.status.ok).toBe(true);
 
     expect(mFail.from).toBe('a');
     expect(mFail.to).toBe('b');
-    expect(isHandshakeRequest(mFail.controlFlags)).toBe(true);
     expect(mFail.payload.status.ok).toBe(false);
   });
 

--- a/transport/message.test.ts
+++ b/transport/message.test.ts
@@ -1,18 +1,40 @@
+import { TransportMessage } from '.';
 import {
   ControlFlags,
+  bootRequestMessage,
+  bootResponseMessage,
   isAck,
+  isHandshakeRequest,
   isStreamClose,
   isStreamOpen,
-  msg,
-  reply,
 } from './message';
 import { describe, test, expect } from 'vitest';
+
+const msg = (
+  to: string,
+  from: string,
+  streamId: string,
+  payload: Record<string, unknown>,
+  serviceName: string,
+  procedureName: string,
+): TransportMessage => ({
+  id: 'abc',
+  to,
+  from,
+  streamId,
+  payload,
+  serviceName,
+  procedureName,
+  controlFlags: 0,
+  seq: 0,
+  ack: 0,
+});
 
 describe('message helpers', () => {
   test('ack', () => {
     const m = msg('a', 'b', 'stream', { test: 1 }, 'svc', 'proc');
     m.controlFlags |= ControlFlags.AckBit;
-    expect(m).toHaveProperty('controlFlags');
+
     expect(isAck(m.controlFlags)).toBe(true);
     expect(isStreamOpen(m.controlFlags)).toBe(false);
     expect(isStreamClose(m.controlFlags)).toBe(false);
@@ -21,7 +43,7 @@ describe('message helpers', () => {
   test('streamOpen', () => {
     const m = msg('a', 'b', 'stream', { test: 1 }, 'svc', 'proc');
     m.controlFlags |= ControlFlags.StreamOpenBit;
-    expect(m).toHaveProperty('controlFlags');
+
     expect(isAck(m.controlFlags)).toBe(false);
     expect(isStreamOpen(m.controlFlags)).toBe(true);
     expect(isStreamClose(m.controlFlags)).toBe(false);
@@ -30,24 +52,38 @@ describe('message helpers', () => {
   test('streamClose', () => {
     const m = msg('a', 'b', 'stream', { test: 1 }, 'svc', 'proc');
     m.controlFlags |= ControlFlags.StreamClosedBit;
-    expect(m).toHaveProperty('controlFlags');
+
     expect(isAck(m.controlFlags)).toBe(false);
     expect(isStreamOpen(m.controlFlags)).toBe(false);
     expect(isStreamClose(m.controlFlags)).toBe(true);
   });
 
-  test('reply', () => {
-    const m = msg('a', 'b', 'stream', { test: 1 }, 'svc', 'proc');
-    const payload = { cool: 2 };
-    const resp = reply(m, payload);
-    expect(resp.id).not.toBe(m.id);
-    expect(resp.payload).toEqual(payload);
-    expect(resp.from).toBe('b');
-    expect(resp.to).toBe('a');
+  test('bootRequestMessage', () => {
+    const m = bootRequestMessage('a', 'b');
+
+    expect(m.from).toBe('a');
+    expect(m.to).toBe('b');
+    expect(isHandshakeRequest(m.controlFlags)).toBe(true);
+  });
+
+  test('bootResponseMessage', () => {
+    const mSuccess = bootResponseMessage('a', 'b', true);
+    const mFail = bootResponseMessage('a', 'b', false);
+
+    expect(mSuccess.from).toBe('a');
+    expect(mSuccess.to).toBe('b');
+    expect(isHandshakeRequest(mSuccess.controlFlags)).toBe(true);
+    expect(mSuccess.payload.status.ok).toBe(true);
+
+    expect(mFail.from).toBe('a');
+    expect(mFail.to).toBe('b');
+    expect(isHandshakeRequest(mFail.controlFlags)).toBe(true);
+    expect(mFail.payload.status.ok).toBe(false);
   });
 
   test('default message has no control flags set', () => {
     const m = msg('a', 'b', 'stream', { test: 1 }, 'svc', 'proc');
+
     expect(isAck(m.controlFlags)).toBe(false);
     expect(isStreamOpen(m.controlFlags)).toBe(false);
     expect(isStreamClose(m.controlFlags)).toBe(false);
@@ -56,8 +92,10 @@ describe('message helpers', () => {
   test('combining control flags works', () => {
     const m = msg('a', 'b', 'stream', { test: 1 }, 'svc', 'proc');
     m.controlFlags |= ControlFlags.StreamOpenBit;
+
     expect(isStreamOpen(m.controlFlags)).toBe(true);
     expect(isStreamClose(m.controlFlags)).toBe(false);
+
     m.controlFlags |= ControlFlags.StreamClosedBit;
     expect(isStreamOpen(m.controlFlags)).toBe(true);
     expect(isStreamClose(m.controlFlags)).toBe(true);

--- a/transport/message.ts
+++ b/transport/message.ts
@@ -25,6 +25,8 @@ export const TransportMessageSchema = <T extends TSchema>(t: T) =>
     id: Type.String(),
     from: Type.String(),
     to: Type.String(),
+    seq: Type.Integer(),
+    ack: Type.Integer(),
     serviceName: Type.Optional(Type.Union([Type.String(), Type.Null()])),
     procedureName: Type.Optional(Type.Union([Type.String(), Type.Null()])),
     streamId: Type.String(),
@@ -39,7 +41,6 @@ export const TransportMessageSchema = <T extends TSchema>(t: T) =>
  */
 export const ControlMessageAckSchema = Type.Object({
   type: Type.Literal('ACK'),
-  ack: Type.String(),
 });
 
 /**
@@ -104,6 +105,8 @@ export type TransportMessage<
   id: string;
   from: string;
   to: string;
+  seq: number;
+  ack: number;
   serviceName?: string;
   procedureName?: string;
   streamId: string;
@@ -111,7 +114,58 @@ export type TransportMessage<
   payload: Payload;
 };
 
-export type MessageId = string;
+export type PartialTransportMessage<
+  Payload extends Record<string, unknown> | unknown = Record<string, unknown>,
+> = Omit<TransportMessage<Payload>, 'id' | 'from' | 'to' | 'seq' | 'ack'>;
+
+export function bootRequestMessage(
+  from: TransportClientId,
+  to: TransportClientId,
+): TransportMessage<Static<typeof ControlMessageHandshakeRequestSchema>> {
+  return {
+    id: nanoid(),
+    from,
+    to,
+    seq: 0,
+    ack: 0,
+    streamId: nanoid(),
+    controlFlags: ControlFlags.StreamOpenBit | ControlFlags.HandshakeBit,
+    payload: {
+      type: 'HANDSHAKE_REQ',
+      protocolVersion: PROTOCOL_VERSION,
+    } satisfies Static<typeof ControlMessageHandshakeRequestSchema>,
+  };
+}
+
+export function bootResponseMessage(
+  from: TransportClientId,
+  to: TransportClientId,
+  ok: boolean,
+): TransportMessage<Static<typeof ControlMessageHandshakeResponseSchema>> {
+  return {
+    id: nanoid(),
+    from,
+    to,
+    seq: 0,
+    ack: 0,
+    streamId: nanoid(),
+    controlFlags: ControlFlags.StreamOpenBit | ControlFlags.HandshakeBit,
+    payload: (ok
+      ? {
+          type: 'HANDSHAKE_RESP',
+          status: {
+            ok: true,
+          },
+        }
+      : {
+          type: 'HANDSHAKE_RESP',
+          status: {
+            ok: false,
+            reason: 'VERSION_MISMATCH',
+          },
+        }) satisfies Static<typeof ControlMessageHandshakeResponseSchema>,
+  };
+}
 
 /**
  * A type alias for a transport message with an opaque payload.
@@ -119,76 +173,6 @@ export type MessageId = string;
  */
 export type OpaqueTransportMessage = TransportMessage<unknown>;
 export type TransportClientId = string;
-
-/**
- * Creates a transport message with the given parameters. You shouldn't need to call this manually unless
- * you're writing a test.
- * @param from The sender of the message.
- * @param to The intended recipient of the message.
- * @param service The name of the service the message is intended for.
- * @param proc The name of the procedure the message is intended for.
- * @param stream The ID of the stream the message is intended for.
- * @param payload The payload of the message.
- * @returns A TransportMessage object with the given parameters.
- */
-export function msg<Payload extends object>(
-  from: string,
-  to: string,
-  streamId: string,
-  payload: Payload,
-  serviceName?: string,
-  procedureName?: string,
-): TransportMessage<Payload> {
-  return {
-    id: nanoid(),
-    to,
-    from,
-    serviceName,
-    procedureName,
-    streamId,
-    controlFlags: 0,
-    payload,
-  };
-}
-
-/**
- * Creates a new transport message as a response to the given message.
- * @param msg The original message to respond to.
- * @param response The payload of the response message.
- * @returns A new transport message with appropriate to, from, and payload fields
- */
-export function reply<Payload extends object>(
-  msg: OpaqueTransportMessage,
-  response: Payload,
-): TransportMessage<Payload> {
-  return {
-    id: nanoid(),
-    streamId: msg.streamId,
-    controlFlags: 0,
-    to: msg.from,
-    from: msg.to,
-    payload: response,
-  };
-}
-
-/**
- * Create a request to close a stream
- * @param from The ID of the client initiating the close.
- * @param to The ID of the client being closed.
- * @param respondTo The transport message to respond to.
- * @returns The close message
- */
-export function closeStream(
-  from: TransportClientId,
-  to: TransportClientId,
-  stream: string,
-) {
-  const closeMessage = msg(from, to, stream, {
-    type: 'CLOSE' as const,
-  } satisfies Static<typeof ControlMessagePayloadSchema>);
-  closeMessage.controlFlags |= ControlFlags.StreamClosedBit;
-  return closeMessage;
-}
 
 /**
  * Checks if the given control flag (usually found in msg.controlFlag) is an ack message.
@@ -219,5 +203,16 @@ export function isStreamClose(controlFlag: number): boolean {
   return (
     (controlFlag & ControlFlags.StreamClosedBit) ===
     ControlFlags.StreamClosedBit
+  );
+}
+
+/**
+ * Checks if the given control flag (usually found in msg.controlFlag) is a handshake request.
+ * @param controlFlag - The control flag to check.
+ * @returns True if the control flag contains the HandshakeBit, false otherwise.
+ */
+export function isHandshakeRequest(controlFlag: number): boolean {
+  return (
+    (controlFlag & ControlFlags.HandshakeBit) === ControlFlags.HandshakeBit
   );
 }

--- a/transport/message.ts
+++ b/transport/message.ts
@@ -129,7 +129,7 @@ export function bootRequestMessage(
     seq: 0,
     ack: 0,
     streamId: nanoid(),
-    controlFlags: ControlFlags.StreamOpenBit | ControlFlags.HandshakeBit,
+    controlFlags: 0,
     payload: {
       type: 'HANDSHAKE_REQ',
       protocolVersion: PROTOCOL_VERSION,
@@ -149,7 +149,7 @@ export function bootResponseMessage(
     seq: 0,
     ack: 0,
     streamId: nanoid(),
-    controlFlags: ControlFlags.StreamOpenBit | ControlFlags.HandshakeBit,
+    controlFlags: 0,
     payload: (ok
       ? {
           type: 'HANDSHAKE_RESP',
@@ -203,16 +203,5 @@ export function isStreamClose(controlFlag: number): boolean {
   return (
     (controlFlag & ControlFlags.StreamClosedBit) ===
     ControlFlags.StreamClosedBit
-  );
-}
-
-/**
- * Checks if the given control flag (usually found in msg.controlFlag) is a handshake request.
- * @param controlFlag - The control flag to check.
- * @returns True if the control flag contains the HandshakeBit, false otherwise.
- */
-export function isHandshakeRequest(controlFlag: number): boolean {
-  return (
-    (controlFlag & ControlFlags.HandshakeBit) === ControlFlags.HandshakeBit
   );
 }

--- a/transport/session.ts
+++ b/transport/session.ts
@@ -171,6 +171,15 @@ export class Session<ConnType extends Connection> {
     );
   }
 
+  /**
+   * Sends a message over the session's connection.
+   * If the connection is not ready or the message fails to send, the message can be buffered for retry unless skipped.
+   *
+   * @param msg The partial message to be sent, which will be constructed into a full message.
+   * @param skipRetry Optional. If true, the message will not be buffered for retry on failure. This should only be used for
+   * ack hearbeats, which contain information that can already be found in the other buffered messages.
+   * @returns The full transport ID of the message that was attempted to be sent.
+   */
   send(msg: PartialTransportMessage, skipRetry?: boolean): string {
     const fullMsg: TransportMessage = this.constructMsg(msg);
     log?.debug(`${this.from} -- sending ${JSON.stringify(fullMsg)}`);

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -20,22 +20,19 @@ describe.each(transports)('transport -- $name', async ({ setup }) => {
     const msg1 = createDummyTransportMessage();
     const msg2 = createDummyTransportMessage();
 
-    const msg1Promise = waitForMessage(
-      serverTransport,
-      (recv) => recv.id === msg1.id,
-    );
-    clientTransport.send(msg1);
-    await expect(msg1Promise).resolves.toStrictEqual(msg1.payload);
+    const msg1Id = clientTransport.send(serverTransport.clientId, msg1);
+    await expect(
+      waitForMessage(serverTransport, (recv) => recv.id === msg1Id),
+    ).resolves.toStrictEqual(msg1.payload);
 
     clientTransport.connections.forEach((conn) => conn.close());
 
     // by this point the client should have reconnected
-    clientTransport.send(msg2);
-    const msg2Promise = waitForMessage(
-      serverTransport,
-      (recv) => recv.id === msg2.id,
-    );
-    await expect(msg2Promise).resolves.toStrictEqual(msg2.payload);
+    const msg2Id = clientTransport.send(serverTransport.clientId, msg2);
+    await expect(
+      waitForMessage(serverTransport, (recv) => recv.id === msg2Id),
+    ).resolves.toStrictEqual(msg2.payload);
+
     await testFinishesCleanly({
       clientTransports: [clientTransport],
       serverTransport,
@@ -97,12 +94,10 @@ describe.each(transports)('transport -- $name', async ({ setup }) => {
     expect(clientSessDisconnect).toHaveBeenCalledTimes(0);
     expect(serverSessDisconnect).toHaveBeenCalledTimes(0);
 
-    const msg1Promise = waitForMessage(
-      serverTransport,
-      (recv) => recv.id === msg1.id,
-    );
-    clientTransport.send(msg1);
-    await expect(msg1Promise).resolves.toStrictEqual(msg1.payload);
+    const msg1Id = clientTransport.send(serverTransport.clientId, msg1);
+    await expect(
+      waitForMessage(serverTransport, (recv) => recv.id === msg1Id),
+    ).resolves.toStrictEqual(msg1.payload);
 
     // session    >  c--| (connected)
     // connection >  c--| (connected)
@@ -132,16 +127,13 @@ describe.each(transports)('transport -- $name', async ({ setup }) => {
     await waitFor(() => expect(clientSessDisconnect).toHaveBeenCalledTimes(0));
     await waitFor(() => expect(serverSessDisconnect).toHaveBeenCalledTimes(0));
 
-    const msg2Promise = waitForMessage(
-      serverTransport,
-      (recv) => recv.id === msg2.id,
-    );
-
     // by this point the client should have reconnected
     // session    >  c----------| (connected)
     // connection >  c--x   c---| (connected)
-    clientTransport.send(msg2);
-    await expect(msg2Promise).resolves.toStrictEqual(msg2.payload);
+    const msg2Id = clientTransport.send(serverTransport.clientId, msg2);
+    await expect(
+      waitForMessage(serverTransport, (recv) => recv.id === msg2Id),
+    ).resolves.toStrictEqual(msg2.payload);
     expect(clientConnConnect).toHaveBeenCalledTimes(2);
     expect(serverConnConnect).toHaveBeenCalledTimes(2);
     expect(clientConnDisconnect).toHaveBeenCalledTimes(1);
@@ -183,15 +175,13 @@ describe.each(transports)('transport -- $name', async ({ setup }) => {
     const msg1 = createDummyTransportMessage();
     const msg2 = createDummyTransportMessage();
 
-    const promise1 = waitForMessage(
-      serverTransport,
-      (recv) => recv.id === msg1.id,
-    );
-    clientTransport.send(msg1);
-    await expect(promise1).resolves.toStrictEqual(msg1.payload);
+    const msg1Id = clientTransport.send(serverTransport.clientId, msg1);
+    await expect(
+      waitForMessage(serverTransport, (recv) => recv.id === msg1Id),
+    ).resolves.toStrictEqual(msg1.payload);
 
     await clientTransport.destroy();
-    expect(() => clientTransport.send(msg2)).toThrow(
+    expect(() => clientTransport.send(serverTransport.clientId, msg2)).toThrow(
       new Error('transport is destroyed, cant send'),
     );
 

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -300,15 +300,17 @@ export abstract class Transport<ConnType extends Connection> {
     log?.debug(`${this.clientId} -- received msg: ${JSON.stringify(msg)}`);
     if (msg.seq !== session.nextExpectedSeq) {
       log?.warn(
-        `${
-          this.clientId
-        } -- received out-of-order msg, discarding: ${JSON.stringify(msg)}`,
+        `${this.clientId} -- received out-of-order msg (got: ${
+          msg.seq
+        }, wanted: ${session.nextExpectedSeq}), discarding: ${JSON.stringify(
+          msg,
+        )}`,
       );
       return;
     }
 
-    session.updateBookkeeping(msg.ack, msg.seq);
     this.eventDispatcher.dispatchEvent('message', msg);
+    session.updateBookkeeping(msg.ack, msg.seq);
   }
 
   /**
@@ -496,6 +498,7 @@ export abstract class ClientTransport<
       // send boot sequence
       this.state = 'open';
       const responseMsg = bootRequestMessage(this.clientId, to);
+      log?.debug(`${this.clientId} -- sending boot handshake to ${to}`);
       conn.send(this.codec.toBuffer(responseMsg));
     } catch (error: unknown) {
       const errStr = error instanceof Error ? error.message : `${error}`;

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -421,7 +421,7 @@ export abstract class Transport<ConnType extends Connection> {
     log?.debug(
       `${this.clientId} -- now at ${session.sendBuffer.length} outstanding messages to ${to}`,
     );
-    return undefined;
+    return fullMsg.id;
   }
 
   // control helpers

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -408,7 +408,7 @@ export abstract class Transport<ConnType extends Connection> {
    */
   async destroy() {
     for (const session of this.sessions.values()) {
-      session.closeStaleConnection();
+      session.closeStaleConnection(session.connection);
     }
 
     this.state = 'destroyed';

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -1,24 +1,23 @@
 import { Codec } from '../codec/types';
 import { Value } from '@sinclair/typebox/value';
 import {
-  ControlFlags,
   OpaqueTransportMessage,
   OpaqueTransportMessageSchema,
-  ControlMessageAckSchema,
   TransportClientId,
-  isAck,
-  reply,
   ControlMessageHandshakeRequestSchema,
   ControlMessageHandshakeResponseSchema,
-  msg,
-  PROTOCOL_VERSION,
+  bootRequestMessage,
+  bootResponseMessage,
+  PartialTransportMessage,
+  TransportMessage,
+  ControlFlags,
+  ControlMessagePayloadSchema,
 } from './message';
 import { log } from '../logging';
 import { EventDispatcher, EventHandler, EventTypes } from './events';
 import { Connection, DISCONNECT_GRACE_MS, Session } from './session';
 import { NaiveJsonCodec } from '../codec';
 import { Static } from '@sinclair/typebox';
-import { nanoid } from 'nanoid';
 
 /**
  * Represents the possible states of a transport.
@@ -164,7 +163,7 @@ export abstract class Transport<ConnType extends Connection> {
     session.connection?.close();
     session.connection = undefined;
     log?.info(
-      `${this.clientId} -- closing old inner connection (id: ${conn.debugId}) from session (id: ${session.debugId}) to ${session.connectedTo}`,
+      `${this.clientId} -- closing old inner connection (id: ${conn.debugId}) from session (id: ${session.debugId}) to ${session.to}`,
     );
   }
 
@@ -216,21 +215,22 @@ export abstract class Transport<ConnType extends Connection> {
     session.cancelGrace();
 
     // if there are any unacked messages in the sendQueue, send them now
-    for (const id of session.sendQueue) {
-      const msg = session.sendBuffer.get(id);
-      if (msg) {
-        const ok = this.send(msg);
-        if (!ok) {
-          // this should never happen unless the transport has an
-          // incorrect implementation of `createNewOutgoingConnection`
-          const msg = `${this.clientId} -- failed to send queued message to ${connectedTo} in session (id: ${session.debugId}) (if you hit this code path something is seriously wrong)`;
-          log?.error(msg);
-          throw new Error(msg);
-        }
-      }
-    }
-
-    session.sendQueue = [];
+    // for (const id of session.sendQueue) {
+    //   const msg = session.sendBuffer.get(id);
+    //   if (msg) {
+    //     const ok = this.send(msg);
+    //     if (!ok) {
+    //       // this should never happen unless the transport has an
+    //       // incorrect implementation of `createNewOutgoingConnection`
+    //       const msg = `${this.clientId} -- failed to send queued message to ${connectedTo} in session (id: ${session.debugId}) (if you hit this code path something is seriously wrong)`;
+    //       log?.error(msg);
+    //       throw new Error(msg);
+    //     }
+    //   }
+    // }
+    //
+    // session.sendQueue = [];
+    // TODO: refactor these
     return session;
   }
 
@@ -238,8 +238,8 @@ export abstract class Transport<ConnType extends Connection> {
     connectedTo: TransportClientId,
     conn: ConnType | undefined,
   ) {
-    const session = new Session<ConnType>(connectedTo, conn);
-    this.sessions.set(session.connectedTo, session);
+    const session = new Session<ConnType>(this.clientId, connectedTo, conn);
+    this.sessions.set(session.to, session);
     this.eventDispatcher.dispatchEvent('sessionStatus', {
       status: 'connect',
       session,
@@ -267,7 +267,7 @@ export abstract class Transport<ConnType extends Connection> {
 
     this.closeStaleConnectionForSession(conn, session);
     session.beginGrace(() => {
-      this.sessions.delete(session.connectedTo);
+      this.sessions.delete(session.to);
       this.eventDispatcher.dispatchEvent('sessionStatus', {
         status: 'disconnect',
         session,
@@ -325,31 +325,21 @@ export abstract class Transport<ConnType extends Connection> {
     const session = this.sessionByClientId(msg.from);
     session.cancelGrace();
 
-    if (
-      isAck(msg.controlFlags) &&
-      Value.Check(ControlMessageAckSchema, msg.payload)
-    ) {
-      // process ack
-      log?.debug(`${this.clientId} -- received ack: ${JSON.stringify(msg)}`);
-      if (session.sendBuffer.has(msg.payload.ack)) {
-        session.sendBuffer.delete(msg.payload.ack);
-      }
-    } else {
-      // regular river message
-      log?.debug(`${this.clientId} -- received msg: ${JSON.stringify(msg)}`);
-      this.eventDispatcher.dispatchEvent('message', msg);
-
-      if (!isAck(msg.controlFlags)) {
-        const ackMsg = reply(msg, {
-          type: 'ACK',
-          ack: msg.id,
-        } satisfies Static<typeof ControlMessageAckSchema>);
-        ackMsg.controlFlags = ControlFlags.AckBit;
-        ackMsg.from = this.clientId;
-
-        this.send(ackMsg);
-      }
+    log?.debug(`${this.clientId} -- received msg: ${JSON.stringify(msg)}`);
+    if (msg.seq !== session.ack + 1) {
+      log?.warn(
+        `${
+          this.clientId
+        } -- received out-of-order msg, discarding: ${JSON.stringify(msg)}`,
+      );
+      return;
     }
+
+    session.sendBuffer = session.sendBuffer.filter(
+      (unacked) => unacked.seq < msg.ack,
+    );
+    this.eventDispatcher.dispatchEvent('message', msg);
+    session.ack = msg.seq;
   }
 
   /**
@@ -380,9 +370,12 @@ export abstract class Transport<ConnType extends Connection> {
    * Sends a message over this transport, delegating to the appropriate connection to actually
    * send the message.
    * @param msg The message to send.
-   * @returns The ID of the sent message.
+   * @returns The ID of the sent message or undefined if it wasn't sent
    */
-  send(msg: OpaqueTransportMessage): boolean {
+  send(
+    to: TransportClientId,
+    msg: PartialTransportMessage,
+  ): string | undefined {
     if (this.state === 'destroyed') {
       const err = 'transport is destroyed, cant send';
       log?.error(`${this.clientId} -- ` + err + `: ${JSON.stringify(msg)}`);
@@ -395,43 +388,59 @@ export abstract class Transport<ConnType extends Connection> {
           msg,
         )}`,
       );
-      return false;
+      return undefined;
     }
 
-    let session = this.sessions.get(msg.to);
+    let session = this.sessions.get(to);
     if (!session) {
       // this case happens on the client as .send()
       // can be called without a session existing so we
       // must create the session here
-      session = this.createSession(msg.to, undefined);
+      session = this.createSession(to, undefined);
       log?.info(
-        `${this.clientId} -- no session for ${msg.to}, created a new one (id: ${session.debugId})`,
+        `${this.clientId} -- no session for ${to}, created a new one (id: ${session.debugId})`,
       );
     }
 
-    // we only use sendBuffer to track messages that we expect an ack from,
-    // messages with the ack flag are not responded to
-    if (!isAck(msg.controlFlags)) {
-      session.sendBuffer.set(msg.id, msg);
-    }
-
-    const conn = session.connection;
+    let conn = session?.connection;
+    const fullMsg: TransportMessage = session.constructMsg(msg);
     if (conn) {
       log?.debug(`${this.clientId} -- sending ${JSON.stringify(msg)}`);
-      const ok = conn.send(this.codec.toBuffer(msg));
-      if (ok) return true;
+      const ok = this.rawSend(conn, fullMsg);
+      if (ok) return fullMsg.id;
       log?.info(
-        `${this.clientId} -- failed to send on connection (id: ${conn.debugId}) to ${msg.to}, queuing msg ${msg.id}`,
+        `${this.clientId} -- failed to send on connection (id: ${conn.debugId}) to ${fullMsg.to}, queuing msg ${fullMsg.id}`,
       );
     } else {
       log?.info(
-        `${this.clientId} -- connection to ${msg.to} doesn't exist, queuing msg ${msg.id}`,
+        `${this.clientId} -- connection to ${to} doesn't exist, queuing msg ${fullMsg.id}`,
       );
     }
 
-    session.sendQueue.push(msg.id);
+    session.sendBuffer.push(fullMsg);
     log?.debug(
-      `${this.clientId} -- now at ${session.sendQueue.length} outstanding messages to ${msg.to}`,
+      `${this.clientId} -- now at ${session.sendBuffer.length} outstanding messages to ${to}`,
+    );
+    return undefined;
+  }
+
+  // control helpers
+  sendCloseStream(to: TransportClientId, streamId: string) {
+    return this.send(to, {
+      streamId: streamId,
+      controlFlags: ControlFlags.StreamClosedBit,
+      payload: {
+        type: 'CLOSE' as const,
+      } satisfies Static<typeof ControlMessagePayloadSchema>,
+    });
+  }
+
+  protected rawSend(conn: ConnType, msg: OpaqueTransportMessage): boolean {
+    log?.debug(`${this.clientId} -- sending ${JSON.stringify(msg)}`);
+    const ok = conn.send(this.codec.toBuffer(msg));
+    if (ok) return true;
+    log?.info(
+      `${this.clientId} -- failed to send on connection (id: ${conn.debugId}) to ${msg.to}, queuing msg ${msg.id}`,
     );
     return false;
   }
@@ -546,10 +555,7 @@ export abstract class ClientTransport<
 
       // send boot sequence
       this.state = 'open';
-      const responseMsg = msg(this.clientId, to, nanoid(), {
-        type: 'HANDSHAKE_REQ',
-        protocolVersion: PROTOCOL_VERSION,
-      } satisfies Static<typeof ControlMessageHandshakeRequestSchema>);
+      const responseMsg = bootRequestMessage(this.clientId, to);
       conn.send(this.codec.toBuffer(responseMsg));
     } catch (error: unknown) {
       const errStr = error instanceof Error ? error.message : `${error}`;
@@ -617,8 +623,7 @@ export abstract class ServerTransport<
 > extends Transport<ConnType> {
   protected handleConnection(conn: ConnType) {
     let session: Session<ConnType> | undefined = undefined;
-    const client = () => session?.connectedTo ?? 'unknown';
-
+    const client = () => session?.to ?? 'unknown';
     const bootHandler = this.receiveWithBootSequence(
       conn,
       (establishedSession) => {
@@ -639,7 +644,7 @@ export abstract class ServerTransport<
           conn.debugId
         }) to ${client()} disconnected`,
       );
-      this.onDisconnect(conn, session.connectedTo);
+      this.onDisconnect(conn, session?.to);
     });
 
     conn.addErrorListener((err) => {
@@ -662,13 +667,11 @@ export abstract class ServerTransport<
 
       // double check protocol version here
       if (!Value.Check(ControlMessageHandshakeRequestSchema, parsed.payload)) {
-        const responseMsg = reply(parsed, {
-          type: 'HANDSHAKE_RESP',
-          status: {
-            ok: false,
-            reason: 'VERSION_MISMATCH',
-          },
-        } satisfies Static<typeof ControlMessageHandshakeResponseSchema>);
+        const responseMsg = bootResponseMessage(
+          this.clientId,
+          parsed.from,
+          false,
+        );
         conn.send(this.codec.toBuffer(responseMsg));
         log?.warn(
           `${this.clientId} -- received invalid handshake msg: ${JSON.stringify(
@@ -678,12 +681,10 @@ export abstract class ServerTransport<
         return;
       }
 
-      const responseMsg = reply(parsed, {
-        type: 'HANDSHAKE_RESP',
-        status: {
-          ok: true,
-        },
-      } satisfies Static<typeof ControlMessageHandshakeResponseSchema>);
+      log?.debug(
+        `${this.clientId} -- handshake from ${parsed.from} ok, responding with handshake success`,
+      );
+      const responseMsg = bootResponseMessage(this.clientId, parsed.from, true);
       conn.send(this.codec.toBuffer(responseMsg));
 
       // we have the session

--- a/util/testHelpers.ts
+++ b/util/testHelpers.ts
@@ -2,14 +2,7 @@ import WebSocket from 'isomorphic-ws';
 import { WebSocketServer } from 'ws';
 import http from 'node:http';
 import { WebSocketClientTransport } from '../transport/impls/ws/client';
-import {
-  Connection,
-  OpaqueTransportMessage,
-  Transport,
-  TransportClientId,
-  TransportMessage,
-  msg,
-} from '../transport';
+import { Connection, OpaqueTransportMessage, Transport } from '../transport';
 import { pushable } from 'it-pushable';
 import { Codec } from '../codec';
 import { WebSocketServerTransport } from '../transport/impls/ws/server';
@@ -98,33 +91,6 @@ export function createWsTransports(
     ),
     new WebSocketServerTransport(wss, 'SERVER', options),
   ];
-}
-
-/**
- * Converts a payload object to a transport message with reasonable defaults.
- * This should only be used for testing.
- * @param payload - The payload object to be converted.
- * @param streamId - The optional stream ID.
- * @returns The transport message.
- */
-export function payloadToTransportMessage<Payload extends object>(
-  payload: Payload,
-  streamId?: string,
-  from: TransportClientId = 'client',
-  to: TransportClientId = 'SERVER',
-): TransportMessage<Payload> {
-  return msg(from, to, streamId ?? 'stream', payload, 'service', 'procedure');
-}
-
-/**
- * Creates a dummy opaque transport message for testing purposes.
- * @returns The created opaque transport message.
- */
-export function createDummyTransportMessage(): OpaqueTransportMessage {
-  return payloadToTransportMessage({
-    msg: 'cool',
-    test: Math.random(),
-  });
 }
 
 /**

--- a/util/testHelpers.ts
+++ b/util/testHelpers.ts
@@ -18,6 +18,7 @@ import {
 import { Static } from '@sinclair/typebox';
 import { nanoid } from 'nanoid';
 import net from 'node:net';
+import { PartialTransportMessage } from '../transport/message';
 
 /**
  * Creates a WebSocket server instance using the provided HTTP server.
@@ -100,6 +101,23 @@ export function createWsTransports(
  */
 export async function iterNext<T>(iter: AsyncIterableIterator<T>) {
   return await iter.next().then((res) => res.value);
+}
+
+export function payloadToTransportMessage<Payload extends object>(
+  payload: Payload,
+): PartialTransportMessage<Payload> {
+  return {
+    streamId: 'stream',
+    controlFlags: 0,
+    payload,
+  };
+}
+
+export function createDummyTransportMessage() {
+  return payloadToTransportMessage({
+    msg: 'cool',
+    test: Math.random(),
+  });
 }
 
 /**


### PR DESCRIPTION
## Why
Because we don’t actually ack acks and we don’t re-transmit acks, sometimes an ack will be dropped during reconnection and we’ll end up with a message stuck in the sendBuffer forever :(

Also, we ack on every single message, it can significantly reduce our throughput we have high RPS (~10k/s)

## What
We can take inspiration from TCP here :) Instead of ack-ing based on `MsgId`, let’s just throw that out the window entirely and use sequence numbers. We also don’t need both `sendBuff` and `sendQueue`, we’ll just use `sendBuff`.

- Each transport message will have `seq` and `ack` fields and the `id` field will purely be for debug purposes.
- Each session will also track `seq` and `ack`
  - Ack: how many messages we’ve sent in the session
  - Seq: how many (unique) messages we’ve received in the session
- It will also have a grace expiry timeout which serves as our ping-pong strategy
  - This gets set on a msg send
  - This gets cleared when receiving a message
  - When this expires, we consider the connection dead and kill the underlying connection and try reconnecting
- We heartbeat on some interval to just send an empty message with the ack heartbeat bit set (this will have an empty payload)
- As ack is also included in each message, each outgoing message also acts like a micro-heartbeat
- On reconnect, send everything in our sendBuff
- If we receive a message with out-of-order seq, signal a session reconnect
