### PR TITLE
[protocol] Close connection on invalid message, account for client-side state loss

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "type": "module",
   "exports": {
     ".": {

--- a/transport/impls/ws/client.ts
+++ b/transport/impls/ws/client.ts
@@ -74,8 +74,15 @@ export class WebSocketClientTransport extends ClientTransport<WebSocketConnectio
             resolve({ err: evt.reason });
           };
 
+          const onError = (evt: WebSocket.ErrorEvent) => {
+            ws.removeEventListener('error', onError);
+            ws.removeEventListener('close', onClose);
+            resolve({ err: evt.message });
+          };
+
           ws.addEventListener('open', onOpen);
           ws.addEventListener('close', onClose);
+          ws.addEventListener('error', onError);
         })
         .catch((e) => {
           const reason = e instanceof Error ? e.message : 'unknown reason';

--- a/transport/message.test.ts
+++ b/transport/message.test.ts
@@ -58,10 +58,11 @@ describe('message helpers', () => {
   });
 
   test('bootRequestMessage', () => {
-    const m = bootRequestMessage('a', 'b');
+    const m = bootRequestMessage('a', 'b', 'abc');
 
     expect(m.from).toBe('a');
     expect(m.to).toBe('b');
+    expect(m.payload.instanceId).toBe('abc');
   });
 
   test('bootResponseMessage', () => {

--- a/transport/message.ts
+++ b/transport/message.ts
@@ -55,6 +55,7 @@ export const PROTOCOL_VERSION = 'v1';
 export const ControlMessageHandshakeRequestSchema = Type.Object({
   type: Type.Literal('HANDSHAKE_REQ'),
   protocolVersion: Type.Literal(PROTOCOL_VERSION),
+  instanceId: Type.String(),
 });
 
 export const ControlMessageHandshakeResponseSchema = Type.Object({
@@ -120,6 +121,7 @@ export type PartialTransportMessage<
 export function bootRequestMessage(
   from: TransportClientId,
   to: TransportClientId,
+  instanceId: string,
 ): TransportMessage<Static<typeof ControlMessageHandshakeRequestSchema>> {
   return {
     id: nanoid(),
@@ -132,6 +134,7 @@ export function bootRequestMessage(
     payload: {
       type: 'HANDSHAKE_REQ',
       protocolVersion: PROTOCOL_VERSION,
+      instanceId,
     } satisfies Static<typeof ControlMessageHandshakeRequestSchema>,
   };
 }

--- a/transport/session.ts
+++ b/transport/session.ts
@@ -68,9 +68,9 @@ export abstract class Connection {
   abstract close(): void;
 }
 
-export const HEARTBEAT_INTERVAL_MS = 250; // 250ms
-export const HEARTBEATS_TILL_DEAD = 4; // can miss max of 4 heartbeats before we consider the connection dead
-export const SESSION_DISCONNECT_GRACE_MS = 3_000; // 3s
+export const HEARTBEAT_INTERVAL_MS = 1000; // 1s
+export const HEARTBEATS_TILL_DEAD = 2; // can miss max of 2 heartbeats before we consider the connection dead
+export const SESSION_DISCONNECT_GRACE_MS = 5_000; // 5s
 
 /**
  * A session is a higher-level abstraction that operates over the span of potentially multiple transport-level connections
@@ -255,7 +255,6 @@ export class Session<ConnType extends Connection> {
   }
 
   updateBookkeeping(ack: number, seq: number) {
-    this.heartbeatMisses = 0;
     this.sendBuffer = this.sendBuffer.filter((unacked) => unacked.seq > ack);
     this.ack = seq + 1;
   }
@@ -291,6 +290,7 @@ export class Session<ConnType extends Connection> {
   }
 
   cancelGrace() {
+    this.heartbeatMisses = 0;
     clearTimeout(this.disconnectionGrace);
   }
 

--- a/transport/session.ts
+++ b/transport/session.ts
@@ -205,11 +205,13 @@ export class Session<ConnType extends Connection> {
   }
 
   sendHeartbeat() {
-    if (this.heartbeatMisses >= HEARTBEATS_TILL_DEAD && this.connection) {
-      log?.info(
-        `${this.from} -- closing connection (id: ${this.connection.debugId}) to ${this.to} due to inactivity`,
-      );
-      this.halfCloseConnection();
+    if (this.heartbeatMisses >= HEARTBEATS_TILL_DEAD) {
+      if (this.connection) {
+        log?.info(
+          `${this.from} -- closing connection (id: ${this.connection.debugId}) to ${this.to} due to inactivity`,
+        );
+        this.halfCloseConnection();
+      }
       return;
     }
 

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -87,6 +87,14 @@ export const defaultTransportOptions: TransportOptions = {
  */
 export abstract class Transport<ConnType extends Connection> {
   /**
+   * Unique per instance of the transport.
+   * This allows us to distinguish reconnects to different
+   * transports.
+   */
+  instanceId: string = nanoid();
+  connectedInstanceIds = new Map<TransportClientId, string>();
+
+  /**
    * A flag indicating whether the transport has been destroyed.
    * A destroyed transport will not attempt to reconnect and cannot be used again.
    */
@@ -177,15 +185,34 @@ export abstract class Transport<ConnType extends Connection> {
   protected onConnect(
     conn: ConnType,
     connectedTo: TransportClientId,
+    instanceId: string,
   ): Session<ConnType> {
     this.eventDispatcher.dispatchEvent('connectionStatus', {
       status: 'connect',
       conn,
     });
 
-    const session = this.sessions.get(connectedTo);
+    let session = this.sessions.get(connectedTo);
+    // check if the peer we are connected to is actually difference by comparing instanceId
+    const lastInstanceId = this.connectedInstanceIds.get(connectedTo);
+    if (
+      session &&
+      lastInstanceId !== instanceId &&
+      lastInstanceId !== undefined
+    ) {
+      // mismatch, kill the old session and begin a new one
+      log?.debug(
+        `${this.clientId} -- handshake from ${connectedTo} has different server instance (got: ${instanceId}, last connected to: ${lastInstanceId}), starting a new session`,
+      );
+      session.resetBufferedMessages();
+      session.closeStaleConnection();
+      this.deleteSession(session);
+      session = undefined;
+    }
+    this.connectedInstanceIds.set(connectedTo, instanceId);
+
+    // if we don't have an existing session, create a new one and return it
     if (session === undefined) {
-      // new session, create and return
       const newSession = this.createSession(connectedTo, conn);
       log?.info(
         `${this.clientId} -- new connection (id: ${conn.debugId}) for new session (id: ${newSession.debugId}) to ${connectedTo}`,
@@ -430,7 +457,6 @@ export abstract class ClientTransport<
    */
   inflightConnectionPromises: Map<TransportClientId, Promise<ConnType>>;
   tryReconnecting = true;
-  serverInstanceIds = new Map<TransportClientId, string>();
 
   constructor(
     clientId: TransportClientId,
@@ -506,7 +532,7 @@ export abstract class ClientTransport<
 
       // send boot sequence
       this.state = 'open';
-      const requestMsg = bootRequestMessage(this.clientId, to);
+      const requestMsg = bootRequestMessage(this.clientId, to, this.instanceId);
       log?.debug(`${this.clientId} -- sending boot handshake to ${to}`);
       conn.send(this.codec.toBuffer(requestMsg));
     } catch (error: unknown) {
@@ -560,29 +586,13 @@ export abstract class ClientTransport<
       }
 
       // handshake ok, check if server instance matches
-      const oldSession = this.sessions.get(parsed.from);
       const serverInstanceId = parsed.payload.status.instanceId;
-      const lastServerInstanceId = this.serverInstanceIds.get(parsed.from);
-      if (
-        oldSession &&
-        lastServerInstanceId !== serverInstanceId &&
-        lastServerInstanceId !== undefined
-      ) {
-        // mismatch, kill the old session and begin a new one
-        log?.debug(
-          `${this.clientId} -- handshake from ${parsed.from} has different server instance (got: ${serverInstanceId}, last connected to: ${lastServerInstanceId}), starting a new session`,
-        );
-        oldSession.resetBufferedMessages();
-        oldSession.closeStaleConnection();
-        this.deleteSession(oldSession);
-      }
 
       // all good, let's connect
       log?.debug(
         `${this.clientId} -- handshake from ${parsed.from} ok (server instance: ${serverInstanceId})`,
       );
-      this.serverInstanceIds.set(parsed.from, serverInstanceId);
-      sessionCb(this.onConnect(conn, parsed.from));
+      sessionCb(this.onConnect(conn, parsed.from, serverInstanceId));
     };
 
     return bootHandler;
@@ -597,15 +607,6 @@ export abstract class ClientTransport<
 export abstract class ServerTransport<
   ConnType extends Connection,
 > extends Transport<ConnType> {
-  /**
-   * Unique per instance of server transport.
-   * This allows us to distinguish reconnects to different
-   * server transports at the same reachable address and signal
-   * the appropriate session disconnect back to the client at the
-   * boot stage.
-   */
-  instanceId: string = nanoid();
-
   constructor(
     clientId: TransportClientId,
     providedOptions?: Partial<TransportOptions>,
@@ -688,8 +689,9 @@ export abstract class ServerTransport<
         return;
       }
 
+      const instanceId = parsed.payload.instanceId;
       log?.debug(
-        `${this.clientId} -- handshake from ${parsed.from} ok, responding with handshake success`,
+        `${this.clientId} -- handshake from ${parsed.from} ok (instance id: ${instanceId}), responding with handshake success`,
       );
       const responseMsg = bootResponseMessage(
         this.clientId,
@@ -700,7 +702,7 @@ export abstract class ServerTransport<
       conn.send(this.codec.toBuffer(responseMsg));
 
       // we have the session
-      sessionCb(this.onConnect(conn, parsed.from));
+      sessionCb(this.onConnect(conn, parsed.from, instanceId));
     };
 
     return bootHandler;


### PR DESCRIPTION
## What changed
- listen on error events when establishing ws client connection
- instanceId is now a transport-agnostic concept
  - this helps us account for client-side dataloss and will prevent the server from re-transmitting in this scenario
- boot request now also contains the instanceId
- more protocol strictness :)
  - close the connection on invalid message
- adjust protocol timings
  - up heartbeat every from 250ms -> 1000ms
  - 2 heartbeats till dead (~2s, same as before)
  - session disconnect grace 3s -> 5s