### PR TITLE
Separate services and procedures types, give each procedure form its own type

### DIFF
--- a/__tests__/fixtures/services.ts
+++ b/__tests__/fixtures/services.ts
@@ -1,5 +1,5 @@
 import { Type } from '@sinclair/typebox';
-import { ServiceBuilder } from '../../router/builder';
+import { ServiceBuilder } from '../../router/services';
 import { Err, Ok } from '../../router/result';
 import { Observable } from './observable';
 

--- a/__tests__/serialize.test.ts
+++ b/__tests__/serialize.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, test } from 'vitest';
-import { serializeService } from '../router/builder';
+import { serializeService } from '../router/services';
 import {
   BinaryFileServiceConstructor,
   FallibleServiceConstructor,

--- a/__tests__/typescript-stress.test.ts
+++ b/__tests__/typescript-stress.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
-import { Procedure, ServiceBuilder, serializeService } from '../router/builder';
+import { Procedure } from '../router/procedures';
+import { ServiceBuilder, serializeService } from '../router/services';
 import { Type } from '@sinclair/typebox';
 import { createServer } from '../router/server';
 import { Connection, ClientTransport, ServerTransport } from '../transport';

--- a/router/client.ts
+++ b/router/client.ts
@@ -7,7 +7,7 @@ import {
   ProcInput,
   ProcOutput,
   ProcType,
-} from './builder';
+} from './services';
 import { pushable } from 'it-pushable';
 import type { Pushable } from 'it-pushable';
 import { Server } from './server';

--- a/router/defs.ts
+++ b/router/defs.ts
@@ -1,4 +1,4 @@
-import { AnyService } from './builder';
+import { AnyService } from './services';
 
 /**
  * Defines a type for a collection service definitions. Should be

--- a/router/index.ts
+++ b/router/index.ts
@@ -1,15 +1,23 @@
-export { serializeService, ServiceBuilder } from './builder';
 export type {
-  ValidProcType,
-  ProcListing,
   Service,
   ProcHandler,
+  ProcInit,
   ProcInput,
   ProcOutput,
+  ProcErrors,
   ProcType,
-  Procedure,
+} from './services';
+export { serializeService, ServiceBuilder } from './services';
+export type {
+  ValidProcType,
   PayloadType,
-} from './builder';
+  ProcListing,
+  RPCProcedure,
+  UploadProcedure,
+  SubscriptionProcedure,
+  StreamProcedure,
+  Procedure,
+} from './procedures';
 export { buildServiceDefs } from './defs';
 export type { ServiceDefs } from './defs';
 export { createClient } from './client';

--- a/router/procedures.ts
+++ b/router/procedures.ts
@@ -1,0 +1,213 @@
+import { TObject, Static, TUnion } from '@sinclair/typebox';
+import type { Pushable } from 'it-pushable';
+import { ServiceContextWithTransportInfo } from './context';
+import { Result, RiverError } from './result';
+
+/**
+ * The valid {@link Procedure} types. The `stream` and `upload` types can optionally have a
+ * different type for the very first initialization message. The suffixless types correspond to
+ * gRPC's four combinations of stream / non-stream in each direction.
+ */
+export type ValidProcType =
+  // Single message in both directions (1:1).
+  | 'rpc'
+  // Client-stream (potentially preceded by an initialization message), single message from server (n:1).
+  | 'upload'
+  // Single message from client, stream from server (1:n).
+  | 'subscription'
+  // Bidirectional stream (potentially preceded by an initialization message) (n:n).
+  | 'stream';
+
+/**
+ * Represents the payload type for {@link Procedure}s.
+ */
+export type PayloadType = TObject | TUnion<Array<TObject>>;
+
+/**
+ * Procedure for a single message in both directions (1:1).
+ *
+ * @template State - The context state object.
+ * @template I - The TypeBox schema of the input object.
+ * @template O - The TypeBox schema of the output object.
+ * @template E - The TypeBox schema of the error object.
+ */
+export interface RPCProcedure<
+  State,
+  I extends PayloadType,
+  O extends PayloadType,
+  E extends RiverError,
+> {
+  type: 'rpc';
+  input: I;
+  output: O;
+  errors: E;
+  handler: (
+    context: ServiceContextWithTransportInfo<State>,
+    input: Static<I>,
+  ) => Promise<Result<Static<O>, Static<E>>>;
+}
+
+/**
+ * Procedure for a client-stream (potentially preceded by an initialization message),
+ * single message from server (n:1).
+ *
+ * @template State - The context state object.
+ * @template I - The TypeBox schema of the input object.
+ * @template O - The TypeBox schema of the output object.
+ * @template E - The TypeBox schema of the error object.
+ * @template Init - The TypeBox schema of the input initialization object, if any.
+ */
+export type UploadProcedure<
+  State,
+  I extends PayloadType,
+  O extends PayloadType,
+  E extends RiverError,
+  Init extends PayloadType | null = null,
+> = Init extends PayloadType
+  ? {
+      type: 'upload';
+      init: Init;
+      input: I;
+      output: O;
+      errors: E;
+      handler: (
+        context: ServiceContextWithTransportInfo<State>,
+        init: Static<Init>,
+        input: AsyncIterableIterator<Static<I>>,
+      ) => Promise<Result<Static<O>, Static<E>>>;
+    }
+  : {
+      type: 'upload';
+      input: I;
+      output: O;
+      errors: E;
+      handler: (
+        context: ServiceContextWithTransportInfo<State>,
+        input: AsyncIterableIterator<Static<I>>,
+      ) => Promise<Result<Static<O>, Static<E>>>;
+    };
+
+/**
+ * Procedure for a single message from client, stream from server (1:n).
+ *
+ * @template State - The context state object.
+ * @template I - The TypeBox schema of the input object.
+ * @template O - The TypeBox schema of the output object.
+ * @template E - The TypeBox schema of the error object.
+ */
+export interface SubscriptionProcedure<
+  State,
+  I extends PayloadType,
+  O extends PayloadType,
+  E extends RiverError,
+> {
+  type: 'subscription';
+  input: I;
+  output: O;
+  errors: E;
+  handler: (
+    context: ServiceContextWithTransportInfo<State>,
+    input: Static<I>,
+    output: Pushable<Result<Static<O>, Static<E>>>,
+  ) => Promise<(() => void) | void>;
+}
+
+/**
+ * Procedure for a bidirectional stream (potentially preceded by an initialization message),
+ * (n:n).
+ *
+ * @template State - The context state object.
+ * @template I - The TypeBox schema of the input object.
+ * @template O - The TypeBox schema of the output object.
+ * @template E - The TypeBox schema of the error object.
+ * @template Init - The TypeBox schema of the input initialization object, if any.
+ */
+export type StreamProcedure<
+  State,
+  I extends PayloadType,
+  O extends PayloadType,
+  E extends RiverError,
+  Init extends PayloadType | null = null,
+> = Init extends PayloadType
+  ? {
+      type: 'stream';
+      init: Init;
+      input: I;
+      output: O;
+      errors: E;
+      handler: (
+        context: ServiceContextWithTransportInfo<State>,
+        init: Static<Init>,
+        input: AsyncIterableIterator<Static<I>>,
+        output: Pushable<Result<Static<O>, Static<E>>>,
+      ) => Promise<void>;
+    }
+  : {
+      type: 'stream';
+      input: I;
+      output: O;
+      errors: E;
+      handler: (
+        context: ServiceContextWithTransportInfo<State>,
+        input: AsyncIterableIterator<Static<I>>,
+        output: Pushable<Result<Static<O>, Static<E>>>,
+      ) => Promise<void>;
+    };
+
+/**
+ * Defines a Procedure type that can be a:
+ * - {@link RPCProcedure} for a single message in both directions (1:1)
+ * - {@link UploadProcedure} for a client-stream (potentially preceded by an
+ *   initialization message)
+ * - {@link SubscriptionProcedure} for a single message from client, stream from server (1:n)
+ * - {@link StreamProcedure} for a bidirectional stream (potentially preceded by an
+ *    initialization message)
+ *
+ * @template State - The TypeBox schema of the state object.
+ * @template Ty - The type of the procedure.
+ * @template I - The TypeBox schema of the input object.
+ * @template O - The TypeBox schema of the output object.
+ * @template Init - The TypeBox schema of the input initialization object, if any.
+ */
+// prettier-ignore
+export type Procedure<
+  State,
+  Ty extends ValidProcType,
+  I extends PayloadType,
+  O extends PayloadType,
+  E extends RiverError,
+  Init extends PayloadType | null = null,
+> = { type: Ty } & (
+  Init extends PayloadType
+    ? Ty extends 'upload' ? UploadProcedure<State, I, O, E, Init>
+    : Ty extends 'stream' ? StreamProcedure<State, I, O, E, Init>
+    : never
+  : Ty extends 'rpc' ? RPCProcedure<State, I, O, E>
+  : Ty extends 'upload' ? UploadProcedure<State, I, O, E>
+  : Ty extends 'subscription' ? SubscriptionProcedure<State, I, O, E>
+  : Ty extends 'stream' ? StreamProcedure<State, I, O, E>
+  : never
+);
+
+/**
+ * Represents any {@link Procedure} type.
+ *
+ * @template State - The context state object. You can provide this to constrain
+ *                   the type of procedures.
+ */
+export type AnyProcedure<State = object> = Procedure<
+  State,
+  ValidProcType,
+  PayloadType,
+  PayloadType,
+  RiverError,
+  PayloadType | null
+>;
+
+/**
+ * Represents a map of {@link Procedure}s.
+ *
+ * @template State - The context state object. You can provide this to constrain
+ *                   the type of procedures.
+ */
+export type ProcListing<State = object> = Record<string, AnyProcedure<State>>;

--- a/router/server.ts
+++ b/router/server.ts
@@ -1,6 +1,7 @@
 import { Static } from '@sinclair/typebox';
 import { ServerTransport, Transport } from '../transport/transport';
-import { AnyProcedure, AnyService, PayloadType } from './builder';
+import { AnyProcedure, PayloadType } from './procedures';
+import { AnyService } from './services';
 import { pushable } from 'it-pushable';
 import type { Pushable } from 'it-pushable';
 import {


### PR DESCRIPTION
Before we change how you construct services, I wanted to change how the procedure types worked so that we could individually type each procedure form. That's what this PR is.

Procedure types are now in `router/procedures.ts`, and service types and the builder for services is now in `router/services.ts`. I gave each procedure type (upload, rpc, etc.) its own type, and then made `Procedure` use those types. I think this might technically break the TS stress test, but the actual constructed type works, it's just TS complains that it _may_ not work, which is strange.