### PR TITLE
protocol: handshake on session id instead of instance id, various stability

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1,4 +1,4 @@
-# River protocol `v1`
+# River protocol `v1.1`
 
 ## Abstract
 
@@ -281,8 +281,6 @@ A `Connection` is the actual raw underlying transport connection.
 It is responsible for dispatching to/from the actual connection itself.
 It's lifecycle is tied to the lifecycle of the underlying transport connection (i.e. if the WebSocket drops, this connection should be deleted).
 
-The protocol also defines the concept of an `instanceId`, which is a unique identifier for a specific instantiation of a client or server.
-
 ### Why distinguish between `Transport` and `Session`?
 
 The distinction between `Transport` and `Session` is important because it allows us to have transparent reconnections.
@@ -303,8 +301,8 @@ The process differs slightly between the client and server:
   - If the handshake fails, the `Connection` is closed immediately.
   - Otherwise, consider the handshake successful and proceed to the next step.
   - The client should check for an existing `Session` for the `clientId` associated with the `Connection`.
-    - If an existing `Session` is found, it is verified whether the last `instanceId` associated with the previous `Session` matches the `instanceId` in the handshake response.
-      - A match in `instanceId` means a reconnection to the same session, and that the server still has the state for this session.
+    - If an existing `Session` is found, it is verified whether the last `sessionId` associated with the previous `Session` matches the `sessionId` in the handshake response.
+      - A match in `sessionId` means a reconnection to the same session, and that the server still has the state for this session.
         - The stale `Connection` object associated with the `Session` is closed, and replaced with the new `Connection` object.
         - Any buffered messages are resent.
       - If they do not match, it indicates the server has lost the session state. The old session is removed, its `Connection` object and heartbeat are closed, and processing falls through to the case of not having an associated session.
@@ -343,7 +341,7 @@ The handshake request payload schema is the following:
 type HandshakeRequest = {
   type: 'HANDSHAKE_REQ';
   protocolVersion: string;
-  instanceId: string;
+  sessionId: string;
 };
 ```
 
@@ -355,7 +353,7 @@ type HandshakeResponse = {
   status:
     | {
         ok: true;
-        instanceId: string;
+        sessionId: string;
       }
     | {
         ok: false;

--- a/__tests__/cleanup.test.ts
+++ b/__tests__/cleanup.test.ts
@@ -15,7 +15,7 @@ import {
 } from './fixtures/services';
 import { createClient, createServer } from '../router';
 import {
-  advanceFakeTimersByDisconnectGrace,
+  advanceFakeTimersBySessionGrace,
   ensureTransportBuffersAreEventuallyEmpty,
   testFinishesCleanly,
   waitFor,
@@ -65,7 +65,7 @@ describe.each(testMatrix())(
 
       await waitForTransportToFinish(clientTransport);
       await waitForTransportToFinish(serverTransport);
-      await advanceFakeTimersByDisconnectGrace();
+      await advanceFakeTimersBySessionGrace();
       await ensureTransportBuffersAreEventuallyEmpty(clientTransport);
       await ensureTransportBuffersAreEventuallyEmpty(serverTransport);
     });
@@ -104,7 +104,7 @@ describe.each(testMatrix())(
 
       await waitForTransportToFinish(clientTransport);
       await waitForTransportToFinish(serverTransport);
-      await advanceFakeTimersByDisconnectGrace();
+      await advanceFakeTimersBySessionGrace();
       await ensureTransportBuffersAreEventuallyEmpty(clientTransport);
       await ensureTransportBuffersAreEventuallyEmpty(serverTransport);
     });
@@ -150,7 +150,7 @@ describe.each(testMatrix())(
       vi.useFakeTimers({ shouldAdvanceTime: true });
       await waitForTransportToFinish(clientTransport);
       await waitForTransportToFinish(serverTransport);
-      await advanceFakeTimersByDisconnectGrace();
+      await advanceFakeTimersBySessionGrace();
       await ensureTransportBuffersAreEventuallyEmpty(clientTransport);
       await ensureTransportBuffersAreEventuallyEmpty(serverTransport);
     });
@@ -217,7 +217,7 @@ describe.each(testMatrix())(
       vi.useFakeTimers({ shouldAdvanceTime: true });
       await waitForTransportToFinish(clientTransport);
       await waitForTransportToFinish(serverTransport);
-      await advanceFakeTimersByDisconnectGrace();
+      await advanceFakeTimersBySessionGrace();
       await ensureTransportBuffersAreEventuallyEmpty(clientTransport);
       await ensureTransportBuffersAreEventuallyEmpty(serverTransport);
     });
@@ -276,7 +276,7 @@ describe.each(testMatrix())(
       vi.useFakeTimers({ shouldAdvanceTime: true });
       await waitForTransportToFinish(clientTransport);
       await waitForTransportToFinish(serverTransport);
-      await advanceFakeTimersByDisconnectGrace();
+      await advanceFakeTimersBySessionGrace();
       await ensureTransportBuffersAreEventuallyEmpty(clientTransport);
       await ensureTransportBuffersAreEventuallyEmpty(serverTransport);
 
@@ -335,7 +335,7 @@ describe.each(testMatrix())(
       vi.useFakeTimers({ shouldAdvanceTime: true });
       await waitForTransportToFinish(clientTransport);
       await waitForTransportToFinish(serverTransport);
-      await advanceFakeTimersByDisconnectGrace();
+      await advanceFakeTimersBySessionGrace();
       await ensureTransportBuffersAreEventuallyEmpty(clientTransport);
       await ensureTransportBuffersAreEventuallyEmpty(serverTransport);
     });

--- a/__tests__/disconnects.test.ts
+++ b/__tests__/disconnects.test.ts
@@ -15,7 +15,7 @@ import {
 } from './fixtures/services';
 import { createClient, createServer } from '../router';
 import {
-  advanceFakeTimersByDisconnectGrace,
+  advanceFakeTimersBySessionGrace,
   testFinishesCleanly,
   waitFor,
 } from './fixtures/cleanup';
@@ -59,7 +59,7 @@ describe.each(testMatrix())(
       // end procedure
 
       // after we've disconnected, hit end of grace period
-      await advanceFakeTimersByDisconnectGrace();
+      await advanceFakeTimersBySessionGrace();
 
       // we should get an error + expect the streams to be cleaned up
       await expect(procPromise).resolves.toMatchObject(
@@ -105,7 +105,7 @@ describe.each(testMatrix())(
       // end procedure
 
       // after we've disconnected, hit end of grace period
-      await advanceFakeTimersByDisconnectGrace();
+      await advanceFakeTimersBySessionGrace();
 
       // we should get an error + expect the streams to be cleaned up
       await expect(nextResPromise).resolves.toMatchObject(
@@ -183,7 +183,7 @@ describe.each(testMatrix())(
       const nextResPromise = iterNext(subscription2);
 
       // after we've disconnected, hit end of grace period
-      await advanceFakeTimersByDisconnectGrace();
+      await advanceFakeTimersBySessionGrace();
 
       // we should get an error from the subscription on client2
       await expect(nextResPromise).resolves.toMatchObject(
@@ -242,7 +242,7 @@ describe.each(testMatrix())(
       clientTransport.connections.forEach((conn) => conn.close());
 
       // after we've disconnected, hit end of grace period
-      await advanceFakeTimersByDisconnectGrace();
+      await advanceFakeTimersBySessionGrace();
 
       // we should get an error + expect the streams to be cleaned up
       await expect(addResult).resolves.toMatchObject(

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -22,7 +22,7 @@ import {
 } from './fixtures/services';
 import { UNCAUGHT_ERROR } from '../router/result';
 import {
-  advanceFakeTimersByDisconnectGrace,
+  advanceFakeTimersBySessionGrace,
   testFinishesCleanly,
   waitFor,
 } from './fixtures/cleanup';
@@ -523,7 +523,7 @@ describe.each(testMatrix())(
       vi.useFakeTimers({ shouldAdvanceTime: true });
       clientTransport.reconnectOnConnectionDrop = false;
       clientTransport.connections.forEach((conn) => conn.close());
-      await advanceFakeTimersByDisconnectGrace();
+      await advanceFakeTimersBySessionGrace();
       clientTransport.reconnectOnConnectionDrop = true;
 
       // we should have no connections
@@ -567,7 +567,7 @@ describe.each(testMatrix())(
       vi.useFakeTimers({ shouldAdvanceTime: true });
       clientTransport.reconnectOnConnectionDrop = false;
       clientTransport.connections.forEach((conn) => conn.close());
-      await advanceFakeTimersByDisconnectGrace();
+      await advanceFakeTimersBySessionGrace();
 
       // we should have no connections
       expect(serverTransport.connections.size).toEqual(0);

--- a/__tests__/fixtures/cleanup.ts
+++ b/__tests__/fixtures/cleanup.ts
@@ -28,8 +28,10 @@ export async function advanceFakeTimersByDisconnectGrace() {
       testingSessionOptions.heartbeatIntervalMs + 1,
     );
   }
+}
 
-  // wait for disconnect timer to propagate
+export async function advanceFakeTimersBySessionGrace() {
+  await advanceFakeTimersByDisconnectGrace();
   await vi.runOnlyPendingTimersAsync();
   await vi.advanceTimersByTimeAsync(
     testingSessionOptions.sessionDisconnectGraceMs + 1,
@@ -114,20 +116,20 @@ export async function testFinishesCleanly({
 
   if (clientTransports) {
     await Promise.all(clientTransports.map(waitForTransportToFinish));
-    await advanceFakeTimersByDisconnectGrace();
+    await advanceFakeTimersBySessionGrace();
     await Promise.all(clientTransports.map(ensureTransportIsClean));
   }
 
   // server sits on top of server transport so we clean it up first
   if (server) {
-    await advanceFakeTimersByDisconnectGrace();
+    await advanceFakeTimersBySessionGrace();
     await ensureServerIsClean(server);
     await server.close();
   }
 
   if (serverTransport) {
     await waitForTransportToFinish(serverTransport);
-    await advanceFakeTimersByDisconnectGrace();
+    await advanceFakeTimersBySessionGrace();
     await ensureTransportIsClean(serverTransport);
   }
 

--- a/__tests__/fixtures/transports.ts
+++ b/__tests__/fixtures/transports.ts
@@ -19,7 +19,7 @@ import { ProvidedTransportOptions } from '../../transport/transport';
 import { WebSocketClientTransport } from '../../transport/impls/ws/client';
 import { WebSocketServerTransport } from '../../transport/impls/ws/server';
 
-export type ValidTransports = 'ws' | 'unix sockets' | 'node streams';
+export type ValidTransports = 'ws' | 'unix sockets';
 export const transports: Array<{
   name: ValidTransports;
   setup: (opts?: ProvidedTransportOptions) => Promise<{

--- a/__tests__/negative.test.ts
+++ b/__tests__/negative.test.ts
@@ -183,7 +183,7 @@ describe('should handle incompatabilities', async () => {
 
     const ws = createLocalWebSocketClient(port);
     await new Promise((resolve) => ws.on('open', resolve));
-    const requestMsg = handshakeRequestMessage('client', 'SERVER', 'instance1');
+    const requestMsg = handshakeRequestMessage('client', 'SERVER', 'sessionId');
     ws.send(NaiveJsonCodec.toBuffer(requestMsg));
 
     // wait for both sides to be happy
@@ -236,7 +236,6 @@ describe('should handle incompatabilities', async () => {
     const ws = createLocalWebSocketClient(port);
     await new Promise((resolve) => ws.on('open', resolve));
 
-    const clientInstanceId = nanoid();
     const requestMsg = {
       id: nanoid(),
       from: 'client',
@@ -248,7 +247,7 @@ describe('should handle incompatabilities', async () => {
       payload: {
         type: 'HANDSHAKE_REQ',
         protocolVersion: 'v0',
-        instanceId: clientInstanceId,
+        sessionId: 'sessionId',
       } satisfies Static<typeof ControlMessageHandshakeRequestSchema>,
     };
     ws.send(NaiveJsonCodec.toBuffer(requestMsg));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.16.2",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "type": "module",
   "exports": {
     ".": {

--- a/transport/message.test.ts
+++ b/transport/message.test.ts
@@ -58,16 +58,22 @@ describe('message helpers', () => {
   });
 
   test('handshakeRequestMessage', () => {
-    const m = handshakeRequestMessage('a', 'b', 'abc');
+    const m = handshakeRequestMessage('a', 'b', 'sess');
 
     expect(m.from).toBe('a');
     expect(m.to).toBe('b');
-    expect(m.payload.instanceId).toBe('abc');
+    expect(m.payload.sessionId).toBe('sess');
   });
 
   test('handshakeResponseMessage', () => {
-    const mSuccess = handshakeResponseMessage('a', '001', 'b', true);
-    const mFail = handshakeResponseMessage('a', '001', 'b', false);
+    const mSuccess = handshakeResponseMessage('a', 'b', {
+      ok: true,
+      sessionId: 'sess',
+    });
+    const mFail = handshakeResponseMessage('a', 'b', {
+      ok: false,
+      reason: 'bad',
+    });
 
     expect(mSuccess.from).toBe('a');
     expect(mSuccess.to).toBe('b');

--- a/transport/session.ts
+++ b/transport/session.ts
@@ -247,8 +247,18 @@ export class Session<ConnType extends Connection> {
   }
 
   updateBookkeeping(ack: number, seq: number) {
+    if (ack < this.ack) {
+      log?.error(`${this.from} -- received stale ack ${ack} < ${this.ack}`);
+      return;
+    }
+
+    if (seq < this.ack) {
+      log?.error(`${this.from} -- received stale seq ${seq} < ${this.seq}`);
+      return;
+    }
+
     this.sendBuffer = this.sendBuffer.filter((unacked) => unacked.seq > ack);
-    this.ack = Math.max(seq + 1, this.ack);
+    this.ack = seq + 1;
   }
 
   closeStaleConnection(conn?: ConnType) {

--- a/transport/session.ts
+++ b/transport/session.ts
@@ -252,7 +252,7 @@ export class Session<ConnType extends Connection> {
       return;
     }
 
-    if (seq < this.ack) {
+    if (seq < this.seq) {
       log?.error(`${this.from} -- received stale seq ${seq} < ${this.seq}`);
       return;
     }

--- a/transport/session.ts
+++ b/transport/session.ts
@@ -114,15 +114,25 @@ export class Session<ConnType extends Connection> {
   /**
    * The unique ID of this session.
    */
-  debugId: string;
+  id: string;
 
   /**
-   * Number of messages we've sent along this session (excluding handshake and acks)
+   * What the other side advertised as their session ID
+   * for this session.
+   */
+  advertisedSessionId?: string;
+
+  /**
+   * Number of messages we've sent along this session.
+   * Starts at one due to the handshake message.
+   * This excludes acks.
    */
   private seq: SequenceNumber = 0;
 
   /**
-   * Number of unique messages we've received this session (excluding handshake and acks)
+   * Number of unique messages we've received this session.
+   * Starts at one due to the handshake message.
+   * This excludes acks.
    */
   private ack: SequenceNumber = 0;
 
@@ -140,18 +150,18 @@ export class Session<ConnType extends Connection> {
   /**
    * The interval for sending heartbeats.
    */
-  private heartbeat?: ReturnType<typeof setInterval>;
+  private heartbeat: ReturnType<typeof setInterval>;
 
   constructor(
-    from: TransportClientId,
-    connectedTo: TransportClientId,
     conn: ConnType | undefined,
+    from: TransportClientId,
+    to: TransportClientId,
     options: SessionOptions,
   ) {
+    this.id = `session-${nanoid(12)}`;
     this.options = options;
-    this.debugId = `sess-${unsafeId()}`; // for debugging, no collision safety needed
     this.from = from;
-    this.to = connectedTo;
+    this.to = to;
     this.connection = conn;
     this.codec = options.codec;
 
@@ -196,12 +206,11 @@ export class Session<ConnType extends Connection> {
         log?.info(
           `${this.from} -- closing connection (id: ${this.connection.debugId}) to ${this.to} due to inactivity`,
         );
-        this.closeStaleConnection(this.connection);
+        this.closeStaleConnection();
       }
       return;
     }
 
-    // don't send heartbeat if we don't have a connection
     this.send({
       streamId: 'heartbeat',
       controlFlags: ControlFlags.AckBit,
@@ -234,7 +243,7 @@ export class Session<ConnType extends Connection> {
       if (!ok) {
         // this should never happen unless the transport has an
         // incorrect implementation of `createNewOutgoingConnection`
-        const msg = `${this.from} -- failed to send buffered message to ${this.to} in session (id: ${this.debugId}) (if you hit this code path something is seriously wrong)`;
+        const msg = `${this.from} -- failed to send buffered message to ${this.to} in session (id: ${this.id}) (if you hit this code path something is seriously wrong)`;
         log?.error(msg);
         throw new Error(msg);
       }
@@ -243,27 +252,27 @@ export class Session<ConnType extends Connection> {
 
   updateBookkeeping(ack: number, seq: number) {
     this.sendBuffer = this.sendBuffer.filter((unacked) => unacked.seq > ack);
-    this.ack = seq + 1;
+    this.ack = Math.max(seq + 1, this.ack);
   }
 
   closeStaleConnection(conn?: ConnType) {
-    if (!this.connection || this.connection !== conn) return;
+    if (this.connection === undefined || this.connection === conn) return;
     log?.info(
-      `${this.from} -- closing old inner connection (id: ${this.connection.debugId}) from session (id: ${this.debugId}) to ${this.to}`,
+      `${this.from} -- closing old inner connection (id: ${this.connection.debugId}) from session (id: ${this.id}) to ${this.to}`,
     );
     this.connection.close();
     this.connection = undefined;
   }
 
   replaceWithNewConnection(newConn: ConnType) {
-    this.closeStaleConnection(this.connection);
+    this.closeStaleConnection(newConn);
     this.cancelGrace();
     this.connection = newConn;
   }
 
   beginGrace(cb: () => void) {
     log?.info(
-      `${this.from} -- starting ${this.options.sessionDisconnectGraceMs}ms grace period until session (id: ${this.debugId}) to ${this.to} is closed`,
+      `${this.from} -- starting ${this.options.sessionDisconnectGraceMs}ms grace period until session (id: ${this.id}) to ${this.to} is closed`,
     );
     this.disconnectionGrace = setTimeout(() => {
       this.close();
@@ -275,12 +284,13 @@ export class Session<ConnType extends Connection> {
   cancelGrace() {
     this.heartbeatMisses = 0;
     clearTimeout(this.disconnectionGrace);
+    this.disconnectionGrace = undefined;
   }
 
   // closed when we want to discard the whole session
   // (i.e. shutdown or session disconnect)
   close() {
-    this.closeStaleConnection(this.connection);
+    this.closeStaleConnection();
     this.cancelGrace();
     this.resetBufferedMessages();
     clearInterval(this.heartbeat);

--- a/transport/session.ts
+++ b/transport/session.ts
@@ -247,13 +247,8 @@ export class Session<ConnType extends Connection> {
   }
 
   updateBookkeeping(ack: number, seq: number) {
-    if (ack < this.ack) {
-      log?.error(`${this.from} -- received stale ack ${ack} < ${this.ack}`);
-      return;
-    }
-
-    if (seq < this.seq) {
-      log?.error(`${this.from} -- received stale seq ${seq} < ${this.seq}`);
+    if (seq + 1 < this.ack) {
+      log?.error(`${this.from} -- received stale seq ${seq} + 1 < ${this.ack}`);
       return;
     }
 

--- a/transport/session.ts
+++ b/transport/session.ts
@@ -123,16 +123,12 @@ export class Session<ConnType extends Connection> {
   advertisedSessionId?: string;
 
   /**
-   * Number of messages we've sent along this session.
-   * Starts at one due to the handshake message.
-   * This excludes acks.
+   * Number of messages we've sent along this session (excluding handshake and acks)
    */
   private seq: SequenceNumber = 0;
 
   /**
-   * Number of unique messages we've received this session.
-   * Starts at one due to the handshake message.
-   * This excludes acks.
+   * Number of unique messages we've received this session (excluding handshake and acks)
    */
   private ack: SequenceNumber = 0;
 

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../util/testHelpers';
 import { EventMap } from '../transport/events';
 import {
-  advanceFakeTimersByDisconnectGrace,
+  advanceFakeTimersBySessionGrace,
   testFinishesCleanly,
   waitFor,
 } from '../__tests__/fixtures/cleanup';
@@ -318,7 +318,7 @@ describe.each(testMatrix())(
       await waitFor(() => expect(clientConnStop).toHaveBeenCalledTimes(2));
       await waitFor(() => expect(serverConnStop).toHaveBeenCalledTimes(2));
 
-      await advanceFakeTimersByDisconnectGrace();
+      await advanceFakeTimersBySessionGrace();
       await waitFor(() => expect(clientSessStart).toHaveBeenCalledTimes(1));
       await waitFor(() => expect(serverSessStart).toHaveBeenCalledTimes(1));
       await waitFor(() => expect(clientSessStop).toHaveBeenCalledTimes(1));

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -180,7 +180,7 @@ export abstract class Transport<ConnType extends Connection> {
       conn,
     });
 
-    // check if the peer we are connected to is actually different by comparing instanceId
+    // check if the peer we are connected to is actually different by comparing session id
     let oldSession = this.sessions.get(connectedTo);
     if (
       oldSession?.advertisedSessionId &&

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -24,7 +24,6 @@ import {
 } from './events';
 import { Connection, Session, SessionOptions } from './session';
 import { Static } from '@sinclair/typebox';
-import { nanoid } from 'nanoid';
 import { coerceErrorString } from '../util/stringify';
 import { ConnectionRetryOptions, LeakyBucketRateLimit } from './rateLimit';
 import { NaiveJsonCodec } from '../codec';
@@ -39,7 +38,7 @@ export type TransportStatus = 'open' | 'closed' | 'destroyed';
 
 type TransportOptions = SessionOptions;
 export type ProvidedTransportOptions = Partial<TransportOptions>;
-const defaultTransportOptions: TransportOptions = {
+export const defaultTransportOptions: TransportOptions = {
   heartbeatIntervalMs: 1_000,
   heartbeatsUntilDead: 2,
   sessionDisconnectGraceMs: 5_000,
@@ -93,14 +92,6 @@ const defaultClientTransportOptions: ClientTransportOptions = {
  * @abstract
  */
 export abstract class Transport<ConnType extends Connection> {
-  /**
-   * Unique per instance of the transport.
-   * This allows us to distinguish reconnects to different
-   * transports.
-   */
-  instanceId: string = nanoid();
-  connectedInstanceIds = new Map<TransportClientId, string>();
-
   /**
    * A flag indicating whether the transport has been destroyed.
    * A destroyed transport will not attempt to reconnect and cannot be used again.
@@ -182,7 +173,7 @@ export abstract class Transport<ConnType extends Connection> {
   protected onConnect(
     conn: ConnType,
     connectedTo: TransportClientId,
-    instanceId: string,
+    advertisedSessionId: string,
   ): Session<ConnType> {
     this.eventDispatcher.dispatchEvent('connectionStatus', {
       status: 'connect',
@@ -191,50 +182,46 @@ export abstract class Transport<ConnType extends Connection> {
 
     // check if the peer we are connected to is actually different by comparing instanceId
     let oldSession = this.sessions.get(connectedTo);
-    const lastInstanceId = this.connectedInstanceIds.get(connectedTo);
     if (
-      oldSession &&
-      lastInstanceId !== undefined &&
-      lastInstanceId !== instanceId
+      oldSession?.advertisedSessionId &&
+      oldSession.advertisedSessionId !== advertisedSessionId
     ) {
       // mismatch, kill the old session and begin a new one
       log?.warn(
-        `${this.clientId} -- connection from ${connectedTo} is a different instance (got: ${instanceId}, last connected to: ${lastInstanceId}), starting a new session`,
+        `${this.clientId} -- connection from ${connectedTo} is a different session (id: ${advertisedSessionId}, last connected to: ${oldSession.advertisedSessionId}), starting a new session`,
       );
       oldSession.close();
       this.deleteSession(oldSession);
       oldSession = undefined;
     }
-    this.connectedInstanceIds.set(connectedTo, instanceId);
 
     // if we don't have an existing session, create a new one and return it
     if (oldSession === undefined) {
       const newSession = this.createSession(connectedTo, conn);
+      newSession.advertisedSessionId = advertisedSessionId;
       log?.info(
-        `${this.clientId} -- new connection (id: ${conn.debugId}) for new session (id: ${newSession.debugId}) to ${connectedTo}`,
+        `${this.clientId} -- new connection (id: ${conn.debugId}) for new session (id: ${newSession.id}) to ${connectedTo}`,
       );
       return newSession;
     }
 
     log?.info(
-      `${this.clientId} -- new connection (id: ${conn.debugId}) for existing session (id: ${oldSession.debugId}) to ${connectedTo}`,
+      `${this.clientId} -- new connection (id: ${conn.debugId}) for existing session (id: ${oldSession.id}) to ${connectedTo}`,
     );
 
     // otherwise, this is a new connection from the same user, let's consider
     // the old one as dead and call this connection canonical
     oldSession.replaceWithNewConnection(conn);
     oldSession.sendBufferedMessages();
+    oldSession.advertisedSessionId = advertisedSessionId;
     return oldSession;
   }
 
-  private createSession(
-    connectedTo: TransportClientId,
-    conn: ConnType | undefined,
-  ) {
+  protected createSession(to: TransportClientId, conn?: ConnType) {
     const session = new Session<ConnType>(
-      this.clientId,
-      connectedTo,
       conn,
+      this.clientId,
+      to,
       this.options,
     );
     this.sessions.set(session.to, session);
@@ -245,10 +232,22 @@ export abstract class Transport<ConnType extends Connection> {
     return session;
   }
 
+  protected getOrCreateSession(to: TransportClientId, conn?: ConnType) {
+    let session = this.sessions.get(to);
+    if (!session) {
+      session = this.createSession(to, conn);
+      log?.info(
+        `${this.clientId} -- no session for ${to}, created a new one (id: ${session.id})`,
+      );
+    }
+
+    return session;
+  }
+
   protected deleteSession(session: Session<ConnType>) {
     this.sessions.delete(session.to);
     log?.info(
-      `${this.clientId} -- session ${session.debugId} disconnect from ${session.to}`,
+      `${this.clientId} -- session ${session.id} disconnect from ${session.to}`,
     );
     this.eventDispatcher.dispatchEvent('sessionStatus', {
       status: 'disconnect',
@@ -331,9 +330,12 @@ export abstract class Transport<ConnType extends Connection> {
         log?.error(
           `${
             this.clientId
-          } -- ${errMsg}, marking connection as dead: ${JSON.stringify(msg)}`,
+          } -- fatal: ${errMsg}, marking connection as dead: ${JSON.stringify(
+            msg,
+          )}`,
         );
         this.protocolError(ProtocolError.MessageOrderingViolated, errMsg);
+        session.close();
       }
 
       return;
@@ -399,18 +401,7 @@ export abstract class Transport<ConnType extends Connection> {
       return undefined;
     }
 
-    let session = this.sessions.get(to);
-    if (!session) {
-      // this case happens on the client as .send()
-      // can be called without a session existing so we
-      // must create the session here
-      session = this.createSession(to, undefined);
-      log?.info(
-        `${this.clientId} -- no session for ${to}, created a new one (id: ${session.debugId})`,
-      );
-    }
-
-    return session.send(msg);
+    return this.getOrCreateSession(to).send(msg);
   }
 
   // control helpers
@@ -498,13 +489,13 @@ export abstract class ClientTransport<
     if (this.state !== 'open') return;
     let session: Session<ConnType> | undefined = undefined;
     const handshakeHandler = (data: Uint8Array) => {
-      const handshake = this.receiveHandshakeResponseMessage(data);
-      if (!handshake) {
+      const maybeSession = this.receiveHandshakeResponseMessage(data, conn);
+      if (!maybeSession) {
         conn.close();
         return;
+      } else {
+        session = maybeSession;
       }
-
-      session = this.onConnect(conn, handshake.from, handshake.instanceId);
 
       // when we are done handshake sequence,
       // remove handshake listener and use the normal message listener
@@ -542,7 +533,10 @@ export abstract class ClientTransport<
     });
   }
 
-  receiveHandshakeResponseMessage(data: Uint8Array) {
+  receiveHandshakeResponseMessage(
+    data: Uint8Array,
+    conn: ConnType,
+  ): Session<ConnType> | false {
     const parsed = this.parseMsg(data);
     if (!parsed) {
       this.protocolError(
@@ -578,16 +572,18 @@ export abstract class ClientTransport<
       return false;
     }
 
-    const instanceId = parsed.payload.status.instanceId;
-    log?.debug(
-      `${this.clientId} -- handshake from ${parsed.from} ok (instance: ${instanceId})`,
+    log?.debug(`${this.clientId} -- handshake from ${parsed.from} ok`);
+    const session = this.onConnect(
+      conn,
+      parsed.from,
+      parsed.payload.status.sessionId,
     );
 
     // After a successful connection, we start restoring the budget
     // so that the next time we try to connect, we don't hit the client
     // with backoff forever.
     this.retryBudget.startRestoringBudget(parsed.from);
-    return { instanceId, from: parsed.from };
+    return session;
   }
 
   /**
@@ -682,11 +678,8 @@ export abstract class ClientTransport<
   }
 
   protected sendHandshake(to: TransportClientId, conn: ConnType) {
-    const requestMsg = handshakeRequestMessage(
-      this.clientId,
-      to,
-      this.instanceId,
-    );
+    const session = this.getOrCreateSession(to, conn);
+    const requestMsg = handshakeRequestMessage(this.clientId, to, session.id);
     log?.debug(`${this.clientId} -- sending handshake request to ${to}`);
     conn.send(this.codec.toBuffer(requestMsg));
   }
@@ -706,7 +699,7 @@ export abstract class ServerTransport<
   ) {
     super(clientId, providedOptions);
     log?.info(
-      `${this.clientId} -- initiated server transport (instance id: ${this.instanceId}, protocol: ${PROTOCOL_VERSION})`,
+      `${this.clientId} -- initiated server transport (protocol: ${PROTOCOL_VERSION})`,
     );
   }
 
@@ -719,13 +712,13 @@ export abstract class ServerTransport<
     let session: Session<ConnType> | undefined = undefined;
     const client = () => session?.to ?? 'unknown';
     const handshakeHandler = (data: Uint8Array) => {
-      const handshake = this.receiveHandshakeRequestMessage(data, conn);
-      if (!handshake) {
+      const maybeSession = this.receiveHandshakeRequestMessage(data, conn);
+      if (!maybeSession) {
         conn.close();
         return;
+      } else {
+        session = maybeSession;
       }
-
-      session = this.onConnect(conn, handshake.from, handshake.instanceId);
 
       // when we are done handshake sequence,
       // remove handshake listener and use the normal message listener
@@ -762,7 +755,10 @@ export abstract class ServerTransport<
     });
   }
 
-  receiveHandshakeRequestMessage(data: Uint8Array, conn: ConnType) {
+  receiveHandshakeRequestMessage(
+    data: Uint8Array,
+    conn: ConnType,
+  ): Session<ConnType> | false {
     const parsed = this.parseMsg(data);
     if (!parsed) {
       this.protocolError(
@@ -773,18 +769,13 @@ export abstract class ServerTransport<
     }
 
     if (!Value.Check(ControlMessageHandshakeRequestSchema, parsed.payload)) {
-      const responseMsg = handshakeResponseMessage(
-        this.clientId,
-        this.instanceId,
-        parsed.from,
-        false,
-      );
+      const reason = 'received invalid handshake msg';
+      const responseMsg = handshakeResponseMessage(this.clientId, parsed.from, {
+        ok: false,
+        reason,
+      });
       conn.send(this.codec.toBuffer(responseMsg));
-      log?.warn(
-        `${this.clientId} -- received invalid handshake msg: ${JSON.stringify(
-          parsed,
-        )}`,
-      );
+      log?.warn(`${this.clientId} -- ${reason}: ${JSON.stringify(parsed)}`);
       this.protocolError(
         ProtocolError.HandshakeFailed,
         'invalid handshake request',
@@ -795,34 +786,28 @@ export abstract class ServerTransport<
     // double check protocol version here
     const gotVersion = parsed.payload.protocolVersion;
     if (gotVersion !== PROTOCOL_VERSION) {
-      const responseMsg = handshakeResponseMessage(
-        this.clientId,
-        this.instanceId,
-        parsed.from,
-        false,
-      );
+      const reason = `incorrect version (got: ${gotVersion} wanted ${PROTOCOL_VERSION})`;
+      const responseMsg = handshakeResponseMessage(this.clientId, parsed.from, {
+        ok: false,
+        reason,
+      });
       conn.send(this.codec.toBuffer(responseMsg));
       log?.warn(
         `${this.clientId} -- received handshake msg with incompatible protocol version (got: ${gotVersion}, expected: ${PROTOCOL_VERSION})`,
       );
-      this.protocolError(
-        ProtocolError.HandshakeFailed,
-        `incorrect version (got: ${gotVersion} wanted ${PROTOCOL_VERSION})`,
-      );
+      this.protocolError(ProtocolError.HandshakeFailed, reason);
       return false;
     }
 
-    const instanceId = parsed.payload.instanceId;
+    const session = this.getOrCreateSession(parsed.from, conn);
     log?.debug(
-      `${this.clientId} -- handshake from ${parsed.from} ok (instance id: ${instanceId}), responding with handshake success`,
+      `${this.clientId} -- handshake from ${parsed.from} ok, responding with handshake success`,
     );
-    const responseMsg = handshakeResponseMessage(
-      this.clientId,
-      this.instanceId,
-      parsed.from,
-      true,
-    );
+    const responseMsg = handshakeResponseMessage(this.clientId, parsed.from, {
+      ok: true,
+      sessionId: session.id,
+    });
     conn.send(this.codec.toBuffer(responseMsg));
-    return { instanceId, from: parsed.from };
+    return this.onConnect(conn, parsed.from, parsed.payload.sessionId);
   }
 }

--- a/util/testHelpers.ts
+++ b/util/testHelpers.ts
@@ -23,7 +23,8 @@ import { nanoid } from 'nanoid';
 import net from 'node:net';
 import { PartialTransportMessage } from '../transport/message';
 import { coerceErrorString } from './stringify';
-import { NaiveJsonCodec } from '../codec';
+import { SessionOptions } from '../transport/session';
+import { defaultTransportOptions } from '../transport/transport';
 
 /**
  * Creates a WebSocket server instance using the provided HTTP server.
@@ -143,21 +144,16 @@ function catchProcError(err: unknown) {
   };
 }
 
-export const testingSessionOptions = {
-  heartbeatIntervalMs: 1_000,
-  heartbeatsUntilDead: 2,
-  sessionDisconnectGraceMs: 5_000,
-  codec: NaiveJsonCodec,
-};
+export const testingSessionOptions: SessionOptions = defaultTransportOptions;
 
 function dummyCtx<State>(
   state: State,
   extendedContext?: Omit<ServiceContext, 'state'>,
 ): ServiceContextWithTransportInfo<State> {
   const session = new Session<Connection>(
+    undefined,
     'client',
     'SERVER',
-    undefined,
     testingSessionOptions,
   );
 


### PR DESCRIPTION
- instance id was the wrong abstraction to determine whether the peer you are connected to still remembers your session
  - this caused out of sync errors where we could
    - client network disconnect, server&client in grace period
    - client grace period ended, close the session
    - client network reconnected, it established a new ws
    - server get client new ws request, still in grace period, reuse the old session
    - server will be on an old session and try to resend and the client will be like 'wtf' because its on a new session
- seems obvious now in hindsight but we should just send the actual session id in the handshake and if the session id is different from the last time we connected, we should discard the session and make a new one