### PR TITLE
[WIP] Implement authorize callback for handshakes

### DIFF
--- a/__tests__/fixtures/matrix.ts
+++ b/__tests__/fixtures/matrix.ts
@@ -16,6 +16,7 @@ interface TestMatrixEntry {
       simulatePhantomDisconnect: () => void;
       getClientTransport: (
         id: TransportClientId,
+        authorization?: unknown,
       ) => ClientTransport<Connection>;
       getServerTransport: () => ServerTransport<Connection>;
       restartServer: () => Promise<void>;

--- a/__tests__/fixtures/transports.ts
+++ b/__tests__/fixtures/transports.ts
@@ -23,7 +23,10 @@ export type ValidTransports = 'ws' | 'unix sockets' | 'node streams';
 export const transports: Array<{
   name: ValidTransports;
   setup: (opts?: Partial<TransportOptions>) => Promise<{
-    getClientTransport: (id: TransportClientId) => ClientTransport<Connection>;
+    getClientTransport: (
+      id: TransportClientId,
+      authorization?: unknown,
+    ) => ClientTransport<Connection>;
     getServerTransport: () => ServerTransport<Connection>;
     simulatePhantomDisconnect: () => void;
     restartServer: () => Promise<void>;
@@ -48,13 +51,13 @@ export const transports: Array<{
             }
           }
         },
-        getClientTransport(id) {
+        getClientTransport(id, authorization) {
           const clientTransport = new WebSocketClientTransport(
             () => Promise.resolve(createLocalWebSocketClient(port)),
             id,
             opts,
           );
-          void clientTransport.connect('SERVER');
+          void clientTransport.connect('SERVER', authorization);
           transports.push(clientTransport);
           return clientTransport;
         },
@@ -109,13 +112,13 @@ export const transports: Array<{
             }
           }
         },
-        getClientTransport(id) {
+        getClientTransport(id, authorization) {
           const clientTransport = new UnixDomainSocketClientTransport(
             socketPath,
             id,
             opts,
           );
-          void clientTransport.connect('SERVER');
+          void clientTransport.connect('SERVER', authorization);
           transports.push(clientTransport);
           return clientTransport;
         },

--- a/transport/impls/uds/client.ts
+++ b/transport/impls/uds/client.ts
@@ -16,7 +16,10 @@ export class UnixDomainSocketClientTransport extends ClientTransport<UdsConnecti
     this.path = socketPath;
   }
 
-  async createNewOutgoingConnection(to: TransportClientId) {
+  async createNewOutgoingConnection(
+    to: TransportClientId,
+    authorization?: unknown,
+  ) {
     const oldConnection = this.connections.get(to);
     if (oldConnection) {
       oldConnection.close();
@@ -31,7 +34,7 @@ export class UnixDomainSocketClientTransport extends ClientTransport<UdsConnecti
     });
 
     const conn = new UdsConnection(sock);
-    this.handleConnection(conn, to);
+    this.handleConnection(conn, to, authorization);
     return conn;
   }
 }

--- a/transport/impls/ws/client.ts
+++ b/transport/impls/ws/client.ts
@@ -33,7 +33,7 @@ export class WebSocketClientTransport extends ClientTransport<WebSocketConnectio
     this.wsGetter = wsGetter;
   }
 
-  async createNewOutgoingConnection(to: string) {
+  async createNewOutgoingConnection(to: string, authorization?: unknown) {
     // get a promise to an actual websocket that's ready
     const wsRes = await new Promise<WebSocketResult>((resolve) => {
       log?.info(`${this.clientId} -- establishing a new websocket to ${to}`);
@@ -75,7 +75,7 @@ export class WebSocketClientTransport extends ClientTransport<WebSocketConnectio
       log?.info(
         `${this.clientId} -- websocket (id: ${conn.debugId}) to ${to} ok`,
       );
-      this.handleConnection(conn, to);
+      this.handleConnection(conn, to, authorization);
       return conn;
     } else {
       throw new Error(wsRes.err);

--- a/transport/message.test.ts
+++ b/transport/message.test.ts
@@ -58,11 +58,12 @@ describe('message helpers', () => {
   });
 
   test('handshakeRequestMessage', () => {
-    const m = handshakeRequestMessage('a', 'b', 'abc');
+    const m = handshakeRequestMessage('a', 'b', 'abc', 'auth');
 
     expect(m.from).toBe('a');
     expect(m.to).toBe('b');
     expect(m.payload.instanceId).toBe('abc');
+    expect(m.payload.authorization).toBe('auth');
   });
 
   test('handshakeResponseMessage', () => {

--- a/transport/message.ts
+++ b/transport/message.ts
@@ -56,6 +56,7 @@ export const ControlMessageHandshakeRequestSchema = Type.Object({
   type: Type.Literal('HANDSHAKE_REQ'),
   protocolVersion: Type.String(),
   instanceId: Type.String(),
+  authorization: Type.Optional(Type.Unknown()),
 });
 
 export const ControlMessageHandshakeResponseSchema = Type.Object({
@@ -124,6 +125,7 @@ export function handshakeRequestMessage(
   from: TransportClientId,
   to: TransportClientId,
   instanceId: string,
+  authorization?: unknown,
 ): TransportMessage<Static<typeof ControlMessageHandshakeRequestSchema>> {
   return {
     id: nanoid(),
@@ -137,6 +139,7 @@ export function handshakeRequestMessage(
       type: 'HANDSHAKE_REQ',
       protocolVersion: PROTOCOL_VERSION,
       instanceId,
+      authorization,
     } satisfies Static<typeof ControlMessageHandshakeRequestSchema>,
   };
 }

--- a/transport/session.ts
+++ b/transport/session.ts
@@ -89,6 +89,7 @@ export interface SessionOptions {
   heartbeatsUntilDead: number;
   sessionDisconnectGraceMs: number;
   codec: Codec;
+  authorize: ((authorization: unknown) => boolean) | null;
 }
 
 export const defaultSessionOptions: SessionOptions = {
@@ -96,6 +97,7 @@ export const defaultSessionOptions: SessionOptions = {
   heartbeatsUntilDead: HEARTBEATS_TILL_DEAD,
   sessionDisconnectGraceMs: SESSION_DISCONNECT_GRACE_MS,
   codec: NaiveJsonCodec,
+  authorize: null,
 };
 
 /**


### PR DESCRIPTION
Very WIP.

Ideally, we could make authorization simple and just do it all in the handshake. I suspect the way this PR does it is not nearly enough though. Likely the server's authorize callback will need async support, and I suspect clients will need a way to handle their authorization automatically, probably through a callback that gets them their authorization details whenever they want.

Tons of open questions here:
- how should we handle transparent reconnects? are you allowed to reuse your authorization?
- how do we prevent someone reading pid2 memory and spoofing another client via their authorization (which may be in memory)? is this even a concern? 
- should we allow some (or even all) messages to be signed, especially ones which may cause destructive actions? also, again, is this even a concern?
- what's the best way to expose sessions and their details to procedures?
- how do we add metadata to this, so that we can attach information like username and user id?
- do we need middleware so that we can gate procedures based on permissions/role? are we ever going to need a permissions system?

Other comments:
- seems like [tRPC recommends authorizing via middleware or in resolvers](https://trpc.io/docs/server/authorization)