### PR TITLE
client-transport: leaky bucket connection retry rate limit

### DIFF
--- a/__tests__/fixtures/cleanup.ts
+++ b/__tests__/fixtures/cleanup.ts
@@ -2,11 +2,7 @@ import { expect, vi } from 'vitest';
 import { Connection, OpaqueTransportMessage, Transport } from '../../transport';
 import { Server } from '../../router';
 import { log } from '../../logging';
-import {
-  HEARTBEATS_TILL_DEAD,
-  HEARTBEAT_INTERVAL_MS,
-  SESSION_DISCONNECT_GRACE_MS,
-} from '../../transport/session';
+import { testingSessionOptions } from '../../util/testHelpers';
 
 const waitUntilOptions = {
   timeout: 250, // these are all local connections so anything above 250ms is sus
@@ -24,15 +20,19 @@ export async function waitForTransportToFinish(t: Transport<Connection>) {
 }
 
 export async function advanceFakeTimersByDisconnectGrace() {
-  for (let i = 0; i < HEARTBEATS_TILL_DEAD; i++) {
+  for (let i = 0; i < testingSessionOptions.heartbeatsUntilDead; i++) {
     // wait for heartbeat interval to elapse
     await vi.runOnlyPendingTimersAsync();
-    await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS + 1);
+    await vi.advanceTimersByTimeAsync(
+      testingSessionOptions.heartbeatIntervalMs + 1,
+    );
   }
 
   // wait for disconnect timer to propagate
   await vi.runOnlyPendingTimersAsync();
-  await vi.advanceTimersByTimeAsync(SESSION_DISCONNECT_GRACE_MS + 1);
+  await vi.advanceTimersByTimeAsync(
+    testingSessionOptions.sessionDisconnectGraceMs + 1,
+  );
 }
 
 async function ensureTransportIsClean(t: Transport<Connection>) {

--- a/__tests__/fixtures/matrix.ts
+++ b/__tests__/fixtures/matrix.ts
@@ -5,14 +5,14 @@ import {
   ServerTransport,
   TransportClientId,
 } from '../../transport';
-import { TransportOptions } from '../../transport/transport';
+import { ProvidedTransportOptions } from '../../transport/transport';
 import { ValidCodecs, codecs } from './codec';
 import { ValidTransports, transports } from './transports';
 
 interface TestMatrixEntry {
   transport: {
     name: string;
-    setup: (opts?: Partial<TransportOptions>) => Promise<{
+    setup: (opts?: Partial<ProvidedTransportOptions>) => Promise<{
       simulatePhantomDisconnect: () => void;
       getClientTransport: (
         id: TransportClientId,

--- a/__tests__/fixtures/transports.ts
+++ b/__tests__/fixtures/transports.ts
@@ -15,14 +15,14 @@ import {
 } from '../../util/testHelpers';
 import { UnixDomainSocketClientTransport } from '../../transport/impls/uds/client';
 import { UnixDomainSocketServerTransport } from '../../transport/impls/uds/server';
-import { TransportOptions } from '../../transport/transport';
+import { ProvidedTransportOptions } from '../../transport/transport';
 import { WebSocketClientTransport } from '../../transport/impls/ws/client';
 import { WebSocketServerTransport } from '../../transport/impls/ws/server';
 
 export type ValidTransports = 'ws' | 'unix sockets' | 'node streams';
 export const transports: Array<{
   name: ValidTransports;
-  setup: (opts?: Partial<TransportOptions>) => Promise<{
+  setup: (opts?: Partial<ProvidedTransportOptions>) => Promise<{
     getClientTransport: (id: TransportClientId) => ClientTransport<Connection>;
     getServerTransport: () => ServerTransport<Connection>;
     simulatePhantomDisconnect: () => void;

--- a/__tests__/negative.test.ts
+++ b/__tests__/negative.test.ts
@@ -1,12 +1,4 @@
-import {
-  afterAll,
-  assert,
-  describe,
-  expect,
-  onTestFinished,
-  test,
-  vi,
-} from 'vitest';
+import { afterAll, describe, expect, onTestFinished, test, vi } from 'vitest';
 import http from 'node:http';
 import { testFinishesCleanly, waitFor } from './fixtures/cleanup';
 import {
@@ -23,7 +15,6 @@ import { Static } from '@sinclair/typebox';
 import { WebSocketClientTransport } from '../transport/impls/ws/client';
 import { ProtocolError } from '../transport/events';
 import { defaultTransportOptions } from '../transport/transport';
-import { bindLogger } from '../logging';
 import WebSocket from 'ws';
 
 describe('should handle incompatabilities', async () => {

--- a/__tests__/negative.test.ts
+++ b/__tests__/negative.test.ts
@@ -106,7 +106,7 @@ describe('should handle incompatabilities', async () => {
       },
       'client',
       {
-        connectionRetryOptions: { maxAttempts },
+        connectionRetryOptions: { attemptCapacity: maxAttempts },
       },
     );
     clientTransport.tryReconnecting = false;

--- a/__tests__/negative.test.ts
+++ b/__tests__/negative.test.ts
@@ -113,11 +113,17 @@ describe('should handle incompatabilities', async () => {
       clientTransport.close();
     });
 
-    for (let i = 0; i < defaultTransportOptions.retryAttemptsMax; i++) {
+    for (
+      let i = 0;
+      i < defaultTransportOptions.maxReconnectionBurstAttempts;
+      i++
+    ) {
       void clientTransport.connect('SERVER');
     }
 
-    expect(conns).toBeLessThan(defaultTransportOptions.retryAttemptsMax);
+    expect(conns).toBeLessThan(
+      defaultTransportOptions.maxReconnectionBurstAttempts,
+    );
   });
 
   test('incorrect client handshake', async () => {

--- a/__tests__/negative.test.ts
+++ b/__tests__/negative.test.ts
@@ -106,7 +106,7 @@ describe('should handle incompatabilities', async () => {
       },
       'client',
       {
-        connectionRetryOptions: { attemptCapacity: maxAttempts },
+        connectionRetryOptions: { attemptBudgetCapacity: maxAttempts },
       },
     );
     clientTransport.tryReconnecting = false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.15.3",
+  "version": "0.15.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.15.3",
+      "version": "0.15.2",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.15.2",
+      "version": "0.15.3",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.15.1",
+      "version": "0.15.2",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "type": "module",
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "type": "module",
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.15.3",
+  "version": "0.15.2",
   "type": "module",
   "exports": {
     ".": {

--- a/transport/impls/uds/client.ts
+++ b/transport/impls/uds/client.ts
@@ -2,7 +2,10 @@ import { TransportClientId } from '../..';
 import { Socket } from 'node:net';
 import { log } from '../../../logging';
 import { UdsConnection } from './connection';
-import { ClientTransport, TransportOptions } from '../../transport';
+import {
+  ClientTransport,
+  ProvidedClientTransportOptions,
+} from '../../transport';
 
 export class UnixDomainSocketClientTransport extends ClientTransport<UdsConnection> {
   path: string;
@@ -10,7 +13,7 @@ export class UnixDomainSocketClientTransport extends ClientTransport<UdsConnecti
   constructor(
     socketPath: string,
     clientId: string,
-    providedOptions?: Partial<TransportOptions>,
+    providedOptions?: ProvidedClientTransportOptions,
   ) {
     super(clientId, providedOptions);
     this.path = socketPath;

--- a/transport/impls/uds/server.ts
+++ b/transport/impls/uds/server.ts
@@ -1,6 +1,6 @@
 import { log } from '../../../logging';
 import { type Server, type Socket } from 'node:net';
-import { ServerTransport, TransportOptions } from '../../transport';
+import { ServerTransport, ProvidedTransportOptions } from '../../transport';
 import { TransportClientId } from '../../message';
 import { UdsConnection } from './connection';
 
@@ -10,7 +10,7 @@ export class UnixDomainSocketServerTransport extends ServerTransport<UdsConnecti
   constructor(
     server: Server,
     clientId: TransportClientId,
-    providedOptions?: Partial<TransportOptions>,
+    providedOptions?: Partial<ProvidedTransportOptions>,
   ) {
     super(clientId, providedOptions);
     this.server = server;

--- a/transport/impls/ws/client.ts
+++ b/transport/impls/ws/client.ts
@@ -1,5 +1,8 @@
 import WebSocket from 'isomorphic-ws';
-import { ClientTransport, TransportOptions } from '../../transport';
+import {
+  ClientTransport,
+  ProvidedClientTransportOptions,
+} from '../../transport';
 import { TransportClientId } from '../../message';
 import { log } from '../../../logging';
 import { WebSocketConnection } from './connection';
@@ -27,7 +30,7 @@ export class WebSocketClientTransport extends ClientTransport<WebSocketConnectio
   constructor(
     wsGetter: () => Promise<WebSocket>,
     clientId: TransportClientId,
-    providedOptions?: Partial<TransportOptions>,
+    providedOptions?: ProvidedClientTransportOptions,
   ) {
     super(clientId, providedOptions);
     this.wsGetter = wsGetter;

--- a/transport/impls/ws/server.ts
+++ b/transport/impls/ws/server.ts
@@ -1,5 +1,5 @@
 import { TransportClientId } from '../../message';
-import { ServerTransport, TransportOptions } from '../../transport';
+import { ServerTransport, ProvidedTransportOptions } from '../../transport';
 import { WebSocketServer } from 'ws';
 import { WebSocket } from 'isomorphic-ws';
 import { WebSocketConnection } from './connection';
@@ -10,7 +10,7 @@ export class WebSocketServerTransport extends ServerTransport<WebSocketConnectio
   constructor(
     wss: WebSocketServer,
     clientId: TransportClientId,
-    providedOptions?: Partial<TransportOptions>,
+    providedOptions?: Partial<ProvidedTransportOptions>,
   ) {
     super(clientId, providedOptions);
     this.wss = wss;

--- a/transport/index.ts
+++ b/transport/index.ts
@@ -1,5 +1,9 @@
 export { Transport, ClientTransport, ServerTransport } from './transport';
-export type { TransportOptions, TransportStatus } from './transport';
+export type {
+  ProvidedTransportOptions as ServerTransporOptions,
+  ProvidedClientTransportOptions as ClientTransportOptions,
+  TransportStatus,
+} from './transport';
 export { Connection, Session } from './session';
 export {
   TransportMessageSchema,

--- a/transport/leakyBucketLimit.ts
+++ b/transport/leakyBucketLimit.ts
@@ -1,0 +1,56 @@
+import { TransportClientId } from './message';
+
+export interface LeakBucketLimitOptions {
+  maxBurst: number;
+  leakIntervalMs: number;
+  baseIntervalMs: number;
+  jitterMs: number;
+}
+
+export class ReconnectionLeakyBucketRateLimit {
+  budgetConsumed: Map<TransportClientId, number>;
+  intervalHandle: ReturnType<typeof setInterval>;
+  readonly options: LeakBucketLimitOptions;
+
+  constructor(options: LeakBucketLimitOptions) {
+    this.options = options;
+    this.budgetConsumed = new Map();
+
+    // start leaking
+    this.intervalHandle = setInterval(() => {
+      for (const [user, budgetConsumed] of this.budgetConsumed.entries()) {
+        const newBudget = budgetConsumed - 1;
+        if (newBudget === 0) {
+          this.budgetConsumed.delete(user);
+        } else {
+          this.budgetConsumed.set(user, newBudget);
+        }
+      }
+    }, this.options.leakIntervalMs);
+  }
+
+  get drainageTimeMs() {
+    return this.options.leakIntervalMs * this.options.maxBurst;
+  }
+
+  getBackoffMs(user: TransportClientId) {
+    if (!this.budgetConsumed.has(user)) return 0;
+
+    const exponent = Math.max(0, this.getBudgetConsumed(user) - 1);
+    const jitter = Math.floor(Math.random() * this.options.jitterMs);
+    const backoffMs = this.options.baseIntervalMs * 2 ** exponent + jitter;
+    return backoffMs;
+  }
+
+  consumeBudget(user: TransportClientId) {
+    this.budgetConsumed.set(user, this.getBudgetConsumed(user) + 1);
+  }
+
+  getBudgetConsumed(user: TransportClientId) {
+    return this.budgetConsumed.get(user) ?? 0;
+  }
+
+  close() {
+    clearInterval(this.intervalHandle);
+  }
+}

--- a/transport/rateLimit.test.ts
+++ b/transport/rateLimit.test.ts
@@ -6,7 +6,7 @@ import { describe, test, expect, vi } from 'vitest';
 
 describe('LeakyBucketRateLimit', () => {
   const options: ConnectionRetryOptions = {
-    attemptCapacity: 10,
+    attemptBudgetCapacity: 10,
     budgetRestoreIntervalMs: 1000,
     baseIntervalMs: 100,
     maxJitterMs: 50,
@@ -100,7 +100,7 @@ describe('LeakyBucketRateLimit', () => {
     const maxAttempts = 3;
     const rateLimit = new LeakyBucketRateLimit({
       ...options,
-      attemptCapacity: maxAttempts,
+      attemptBudgetCapacity: maxAttempts,
     });
     const user = 'user1';
 

--- a/transport/rateLimit.test.ts
+++ b/transport/rateLimit.test.ts
@@ -6,7 +6,7 @@ import { describe, test, expect, vi } from 'vitest';
 
 describe('LeakyBucketRateLimit', () => {
   const options: ConnectionRetryOptions = {
-    maxAttempts: 10,
+    attemptCapacity: 10,
     budgetRestoreIntervalMs: 1000,
     baseIntervalMs: 100,
     maxJitterMs: 50,
@@ -47,7 +47,6 @@ describe('LeakyBucketRateLimit', () => {
     expect(rateLimit.getBudgetConsumed(user)).toBe(2);
 
     rateLimit.startRestoringBudget(user);
-    vi.advanceTimersByTime(options.budgetRestoreIntervalMs);
     expect(rateLimit.getBudgetConsumed(user)).toBe(1);
     vi.advanceTimersByTime(options.budgetRestoreIntervalMs);
     expect(rateLimit.getBudgetConsumed(user)).toBe(0);
@@ -62,7 +61,6 @@ describe('LeakyBucketRateLimit', () => {
     expect(rateLimit.getBudgetConsumed(user)).toBe(2);
 
     rateLimit.startRestoringBudget(user);
-    vi.advanceTimersByTime(options.budgetRestoreIntervalMs);
     expect(rateLimit.getBudgetConsumed(user)).toBe(1);
 
     rateLimit.consumeBudget(user);
@@ -100,7 +98,10 @@ describe('LeakyBucketRateLimit', () => {
 
   test('reports remaining budget correctly', () => {
     const maxAttempts = 3;
-    const rateLimit = new LeakyBucketRateLimit({ ...options, maxAttempts });
+    const rateLimit = new LeakyBucketRateLimit({
+      ...options,
+      attemptCapacity: maxAttempts,
+    });
     const user = 'user1';
 
     expect(rateLimit.hasBudget(user)).toBe(true);

--- a/transport/rateLimit.test.ts
+++ b/transport/rateLimit.test.ts
@@ -1,0 +1,54 @@
+import {
+  LeakyBucketRateLimit,
+  LeakBucketLimitOptions,
+} from '../transport/rateLimit';
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+
+describe('LeakyBucketRateLimit', () => {
+  const options: LeakBucketLimitOptions = {
+    maxBurst: 10,
+    leakIntervalMs: 1000,
+    baseIntervalMs: 100,
+    jitterMs: 50,
+  };
+
+  test('should calculate drainage time correctly', () => {
+    const rateLimit = new LeakyBucketRateLimit(options);
+    expect(rateLimit.drainageTimeMs).toBe(
+      options.leakIntervalMs * options.maxBurst,
+    );
+  });
+
+  test('should return 0 backoff time for new user', () => {
+    const rateLimit = new LeakyBucketRateLimit(options);
+    const user = 'user1';
+    const backoffMs = rateLimit.getBackoffMs(user);
+    expect(backoffMs).toBe(0);
+  });
+
+  test('should return 0 budget consumed for new user', () => {
+    const rateLimit = new LeakyBucketRateLimit(options);
+    const user = 'user1';
+    const budgetConsumed = rateLimit.getBudgetConsumed(user);
+    expect(budgetConsumed).toBe(0);
+  });
+
+  test('should consume budget correctly', () => {
+    const rateLimit = new LeakyBucketRateLimit(options);
+    const user = 'user1';
+    rateLimit.consumeBudget(user);
+    expect(rateLimit.getBudgetConsumed(user)).toBe(1);
+  });
+
+  test('leaking should reduce budget consumed', () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const rateLimit = new LeakyBucketRateLimit(options);
+    const user = 'user1';
+    rateLimit.consumeBudget(user);
+    rateLimit.consumeBudget(user);
+    expect(rateLimit.getBudgetConsumed(user)).toBe(2);
+
+    vi.advanceTimersByTime(options.leakIntervalMs);
+    expect(rateLimit.getBudgetConsumed(user)).toBe(1);
+  });
+});

--- a/transport/rateLimit.test.ts
+++ b/transport/rateLimit.test.ts
@@ -2,7 +2,7 @@ import {
   LeakyBucketRateLimit,
   LeakBucketLimitOptions,
 } from '../transport/rateLimit';
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, test, expect, vi } from 'vitest';
 
 describe('LeakyBucketRateLimit', () => {
   const options: LeakBucketLimitOptions = {

--- a/transport/rateLimit.ts
+++ b/transport/rateLimit.ts
@@ -7,7 +7,7 @@ export interface LeakBucketLimitOptions {
   jitterMs: number;
 }
 
-export class ReconnectionLeakyBucketRateLimit {
+export class LeakyBucketRateLimit {
   budgetConsumed: Map<TransportClientId, number>;
   intervalHandle: ReturnType<typeof setInterval>;
   readonly options: LeakBucketLimitOptions;

--- a/transport/rateLimit.ts
+++ b/transport/rateLimit.ts
@@ -1,10 +1,16 @@
 import { TransportClientId } from './message';
 
 /**
- * Options to control the backoff and retry behavior of the transport's connection.
+ * Options to control the backoff and retry behavior of the client transport's connection behaviour.
  *
  * River implements exponential backoff with jitter to prevent flooding the server
- * when there's an issue.
+ * when there's an issue with connection establishment.
+ *
+ * The backoff is calculated via the following:
+ *   backOff = min(jitter + {@link baseIntervalMs} * 2 ^ budget_consumed, {@link maxBackoffMs})
+ *
+ * We use a leaky bucket rate limit with a budget of {@link attemptCapacity} reconnection attempts.
+ * Budget only starts to restore after a successful handshake at a rate of one budget per {@link budgetRestoreIntervalMs}.
  */
 export interface ConnectionRetryOptions {
   /**

--- a/transport/session.ts
+++ b/transport/session.ts
@@ -7,7 +7,7 @@ import {
   TransportClientId,
   TransportMessage,
 } from './message';
-import { Codec, NaiveJsonCodec } from '../codec';
+import { Codec } from '../codec';
 import { log } from '../logging';
 import { Static } from '@sinclair/typebox';
 
@@ -68,35 +68,25 @@ export abstract class Connection {
   abstract close(): void;
 }
 
-/**
- * Frequency at which to send heartbeat acknowledgements
- */
-export const HEARTBEAT_INTERVAL_MS = 1000; // 1s
-
-/**
- * Number of elapsed heartbeats without a response message before we consider
- * the connection dead.
- */
-export const HEARTBEATS_TILL_DEAD = 2;
-
-/**
- * Duration to wait between connection disconnect and actual session disconnect
- */
-export const SESSION_DISCONNECT_GRACE_MS = 5_000;
-
 export interface SessionOptions {
+  /**
+   * Frequency at which to send heartbeat acknowledgements
+   */
   heartbeatIntervalMs: number;
+  /**
+   * Number of elapsed heartbeats without a response message before we consider
+   * the connection dead.
+   */
   heartbeatsUntilDead: number;
+  /**
+   * Duration to wait between connection disconnect and actual session disconnect
+   */
   sessionDisconnectGraceMs: number;
+  /**
+   * The codec to use for encoding/decoding messages over the wire
+   */
   codec: Codec;
 }
-
-export const defaultSessionOptions: SessionOptions = {
-  heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
-  heartbeatsUntilDead: HEARTBEATS_TILL_DEAD,
-  sessionDisconnectGraceMs: SESSION_DISCONNECT_GRACE_MS,
-  codec: NaiveJsonCodec,
-};
 
 /**
  * A session is a higher-level abstraction that operates over the span of potentially multiple transport-level connections

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -3,6 +3,7 @@ import {
   createDummyTransportMessage,
   payloadToTransportMessage,
   waitForMessage,
+  testingSessionOptions,
 } from '../util/testHelpers';
 import { EventMap } from '../transport/events';
 import {
@@ -12,7 +13,6 @@ import {
 } from '../__tests__/fixtures/cleanup';
 import { testMatrix } from '../__tests__/fixtures/matrix';
 import { PartialTransportMessage } from './message';
-import { HEARTBEATS_TILL_DEAD, HEARTBEAT_INTERVAL_MS } from './session';
 
 describe.each(testMatrix())(
   'transport connection behaviour tests ($transport.name transport, $codec.name codec)',
@@ -83,7 +83,7 @@ describe.each(testMatrix())(
         // wait for heartbeat interval to elapse
         await vi.runOnlyPendingTimersAsync();
         await vi.advanceTimersByTimeAsync(
-          HEARTBEAT_INTERVAL_MS * (1 + Math.random()),
+          testingSessionOptions.heartbeatIntervalMs * (1 + Math.random()),
         );
       }
     });
@@ -703,8 +703,10 @@ describe.each(testMatrix())(
       // now, let's wait until the connection is considered dead
       simulatePhantomDisconnect();
       await vi.runOnlyPendingTimersAsync();
-      for (let i = 0; i < HEARTBEATS_TILL_DEAD; i++) {
-        await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS + 1);
+      for (let i = 0; i < testingSessionOptions.heartbeatsUntilDead; i++) {
+        await vi.advanceTimersByTimeAsync(
+          testingSessionOptions.heartbeatIntervalMs + 1,
+        );
       }
 
       await waitFor(() => expect(clientConnStart).toHaveBeenCalledTimes(2));

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -162,47 +162,55 @@ describe.each(testMatrix())(
     test('both client and server transport get connect/disconnect notifs', async () => {
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const clientConnStart = vi.fn<[], unknown>();
-      const clientConnStop = vi.fn<[], unknown>();
+      const clientConnStart = vi.fn();
+      const clientConnStop = vi.fn();
       const clientConnHandler = (evt: EventMap['connectionStatus']) => {
         switch (evt.status) {
           case 'connect':
-            return clientConnStart();
+            clientConnStart();
+            break;
           case 'disconnect':
-            return clientConnStop();
+            clientConnStop();
+            break;
         }
       };
 
-      const clientSessStart = vi.fn<[], unknown>();
-      const clientSessStop = vi.fn<[], unknown>();
+      const clientSessStart = vi.fn();
+      const clientSessStop = vi.fn();
       const clientSessHandler = (evt: EventMap['sessionStatus']) => {
         switch (evt.status) {
           case 'connect':
-            return clientSessStart();
+            clientSessStart();
+            break;
           case 'disconnect':
-            return clientSessStop();
+            clientSessStop();
+            break;
         }
       };
 
-      const serverConnStart = vi.fn<[], unknown>();
-      const serverConnStop = vi.fn<[], unknown>();
+      const serverConnStart = vi.fn();
+      const serverConnStop = vi.fn();
       const serverConnHandler = (evt: EventMap['connectionStatus']) => {
         switch (evt.status) {
           case 'connect':
-            return serverConnStart();
+            serverConnStart();
+            break;
           case 'disconnect':
-            return serverConnStop();
+            serverConnStop();
+            break;
         }
       };
 
-      const serverSessStart = vi.fn<[], unknown>();
-      const serverSessStop = vi.fn<[], unknown>();
+      const serverSessStart = vi.fn();
+      const serverSessStop = vi.fn();
       const serverSessHandler = (evt: EventMap['sessionStatus']) => {
         switch (evt.status) {
           case 'connect':
-            return serverSessStart();
+            serverSessStart();
+            break;
           case 'disconnect':
-            return serverSessStop();
+            serverSessStop();
+            break;
         }
       };
 
@@ -402,25 +410,29 @@ describe.each(testMatrix())(
 
       let clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const serverConnStart = vi.fn<[], unknown>();
-      const serverConnStop = vi.fn<[], unknown>();
+      const serverConnStart = vi.fn();
+      const serverConnStop = vi.fn();
       const serverConnHandler = (evt: EventMap['connectionStatus']) => {
         switch (evt.status) {
           case 'connect':
-            return serverConnStart();
+            serverConnStart();
+            break;
           case 'disconnect':
-            return serverConnStop();
+            serverConnStop();
+            break;
         }
       };
 
-      const serverSessStart = vi.fn<[], unknown>();
-      const serverSessStop = vi.fn<[], unknown>();
+      const serverSessStart = vi.fn();
+      const serverSessStop = vi.fn();
       const serverSessHandler = (evt: EventMap['sessionStatus']) => {
         switch (evt.status) {
           case 'connect':
-            return serverSessStart();
+            serverSessStart();
+            break;
           case 'disconnect':
-            return serverSessStop();
+            serverSessStop();
+            break;
         }
       };
 
@@ -490,25 +502,29 @@ describe.each(testMatrix())(
 
       const clientTransport = getClientTransport('client');
       let serverTransport = getServerTransport();
-      const clientConnStart = vi.fn<[], unknown>();
-      const clientConnStop = vi.fn<[], unknown>();
+      const clientConnStart = vi.fn();
+      const clientConnStop = vi.fn();
       const clientConnHandler = (evt: EventMap['connectionStatus']) => {
         switch (evt.status) {
           case 'connect':
-            return clientConnStart();
+            clientConnStart();
+            break;
           case 'disconnect':
-            return clientConnStop();
+            clientConnStop();
+            break;
         }
       };
 
-      const clientSessStart = vi.fn<[], unknown>();
-      const clientSessStop = vi.fn<[], unknown>();
+      const clientSessStart = vi.fn();
+      const clientSessStop = vi.fn();
       const clientSessHandler = (evt: EventMap['sessionStatus']) => {
         switch (evt.status) {
           case 'connect':
-            return clientSessStart();
+            clientSessStart();
+            break;
           case 'disconnect':
-            return clientSessStop();
+            clientSessStop();
+            break;
         }
       };
 
@@ -593,47 +609,55 @@ describe.each(testMatrix())(
       vi.useFakeTimers({ shouldAdvanceTime: true });
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const clientConnStart = vi.fn<[], unknown>();
-      const clientConnStop = vi.fn<[], unknown>();
+      const clientConnStart = vi.fn();
+      const clientConnStop = vi.fn();
       const clientConnHandler = (evt: EventMap['connectionStatus']) => {
         switch (evt.status) {
           case 'connect':
-            return clientConnStart();
+            clientConnStart();
+            break;
           case 'disconnect':
-            return clientConnStop();
+            clientConnStop();
+            break;
         }
       };
 
-      const clientSessStart = vi.fn<[], unknown>();
-      const clientSessStop = vi.fn<[], unknown>();
+      const clientSessStart = vi.fn();
+      const clientSessStop = vi.fn();
       const clientSessHandler = (evt: EventMap['sessionStatus']) => {
         switch (evt.status) {
           case 'connect':
-            return clientSessStart();
+            clientSessStart();
+            break;
           case 'disconnect':
-            return clientSessStop();
+            clientSessStop();
+            break;
         }
       };
 
-      const serverConnStart = vi.fn<[], unknown>();
-      const serverConnStop = vi.fn<[], unknown>();
+      const serverConnStart = vi.fn();
+      const serverConnStop = vi.fn();
       const serverConnHandler = (evt: EventMap['connectionStatus']) => {
         switch (evt.status) {
           case 'connect':
-            return serverConnStart();
+            serverConnStart();
+            break;
           case 'disconnect':
-            return serverConnStop();
+            serverConnStop();
+            break;
         }
       };
 
-      const serverSessStart = vi.fn<[], unknown>();
-      const serverSessStop = vi.fn<[], unknown>();
+      const serverSessStart = vi.fn();
+      const serverSessStop = vi.fn();
       const serverSessHandler = (evt: EventMap['sessionStatus']) => {
         switch (evt.status) {
           case 'connect':
-            return serverSessStart();
+            serverSessStart();
+            break;
           case 'disconnect':
-            return serverSessStop();
+            serverSessStop();
+            break;
         }
       };
 

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -702,7 +702,7 @@ export abstract class ClientTransport<
     conn.send(this.codec.toBuffer(requestMsg));
   }
 
-  protected close() {
+  close() {
     this.retryBudget.close();
     super.close();
   }

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -593,10 +593,10 @@ export abstract class ClientTransport<
       return;
     }
 
-    log?.info(`${this.clientId} -- attempting connection to ${to}`);
-
     let reconnectPromise = this.inflightConnectionPromises.get(to);
     if (!reconnectPromise) {
+      log?.info(`${this.clientId} -- attempting connection to ${to}`);
+
       // check budget
       const budgetConsumed = this.retryBudget.getBudgetConsumed(to);
       if (budgetConsumed >= this.options.maxReconnectionBurstAttempts) {
@@ -635,6 +635,10 @@ export abstract class ClientTransport<
           return conn;
         });
       this.inflightConnectionPromises.set(to, reconnectPromise);
+    } else {
+      log?.info(
+        `${this.clientId} -- attempting connection to ${to} (reusing previous attempt)`,
+      );
     }
 
     try {

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -630,6 +630,11 @@ export abstract class ClientTransport<
             throw new Error('transport state is no longer open');
           }
 
+          // After a successful connection, we start restoring the budget
+          // so that the next time we try to connect, we don't hit the client
+          // with backoff forever.
+          this.retryBudget.startRestoringBudget(to);
+
           // only send handshake once per attempt
           this.sendHandshake(to, conn);
           return conn;

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -37,9 +37,9 @@ import { NaiveJsonCodec } from '../codec';
  */
 export type TransportStatus = 'open' | 'closed' | 'destroyed';
 
-// eslint-ignore-next-line @typescript-eslint/no-empty-interface
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ProvidedTransportOptions extends Partial<SessionOptions> {}
-// eslint-ignore-next-line @typescript-eslint/no-empty-interface
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface TransportOptions extends Required<ProvidedTransportOptions> {}
 const defaultTransportOptions: TransportOptions = {
   heartbeatIntervalMs: 1_000,

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -59,7 +59,7 @@ const defaultClientTransportOptions: ClientTransportOptions = {
     baseIntervalMs: 250,
     maxJitterMs: 200,
     maxBackoffMs: 32_000,
-    attemptCapacity: 15,
+    attemptBudgetCapacity: 15,
     budgetRestoreIntervalMs: 200,
   },
   ...defaultTransportOptions,
@@ -614,7 +614,7 @@ export abstract class ClientTransport<
       // check budget
       const budgetConsumed = this.retryBudget.getBudgetConsumed(to);
       if (!this.retryBudget.hasBudget(to)) {
-        const errMsg = `not attempting to connect to ${to}, retry budget exceeded (more than ${budgetConsumed} attempts in the last ${this.retryBudget.drainageTimeMs}ms)`;
+        const errMsg = `not attempting to connect to ${to}, retry budget exceeded (more than ${budgetConsumed} attempts in the last ${this.retryBudget.totalBudgetRestoreTime}ms)`;
         log?.warn(`${this.clientId} -- ${errMsg}`);
         this.protocolError(ProtocolError.RetriesExceeded, errMsg);
         return;

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -701,6 +701,11 @@ export abstract class ClientTransport<
     log?.debug(`${this.clientId} -- sending handshake request to ${to}`);
     conn.send(this.codec.toBuffer(requestMsg));
   }
+
+  protected close() {
+    this.retryBudget.close();
+    super.close();
+  }
 }
 
 export abstract class ServerTransport<

--- a/util/testHelpers.ts
+++ b/util/testHelpers.ts
@@ -23,7 +23,7 @@ import { nanoid } from 'nanoid';
 import net from 'node:net';
 import { PartialTransportMessage } from '../transport/message';
 import { coerceErrorString } from './stringify';
-import { defaultSessionOptions } from '../transport/session';
+import { NaiveJsonCodec } from '../codec';
 
 /**
  * Creates a WebSocket server instance using the provided HTTP server.
@@ -143,6 +143,13 @@ function catchProcError(err: unknown) {
   };
 }
 
+export const testingSessionOptions = {
+  heartbeatIntervalMs: 1_000,
+  heartbeatsUntilDead: 2,
+  sessionDisconnectGraceMs: 5_000,
+  codec: NaiveJsonCodec,
+};
+
 function dummyCtx<State>(
   state: State,
   extendedContext?: Omit<ServiceContext, 'state'>,
@@ -151,7 +158,7 @@ function dummyCtx<State>(
     'client',
     'SERVER',
     undefined,
-    defaultSessionOptions,
+    testingSessionOptions,
   );
 
   return {


### PR DESCRIPTION
## why
- our retry logic didn't handle cases where a connection appears successful (i.e. we get an 'open' message) and then is immediately closed
  - this can end up in connection spam
- we should globally add some form of rate-limiting at a transport-level per node it is attempting to connect to

## what changed
- add leaky bucket rate limiting so we dont spam retry even on connections that open and then immediately close
- moved all retry args to `connectionRetryOptions`
    - add arg `budgetRestoreIntervalMs` that controls how often we refill the bucket
- `connect` promise lifetime is now accurate across retries
- add test `repeated connections that close instantly causes retry limit to still be reached`
- Split `TransportOptions` to `ServerTransportOptions` and `ClientTransportOptions`. We now only export the shape that is accepted by the transport constructor, instead of the options internal to the transports.
- Isolate default values in tests to use their own instead of relying on global defaults.