### PR TITLE
error hooks, test stability

### DIFF
--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -56,6 +56,10 @@ test('ws <-> uds proxy works', async () => {
 
       ws.send(data);
     });
+
+    ws.onclose = () => {
+      uds.destroy();
+    };
   });
 
   // setup transports

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "type": "module",
   "exports": {
     ".": {

--- a/transport/events.ts
+++ b/transport/events.ts
@@ -2,6 +2,12 @@ import { OpaqueTransportMessage } from './message';
 import { Connection, Session } from './session';
 
 type ConnectionStatus = 'connect' | 'disconnect';
+export const enum ProtocolErrorType {
+  RetriesExceeded = 'conn_retry_exceeded',
+  HandshakeFailed = 'handshake_failed',
+  UseAfterDestroy = 'use_after_destroy',
+}
+
 export interface EventMap {
   message: OpaqueTransportMessage;
   connectionStatus: {
@@ -11,6 +17,10 @@ export interface EventMap {
   sessionStatus: {
     status: ConnectionStatus;
     session: Session<Connection>;
+  };
+  protocolError: {
+    type: ProtocolErrorType;
+    message: string;
   };
 }
 

--- a/transport/index.ts
+++ b/transport/index.ts
@@ -12,4 +12,9 @@ export type {
   isStreamOpen,
   isStreamClose,
 } from './message';
-export { EventMap, EventTypes, EventHandler } from './events';
+export {
+  EventMap,
+  EventTypes,
+  EventHandler,
+  ProtocolErrorType,
+} from './events';

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -52,6 +52,7 @@ describe.each(testMatrix())(
     test('idle transport cleans up nicely', async () => {
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
+      await waitFor(() => expect(serverTransport.connections.size).toBe(1));
       onTestFinished(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
@@ -320,7 +321,6 @@ describe.each(testMatrix())(
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
       const msg1 = createDummyTransportMessage();
-      const msg2 = createDummyTransportMessage();
 
       const msg1Id = clientTransport.send(serverTransport.clientId, msg1);
       await expect(
@@ -328,9 +328,6 @@ describe.each(testMatrix())(
       ).resolves.toStrictEqual(msg1.payload);
 
       clientTransport.destroy();
-      expect(() =>
-        clientTransport.send(serverTransport.clientId, msg2),
-      ).toThrow(new Error('transport is destroyed, cant send'));
 
       // this is not expected to be clean because we destroyed the transport
       expect(clientTransport.state).toEqual('destroyed');

--- a/util/testHelpers.ts
+++ b/util/testHelpers.ts
@@ -123,6 +123,7 @@ export async function waitForMessage(
         cleanup();
         resolve(msg.payload);
       } else if (rejectMismatch) {
+        cleanup();
         reject(new Error('message didnt match the filter'));
       }
     }


### PR DESCRIPTION
- improve test stability
- introduce the `ProtocolErrorType` event type on the transport event dispatcher

currently, we emit events for

```ts
export const enum ProtocolErrorType {
  RetriesExceeded = 'conn_retry_exceeded',
  HandshakeFailed = 'handshake_failed',
  UseAfterDestroy = 'use_after_destroy',
}
```