### PR TITLE
reconnect on new proc after session end, session desync protocol error

### DIFF
--- a/__tests__/cleanup.test.ts
+++ b/__tests__/cleanup.test.ts
@@ -60,7 +60,7 @@ describe.each(testMatrix())(
 
       // should be back to 0 connections after client closes
       vi.useFakeTimers({ shouldAdvanceTime: true });
-      clientTransport.tryReconnecting = false;
+      clientTransport.reconnectOnConnectionDrop = false;
       clientTransport.close();
 
       await waitForTransportToFinish(clientTransport);
@@ -99,7 +99,7 @@ describe.each(testMatrix())(
 
       // should be back to 0 connections after client closes
       vi.useFakeTimers({ shouldAdvanceTime: true });
-      clientTransport.tryReconnecting = false;
+      clientTransport.reconnectOnConnectionDrop = false;
       serverTransport.close();
 
       await waitForTransportToFinish(clientTransport);

--- a/__tests__/disconnects.test.ts
+++ b/__tests__/disconnects.test.ts
@@ -52,7 +52,7 @@ describe.each(testMatrix())(
       expect(serverTransport.connections.size).toEqual(1);
 
       vi.useFakeTimers({ shouldAdvanceTime: true });
-      clientTransport.tryReconnecting = false;
+      clientTransport.reconnectOnConnectionDrop = false;
       clientTransport.connections.forEach((conn) => conn.close());
 
       const procPromise = client.test.add.rpc({ n: 4 });
@@ -98,7 +98,7 @@ describe.each(testMatrix())(
       expect(serverTransport.connections.size).toEqual(1);
 
       vi.useFakeTimers({ shouldAdvanceTime: true });
-      clientTransport.tryReconnecting = false;
+      clientTransport.reconnectOnConnectionDrop = false;
       clientTransport.connections.forEach((conn) => conn.close());
 
       const nextResPromise = iterNext(output);
@@ -175,7 +175,7 @@ describe.each(testMatrix())(
 
       // kill the connection for client2
       vi.useFakeTimers({ shouldAdvanceTime: true });
-      client2Transport.tryReconnecting = false;
+      client2Transport.reconnectOnConnectionDrop = false;
       client2Transport.connections.forEach((conn) => conn.close());
 
       // client1 who is still connected can still add values and receive updates
@@ -238,7 +238,7 @@ describe.each(testMatrix())(
       await waitFor(() => expect(serverTransport.connections.size).toEqual(1));
 
       vi.useFakeTimers({ shouldAdvanceTime: true });
-      clientTransport.tryReconnecting = false;
+      clientTransport.reconnectOnConnectionDrop = false;
       clientTransport.connections.forEach((conn) => conn.close());
 
       // after we've disconnected, hit end of grace period

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -505,6 +505,7 @@ describe.each(testMatrix())(
       const client = createClient<typeof server>(
         clientTransport,
         serverTransport.clientId,
+        { connectOnInvoke: true },
       );
       onTestFinished(async () => {
         await testFinishesCleanly({
@@ -526,10 +527,12 @@ describe.each(testMatrix())(
       clientTransport.reconnectOnConnectionDrop = true;
 
       // we should have no connections
+      console.log('test 1');
       expect(serverTransport.connections.size).toEqual(0);
       expect(clientTransport.connections.size).toEqual(0);
+      console.log('test 2');
 
-      // client should reconnect when making another call
+      // client should reconnect when making another call without explicitly calling connect
       await client.test.add.rpc({ n: 4 });
       await waitFor(() => expect(serverTransport.connections.size).toEqual(1));
       await waitFor(() => expect(clientTransport.connections.size).toEqual(1));

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -21,7 +21,11 @@ import {
   OrderingServiceSchema,
 } from './fixtures/services';
 import { UNCAUGHT_ERROR } from '../router/result';
-import { advanceFakeTimersByDisconnectGrace, testFinishesCleanly, waitFor } from './fixtures/cleanup';
+import {
+  advanceFakeTimersByDisconnectGrace,
+  testFinishesCleanly,
+  waitFor,
+} from './fixtures/cleanup';
 import { testMatrix } from './fixtures/matrix';
 
 describe.each(testMatrix())(
@@ -494,10 +498,10 @@ describe.each(testMatrix())(
 
       // kill the session
       vi.useFakeTimers({ shouldAdvanceTime: true });
-      clientTransport.tryReconnecting = false;
+      clientTransport.reconnectOnConnectionDrop = false;
       clientTransport.connections.forEach((conn) => conn.close());
       await advanceFakeTimersByDisconnectGrace();
-      clientTransport.tryReconnecting = true;
+      clientTransport.reconnectOnConnectionDrop = true;
 
       // we should have no connections
       expect(serverTransport.connections.size).toEqual(0);

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -27,7 +27,6 @@ import {
   waitFor,
 } from './fixtures/cleanup';
 import { testMatrix } from './fixtures/matrix';
-import { bindLogger, unbindLogger } from '../logging';
 
 describe.each(testMatrix())(
   'client <-> server integration test ($transport.name transport, $codec.name codec)',
@@ -500,7 +499,6 @@ describe.each(testMatrix())(
 
     test('client reconnects even after session grace', async () => {
       // setup
-      bindLogger(console.log);
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
       const server = createServer(serverTransport, { test: TestServiceSchema });
@@ -515,7 +513,6 @@ describe.each(testMatrix())(
           serverTransport,
           server,
         });
-        unbindLogger();
       });
 
       await client.test.add.rpc({ n: 3 });
@@ -534,12 +531,9 @@ describe.each(testMatrix())(
       expect(clientTransport.connections.size).toEqual(0);
 
       // client should reconnect when making another call without explicitly calling connect
-      console.log('1');
       void client.test.add.rpc({ n: 4 });
-      console.log('2');
       await waitFor(() => expect(clientTransport.connections.size).toEqual(1));
       await waitFor(() => expect(serverTransport.connections.size).toEqual(1));
-      console.log('3');
     });
 
     test("client doesn't reconnect if client sets connectOnInvoke to false", async () => {

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -531,8 +531,8 @@ describe.each(testMatrix())(
       expect(clientTransport.connections.size).toEqual(0);
 
       // client should reconnect when making another call without explicitly calling connect
-      await client.test.add.rpc({ n: 4 });
-      console.log('test 1');
+      const res = await client.test.add.rpc({ n: 4 });
+      console.log('test 1', res);
       await waitFor(() => expect(serverTransport.connections.size).toEqual(1));
       console.log('test 2');
       await waitFor(() => expect(clientTransport.connections.size).toEqual(1));

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -510,12 +510,12 @@ describe.each(testMatrix())(
         { connectOnInvoke: true },
       );
       onTestFinished(async () => {
-        unbindLogger();
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
           server,
         });
+        unbindLogger();
       });
 
       await client.test.add.rpc({ n: 3 });
@@ -534,13 +534,12 @@ describe.each(testMatrix())(
       expect(clientTransport.connections.size).toEqual(0);
 
       // client should reconnect when making another call without explicitly calling connect
-      console.log('???');
-      const res = await client.test.add.rpc({ n: 4 });
-      console.log('test 1', res);
-      await waitFor(() => expect(serverTransport.connections.size).toEqual(1));
-      console.log('test 2');
+      console.log('1');
+      await client.test.add.rpc({ n: 4 });
+      console.log('2');
       await waitFor(() => expect(clientTransport.connections.size).toEqual(1));
-      console.log('test 3');
+      await waitFor(() => expect(serverTransport.connections.size).toEqual(1));
+      console.log('3');
     });
 
     test("client doesn't reconnect if client sets connectOnInvoke to false", async () => {

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -531,12 +531,15 @@ describe.each(testMatrix())(
       expect(clientTransport.connections.size).toEqual(0);
 
       // client should reconnect when making another call without explicitly calling connect
-      void client.test.add.rpc({ n: 4 });
+      const resultPromise = client.test.add.rpc({ n: 4 });
       await waitFor(() => expect(clientTransport.connections.size).toEqual(1));
       await waitFor(() => expect(serverTransport.connections.size).toEqual(1));
+      const result = await resultPromise;
+      assert(result.ok);
+      expect(result.payload).toStrictEqual({ result: 7 });
     });
 
-    test("client doesn't reconnect if client sets connectOnInvoke to false", async () => {
+    test("client doesn't reconnect after session grace if connectOnInvoke is false", async () => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -510,6 +510,7 @@ describe.each(testMatrix())(
         { connectOnInvoke: true },
       );
       onTestFinished(async () => {
+        unbindLogger();
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -529,17 +530,17 @@ describe.each(testMatrix())(
       clientTransport.reconnectOnConnectionDrop = true;
 
       // we should have no connections
-      await waitFor(() => expect(serverTransport.connections.size).toEqual(0));
-      await waitFor(() => expect(clientTransport.connections.size).toEqual(0));
+      expect(serverTransport.connections.size).toEqual(0);
+      expect(clientTransport.connections.size).toEqual(0);
 
       // client should reconnect when making another call without explicitly calling connect
+      console.log('???');
       const res = await client.test.add.rpc({ n: 4 });
       console.log('test 1', res);
       await waitFor(() => expect(serverTransport.connections.size).toEqual(1));
       console.log('test 2');
       await waitFor(() => expect(clientTransport.connections.size).toEqual(1));
       console.log('test 3');
-      unbindLogger();
     });
 
     test("client doesn't reconnect if client sets connectOnInvoke to false", async () => {

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -527,15 +527,16 @@ describe.each(testMatrix())(
       clientTransport.reconnectOnConnectionDrop = true;
 
       // we should have no connections
-      console.log('test 1');
       expect(serverTransport.connections.size).toEqual(0);
       expect(clientTransport.connections.size).toEqual(0);
-      console.log('test 2');
 
       // client should reconnect when making another call without explicitly calling connect
       await client.test.add.rpc({ n: 4 });
+      console.log('test 1');
       await waitFor(() => expect(serverTransport.connections.size).toEqual(1));
+      console.log('test 2');
       await waitFor(() => expect(clientTransport.connections.size).toEqual(1));
+      console.log('test 3');
     });
 
     test("client doesn't reconnect if client sets connectOnInvoke to false", async () => {

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -27,6 +27,7 @@ import {
   waitFor,
 } from './fixtures/cleanup';
 import { testMatrix } from './fixtures/matrix';
+import { bindLogger, unbindLogger } from '../logging';
 
 describe.each(testMatrix())(
   'client <-> server integration test ($transport.name transport, $codec.name codec)',
@@ -499,6 +500,7 @@ describe.each(testMatrix())(
 
     test('client reconnects even after session grace', async () => {
       // setup
+      bindLogger(console.log);
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
       const server = createServer(serverTransport, { test: TestServiceSchema });
@@ -537,6 +539,7 @@ describe.each(testMatrix())(
       console.log('test 2');
       await waitFor(() => expect(clientTransport.connections.size).toEqual(1));
       console.log('test 3');
+      unbindLogger();
     });
 
     test("client doesn't reconnect if client sets connectOnInvoke to false", async () => {

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -535,7 +535,7 @@ describe.each(testMatrix())(
 
       // client should reconnect when making another call without explicitly calling connect
       console.log('1');
-      await client.test.add.rpc({ n: 4 });
+      void client.test.add.rpc({ n: 4 });
       console.log('2');
       await waitFor(() => expect(clientTransport.connections.size).toEqual(1));
       await waitFor(() => expect(serverTransport.connections.size).toEqual(1));
@@ -563,7 +563,6 @@ describe.each(testMatrix())(
         });
       });
 
-      await clientTransport.connect(serverTransport.clientId);
       await waitFor(() => expect(serverTransport.connections.size).toEqual(1));
       await waitFor(() => expect(clientTransport.connections.size).toEqual(1));
 

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -529,8 +529,8 @@ describe.each(testMatrix())(
       clientTransport.reconnectOnConnectionDrop = true;
 
       // we should have no connections
-      expect(serverTransport.connections.size).toEqual(0);
-      expect(clientTransport.connections.size).toEqual(0);
+      await waitFor(() => expect(serverTransport.connections.size).toEqual(0));
+      await waitFor(() => expect(clientTransport.connections.size).toEqual(0));
 
       // client should reconnect when making another call without explicitly calling connect
       const res = await client.test.add.rpc({ n: 4 });

--- a/__tests__/fixtures/cleanup.ts
+++ b/__tests__/fixtures/cleanup.ts
@@ -6,7 +6,7 @@ import { ServiceSchemaMap } from '../../router/services';
 import { testingSessionOptions } from '../../util/testHelpers';
 
 const waitUntilOptions = {
-  timeout: 500, // these are all local connections so anything above 250ms is sus
+  timeout: 500, // account for possibility of conn backoff
   interval: 5, // check every 5ms
 };
 

--- a/__tests__/fixtures/cleanup.ts
+++ b/__tests__/fixtures/cleanup.ts
@@ -6,7 +6,7 @@ import { ServiceSchemaMap } from '../../router/services';
 import { testingSessionOptions } from '../../util/testHelpers';
 
 const waitUntilOptions = {
-  timeout: 250, // these are all local connections so anything above 250ms is sus
+  timeout: 500, // these are all local connections so anything above 250ms is sus
   interval: 5, // check every 5ms
 };
 

--- a/__tests__/negative.test.ts
+++ b/__tests__/negative.test.ts
@@ -110,11 +110,9 @@ describe('should handle incompatabilities', async () => {
         return Promise.resolve(ws);
       },
       'client',
-      {
-        connectionRetryOptions: { attemptBudgetCapacity: maxAttempts },
-      },
+      { attemptBudgetCapacity: maxAttempts },
     );
-    clientTransport.tryReconnecting = false;
+    clientTransport.reconnectOnConnectionDrop = false;
 
     const errMock = vi.fn();
     clientTransport.addEventListener('protocolError', errMock);

--- a/__tests__/negative.test.ts
+++ b/__tests__/negative.test.ts
@@ -165,14 +165,17 @@ describe('should handle incompatabilities', async () => {
     );
   });
 
-  test('mismatched seq number should close the whole session', async () => {
+  test('seq number in the future should raise protocol error', async () => {
     const serverTransport = new WebSocketServerTransport(wss, 'SERVER');
 
     // add listeners
     const spy = vi.fn();
+    const errMock = vi.fn();
     serverTransport.addEventListener('connectionStatus', spy);
+    serverTransport.addEventListener('protocolError', errMock);
     onTestFinished(async () => {
       serverTransport.removeEventListener('connectionStatus', spy);
+      serverTransport.removeEventListener('protocolError', errMock);
 
       await testFinishesCleanly({
         clientTransports: [],
@@ -187,6 +190,12 @@ describe('should handle incompatabilities', async () => {
 
     // wait for both sides to be happy
     await waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+    expect(errMock).toHaveBeenCalledTimes(0);
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'connect',
+      }),
+    );
 
     // send one with bad sequence number
     const msg: OpaqueTransportMessage = {
@@ -201,9 +210,12 @@ describe('should handle incompatabilities', async () => {
     };
     ws.send(NaiveJsonCodec.toBuffer(msg));
 
-    // ws should be closed after we send something bad
-    await waitFor(() => expect(ws.readyState).toBe(ws.CLOSED));
-    expect(serverTransport.connections.size).toBe(0);
+    await waitFor(() => expect(errMock).toHaveBeenCalledTimes(1));
+    expect(errMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: ProtocolError.MessageOrderingViolated,
+      }),
+    );
   });
 
   test('mismatched protocol version', async () => {

--- a/__tests__/typescript-stress.test.ts
+++ b/__tests__/typescript-stress.test.ts
@@ -183,7 +183,7 @@ describe("ensure typescript doesn't give up trying to infer the types for large 
     const client = createClient<typeof server>(
       new MockClientTransport('client'),
       'SERVER',
-      false,
+      { eagerlyConnect: false },
     );
 
     expect(client.d.f59.rpc({ a: 0 })).toBeTruthy();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.15.7",
+  "version": "0.16.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.15.7",
+      "version": "0.16.2",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "type": "module",
   "exports": {
     ".": {

--- a/router/client.ts
+++ b/router/client.ts
@@ -205,9 +205,6 @@ export const createClient = <Srv extends Server<ServiceSchemaMap>>(
     }
 
     const [input] = opts.args;
-    if (options.connectOnInvoke && !transport.connections.has(serverId)) {
-      void transport.connect(serverId);
-    }
     log?.info(
       `${
         transport.clientId
@@ -215,6 +212,11 @@ export const createClient = <Srv extends Server<ServiceSchemaMap>>(
         input,
       )}`,
     );
+
+    if (options.connectOnInvoke && !transport.connections.has(serverId)) {
+      void transport.connect(serverId);
+    }
+
     if (procType === 'rpc') {
       return handleRpc(
         transport,

--- a/router/client.ts
+++ b/router/client.ts
@@ -205,7 +205,7 @@ export const createClient = <Srv extends Server<ServiceSchemaMap>>(
     }
 
     const [input] = opts.args;
-    if (options.connectOnInvoke && transport.connections.size === 0) {
+    if (options.connectOnInvoke && !transport.connections.has(serverId)) {
       void transport.connect(serverId);
     }
     log?.info(

--- a/transport/events.ts
+++ b/transport/events.ts
@@ -6,6 +6,7 @@ export const ProtocolError = {
   RetriesExceeded: 'conn_retry_exceeded',
   HandshakeFailed: 'handshake_failed',
   UseAfterDestroy: 'use_after_destroy',
+  MessageOrderingViolated: 'message_ordering_violated',
 } as const;
 export type ProtocolErrorType =
   (typeof ProtocolError)[keyof typeof ProtocolError];

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -124,7 +124,7 @@ describe.each(testMatrix())(
         Promise.all(first90Promises.slice(0, 30)),
       ).resolves.toStrictEqual(first90.slice(0, 30).map((msg) => msg.payload));
 
-      clientTransport.tryReconnecting = false;
+      clientTransport.reconnectOnConnectionDrop = false;
       clientTransport.connections.forEach((conn) => conn.close());
       await waitFor(() => expect(clientTransport.connections.size).toEqual(0));
       await waitFor(() => expect(serverTransport.connections.size).toEqual(0));
@@ -149,7 +149,7 @@ describe.each(testMatrix())(
         waitForMessage(serverTransport, (recv) => recv.id === id),
       );
 
-      clientTransport.tryReconnecting = true;
+      clientTransport.reconnectOnConnectionDrop = true;
       await clientTransport.connect('SERVER');
       await waitFor(() => expect(clientTransport.connections.size).toEqual(1));
       await waitFor(() => expect(serverTransport.connections.size).toEqual(1));
@@ -311,7 +311,7 @@ describe.each(testMatrix())(
       // session    >  c------------x  | (disconnected)
       // connection >  c--x   c-----x  | (disconnected)
       vi.useFakeTimers({ shouldAdvanceTime: true });
-      clientTransport.tryReconnecting = false;
+      clientTransport.reconnectOnConnectionDrop = false;
       clientTransport.connections.forEach((conn) => conn.close());
       await waitFor(() => expect(clientConnStart).toHaveBeenCalledTimes(2));
       await waitFor(() => expect(serverConnStart).toHaveBeenCalledTimes(2));
@@ -555,7 +555,7 @@ describe.each(testMatrix())(
       expect(clientSessStop).toHaveBeenCalledTimes(0);
 
       // bring client side connections down and stop trying to reconnect
-      clientTransport.tryReconnecting = false;
+      clientTransport.reconnectOnConnectionDrop = false;
       clientTransport.connections.forEach((conn) => conn.close());
 
       // buffer some messages
@@ -579,7 +579,7 @@ describe.each(testMatrix())(
       expect(serverTransport.sessions.size).toBe(0);
 
       // eagerly reconnect client
-      clientTransport.tryReconnecting = true;
+      clientTransport.reconnectOnConnectionDrop = true;
       await clientTransport.connect('SERVER');
 
       await waitFor(() => expect(clientConnStart).toHaveBeenCalledTimes(2));

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -639,6 +639,7 @@ export abstract class ClientTransport<
       reconnectPromise = sleep
         .then(() => {
           if (!canProceedWithConnection()) {
+            console.log("hrrrm")
             throw new Error('transport state is no longer open');
           }
         })

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -332,15 +332,13 @@ export abstract class Transport<ConnType extends Connection> {
           )}`,
         );
       } else {
+        const errMsg = `received out-of-order msg (got seq: ${msg.seq}, wanted seq: ${session.nextExpectedSeq})`;
         log?.error(
-          `${this.clientId} -- received out-of-order msg (got: ${
-            msg.seq
-          }, wanted: ${
-            session.nextExpectedSeq
-          }), marking connection as dead: ${JSON.stringify(msg)}`,
+          `${
+            this.clientId
+          } -- ${errMsg}, marking connection as dead: ${JSON.stringify(msg)}`,
         );
-        session.close();
-        this.deleteSession(session);
+        this.protocolError(ProtocolError.MessageOrderingViolated, errMsg);
       }
 
       return;

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -639,7 +639,6 @@ export abstract class ClientTransport<
       reconnectPromise = sleep
         .then(() => {
           if (!canProceedWithConnection()) {
-            console.log('hrrrm');
             throw new Error('transport state is no longer open');
           }
         })

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -639,7 +639,7 @@ export abstract class ClientTransport<
       reconnectPromise = sleep
         .then(() => {
           if (!canProceedWithConnection()) {
-            console.log("hrrrm")
+            console.log('hrrrm');
             throw new Error('transport state is no longer open');
           }
         })


### PR DESCRIPTION
## what changed

- rename `tryReconnecting` on `ClientTransport` to `reconnectOnConnectionDrop` as a more descriptive name
- add a test for 'client reconnects even after session grace'
- unnest `connectionRetryOptions` from `ClientTransport` options
- add `connectOnInvoke` option to handle cases where we want to reconnect after the session grace