### PR TITLE
Allow subscriptions to provide cleanup functions from handler

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -36,6 +36,7 @@ module.exports = {
     ],
     '@typescript-eslint/require-await': 'off',
     '@typescript-eslint/array-type': ['error', { default: 'generic' }],
+    '@typescript-eslint/no-invalid-void-type': 'off'
   },
   ignorePatterns: ['dist/**/*'],
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -36,7 +36,7 @@ module.exports = {
     ],
     '@typescript-eslint/require-await': 'off',
     '@typescript-eslint/array-type': ['error', { default: 'generic' }],
-    '@typescript-eslint/no-invalid-void-type': 'off'
+    '@typescript-eslint/no-invalid-void-type': 'off',
   },
   ignorePatterns: ['dist/**/*'],
 };

--- a/__tests__/cleanup.test.ts
+++ b/__tests__/cleanup.test.ts
@@ -283,6 +283,9 @@ describe.each(testMatrix())(
       await advanceFakeTimersByDisconnectGrace();
       await ensureTransportBuffersAreEventuallyEmpty(clientTransport);
       await ensureTransportBuffersAreEventuallyEmpty(serverTransport);
+
+      // no observers should remain subscribed to the observable
+      expect(server.services.subscribable.state.count.listenerCount).toEqual(0);
     });
 
     test('upload', async () => {

--- a/__tests__/fixtures/observable.ts
+++ b/__tests__/fixtures/observable.ts
@@ -39,4 +39,11 @@ export class Observable<T> {
     listener(this.get());
     return () => this.listeners.delete(listener);
   }
+
+  /**
+   * Returns the number of listeners currently observing the observable
+   */
+  get listenerCount(): number {
+    return this.listeners.size;
+  }
 }

--- a/__tests__/fixtures/services.ts
+++ b/__tests__/fixtures/services.ts
@@ -178,7 +178,7 @@ export const SubscribableServiceConstructor = () =>
       output: Type.Object({ result: Type.Number() }),
       errors: Type.Never(),
       async handler(ctx, _msg, returnStream) {
-        ctx.state.count.observe((count) => {
+        return ctx.state.count.observe((count) => {
           returnStream.push(Ok({ result: count }));
         });
       },

--- a/router/builder.ts
+++ b/router/builder.ts
@@ -216,7 +216,7 @@ export type Procedure<
           context: ServiceContextWithTransportInfo<State>,
           input: Static<I>,
           output: Pushable<Result<Static<O>, Static<E>>>,
-        ) => Promise<void>;
+        ) => Promise<(() => void) | void>;
         type: Ty;
       }
     : never


### PR DESCRIPTION
See discussion here: https://replit.slack.com/archives/C05GZ4NRSJ3/p1711562720244819

Otherwise we could have listeners set up within subscription handlers that we don't have a good way of cleaning up. Now, subscriptions can return a disposal callback `() => void` that gets called when the subscription ends.

 I didn't implement this for streams or uploads yet because there is another way of handling it for now:
 ```
for await (const msg of input) {
  // processing...
}


// by the time we get here we're closed, so you can clean up right here
```




```
~/replit/river [main] 
> npm run test

> @replit/river@0.14.0 test
> vitest --test-timeout=500


 DEV  v1.3.1 /Users/brady/replit/river

 ✓ transport/impls/ws/ws.test.ts (3)
 ✓ __tests__/disconnects.test.ts (16)
 ✓ __tests__/cleanup.test.ts (24)
 ✓ transport/impls/ws/ws.test.ts (3)
 ✓ __tests__/disconnects.test.ts (16)
 ✓ transport/impls/ws/ws.test.ts (3)
 ✓ __tests__/disconnects.test.ts (16)
 ✓ __tests__/cleanup.test.ts (24)
 ✓ __tests__/e2e.test.ts (48)
 ✓ transport/transport.test.ts (40) 453ms
 ✓ __tests__/negative.test.ts (2)
 ✓ transport/transforms/messageFraming.test.ts (6)
 ✓ __tests__/proxy.test.ts (1)
 ✓ transport/impls/uds/uds.test.ts (1)
 ✓ codec/codec.test.ts (12)
 ✓ __tests__/handler.test.ts (9)
 ✓ __tests__/serialize.test.ts (3)
 ✓ transport/message.test.ts (7)
 ✓ __tests__/typescript-stress.test.ts (2)
 ✓ __tests__/fixtures/observable.test.ts (4)

 Test Files  15 passed (15)
      Tests  178 passed (178)
   Start at  15:12:30
   Duration  1.19s (transform 378ms, setup 2ms, collect 2.20s, tests 1.11s, environment 2ms, prepare 878ms)
```