### PR TITLE
Force description types

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
+.cache
 node_modules

--- a/__tests__/fixtures/services.ts
+++ b/__tests__/fixtures/services.ts
@@ -39,6 +39,7 @@ const testServiceProcedures = TestServiceScaffold.procedures({
   }),
 
   echo: Procedure.stream({
+    description: 'Streams an echo back',
     input: EchoRequest,
     output: EchoResponse,
     async handler(_ctx, msgStream, returnStream) {
@@ -55,6 +56,7 @@ const testServiceProcedures = TestServiceScaffold.procedures({
   }),
 
   echoWithPrefix: Procedure.stream({
+    description: 'Streams an echo back',
     init: Type.Object(
       { prefix: Type.String({ description: 'A prefix' }) },
       { description: 'An init object' },
@@ -66,6 +68,37 @@ const testServiceProcedures = TestServiceScaffold.procedures({
         if (!ignore) {
           returnStream.push(Ok({ response: `${init.prefix} ${msg}` }));
         }
+      }
+    },
+  }),
+
+  echoUnion: Procedure.rpc({
+    description: 'Echos back whatever we sent',
+    input: Type.Union([
+      Type.Object(
+        { a: Type.Number({ description: 'A number' }) },
+        { description: 'A' },
+      ),
+      Type.Object(
+        { b: Type.String({ description: 'A string' }) },
+        { description: 'B' },
+      ),
+    ]),
+    output: Type.Union([
+      Type.Object(
+        { a: Type.Number({ description: 'A number' }) },
+        { description: 'A' },
+      ),
+      Type.Object(
+        { b: Type.String({ description: 'A string' }) },
+        { description: 'B' },
+      ),
+    ]),
+    async handler(_, i) {
+      if ('a' in i) {
+        return Ok({ a: i.a });
+      } else {
+        return Ok({ b: i.b });
       }
     },
   }),
@@ -135,7 +168,7 @@ export const STREAM_ERROR = 'STREAM_ERROR';
 
 export const FallibleServiceSchema = ServiceSchema.define({
   divide: Procedure.rpc({
-    /* description: Get the probability of rain for a specific location */
+    description: 'Divide one number by another number',
     input: Type.Object(
       {
         a: Type.Number({ description: 'A number' }),
@@ -174,6 +207,7 @@ export const FallibleServiceSchema = ServiceSchema.define({
   }),
 
   echo: Procedure.stream({
+    description: 'Streams an echo back',
     input: Type.Object(
       {
         msg: Type.String({ description: 'The message' }),
@@ -232,6 +266,7 @@ export const SubscribableServiceSchema = ServiceSchema.define(
     }),
 
     value: Procedure.subscription({
+      description: 'Subscribes to a count',
       input: Type.Object({}, { description: 'An input object' }),
       output: Type.Object(
         { result: Type.Number({ description: 'A result' }) },
@@ -248,6 +283,7 @@ export const SubscribableServiceSchema = ServiceSchema.define(
 
 export const UploadableServiceSchema = ServiceSchema.define({
   addMultiple: Procedure.upload({
+    description: 'Add multiple values over time',
     input: Type.Object(
       { n: Type.Number({ description: 'A number' }) },
       { description: 'An input object' },

--- a/__tests__/serialize.test.ts
+++ b/__tests__/serialize.test.ts
@@ -10,17 +10,20 @@ describe('serialize service to jsonschema', () => {
     expect(TestServiceSchema.serialize()).toStrictEqual({
       procedures: {
         add: {
+          description: 'Adds two numbers and returns a value',
           input: {
             properties: {
-              n: { type: 'number' },
+              n: { description: 'A number', type: 'number' },
             },
+            description: 'An input object',
             required: ['n'],
             type: 'object',
           },
           output: {
             properties: {
-              result: { type: 'number' },
+              result: { description: 'A number', type: 'number' },
             },
+            description: 'An output object',
             required: ['result'],
             type: 'object',
           },
@@ -30,18 +33,21 @@ describe('serialize service to jsonschema', () => {
           type: 'rpc',
         },
         echo: {
+          description: 'Streams an echo back',
           input: {
+            description: 'A request that echos',
             properties: {
-              msg: { type: 'string' },
-              ignore: { type: 'boolean' },
-              end: { type: 'boolean' },
+              msg: { description: 'A string', type: 'string' },
+              ignore: { description: 'A boolean', type: 'boolean' },
+              end: { description: 'A boolean', type: 'boolean' },
             },
             required: ['msg', 'ignore'],
             type: 'object',
           },
           output: {
+            description: 'A response from an echo',
             properties: {
-              response: { type: 'string' },
+              response: { description: 'A string', type: 'string' },
             },
             required: ['response'],
             type: 'object',
@@ -52,12 +58,15 @@ describe('serialize service to jsonschema', () => {
           type: 'stream',
         },
         echoWithPrefix: {
+          description: 'Streams an echo back',
           errors: {
             not: {},
           },
           init: {
+            description: 'An init object',
             properties: {
               prefix: {
+                description: 'A prefix',
                 type: 'string',
               },
             },
@@ -65,14 +74,18 @@ describe('serialize service to jsonschema', () => {
             type: 'object',
           },
           input: {
+            description: 'A request that echos',
             properties: {
               end: {
+                description: 'A boolean',
                 type: 'boolean',
               },
               ignore: {
+                description: 'A boolean',
                 type: 'boolean',
               },
               msg: {
+                description: 'A string',
                 type: 'string',
               },
             },
@@ -80,8 +93,10 @@ describe('serialize service to jsonschema', () => {
             type: 'object',
           },
           output: {
+            description: 'A response from an echo',
             properties: {
               response: {
+                description: 'A string',
                 type: 'string',
               },
             },
@@ -89,6 +104,65 @@ describe('serialize service to jsonschema', () => {
             type: 'object',
           },
           type: 'stream',
+        },
+        echoUnion: {
+          description: 'Echos back whatever we sent',
+          errors: {
+            not: {},
+          },
+          input: {
+            anyOf: [
+              {
+                description: 'A',
+                properties: {
+                  a: {
+                    description: 'A number',
+                    type: 'number',
+                  },
+                },
+                required: ['a'],
+                type: 'object',
+              },
+              {
+                description: 'B',
+                properties: {
+                  b: {
+                    description: 'A string',
+                    type: 'string',
+                  },
+                },
+                required: ['b'],
+                type: 'object',
+              },
+            ],
+          },
+          output: {
+            anyOf: [
+              {
+                description: 'A',
+                properties: {
+                  a: {
+                    description: 'A number',
+                    type: 'number',
+                  },
+                },
+                required: ['a'],
+                type: 'object',
+              },
+              {
+                description: 'B',
+                properties: {
+                  b: {
+                    description: 'A string',
+                    type: 'string',
+                  },
+                },
+                required: ['b'],
+                type: 'object',
+              },
+            ],
+          },
+          type: 'rpc',
         },
       },
     });
@@ -98,12 +172,15 @@ describe('serialize service to jsonschema', () => {
     expect(BinaryFileServiceSchema.serialize()).toStrictEqual({
       procedures: {
         getFile: {
+          description: 'Retrieves a file from a path',
           errors: {
             not: {},
           },
           input: {
+            description: 'An input object',
             properties: {
               file: {
+                description: 'A file path',
                 type: 'string',
               },
             },
@@ -111,8 +188,10 @@ describe('serialize service to jsonschema', () => {
             type: 'object',
           },
           output: {
+            description: 'An output object',
             properties: {
               contents: {
+                description: 'File contents',
                 type: 'Uint8Array',
               },
             },
@@ -129,28 +208,38 @@ describe('serialize service to jsonschema', () => {
     expect(FallibleServiceSchema.serialize()).toStrictEqual({
       procedures: {
         divide: {
+          description: 'Divide one number by another number',
           input: {
+            description: 'An input object',
             properties: {
-              a: { type: 'number' },
-              b: { type: 'number' },
+              a: { description: 'A number', type: 'number' },
+              b: { description: 'A number', type: 'number' },
             },
             required: ['a', 'b'],
             type: 'object',
           },
           output: {
+            description: 'An output object',
             properties: {
-              result: { type: 'number' },
+              result: { description: 'A result', type: 'number' },
             },
             required: ['result'],
             type: 'object',
           },
           errors: {
+            description: 'An error object',
             properties: {
-              code: { const: 'DIV_BY_ZERO', type: 'string' },
-              message: { type: 'string' },
+              code: {
+                description: 'A literal',
+                const: 'DIV_BY_ZERO',
+                type: 'string',
+              },
+              message: { description: 'A message', type: 'string' },
               extras: {
+                description: 'A set of extras',
                 properties: {
                   test: {
+                    description: 'A test string',
                     type: 'string',
                   },
                 },
@@ -164,39 +253,34 @@ describe('serialize service to jsonschema', () => {
           type: 'rpc',
         },
         echo: {
+          description: 'Streams an echo back',
           errors: {
+            description: 'An error',
             properties: {
               code: {
                 const: 'STREAM_ERROR',
+                description: 'A literal code',
                 type: 'string',
               },
-              message: {
-                type: 'string',
-              },
+              message: { description: 'A message', type: 'string' },
             },
             required: ['code', 'message'],
             type: 'object',
           },
           input: {
+            description: 'An input',
             properties: {
-              msg: {
-                type: 'string',
-              },
-              throwError: {
-                type: 'boolean',
-              },
-              throwResult: {
-                type: 'boolean',
-              },
+              msg: { description: 'The message', type: 'string' },
+              throwError: { description: 'Throw on error', type: 'boolean' },
+              throwResult: { description: 'Throw on result', type: 'boolean' },
             },
             required: ['msg', 'throwResult', 'throwError'],
             type: 'object',
           },
           output: {
+            description: 'An output',
             properties: {
-              response: {
-                type: 'string',
-              },
+              response: { description: 'A response', type: 'string' },
             },
             required: ['response'],
             type: 'object',

--- a/__tests__/typescript-stress.test.ts
+++ b/__tests__/typescript-stress.test.ts
@@ -1,27 +1,47 @@
 import { describe, expect, test } from 'vitest';
 import { Procedure } from '../router/procedures';
 import { ServiceSchema } from '../router/services';
-import { Type } from '@sinclair/typebox';
 import { createServer } from '../router/server';
 import { Connection, ClientTransport, ServerTransport } from '../transport';
 import { createClient } from '../router/client';
 import { Ok } from '../router/result';
 import { TestServiceSchema } from './fixtures/services';
+import { Type } from '../types';
 
 const input = Type.Union([
-  Type.Object({ a: Type.Number() }),
-  Type.Object({ c: Type.String() }),
+  Type.Object(
+    { a: Type.Number({ description: 'A number' }) },
+    { description: 'One type' },
+  ),
+  Type.Object(
+    { c: Type.String({ description: 'A string' }) },
+    { description: 'Another type' },
+  ),
 ]);
-const output = Type.Object({ b: Type.Union([Type.Number(), Type.String()]) });
+const output = Type.Object(
+  {
+    b: Type.Union([
+      Type.Number({ description: 'A number' }),
+      Type.String({ description: 'A string' }),
+    ]),
+  },
+  { description: 'An output type' },
+);
 const errors = Type.Union([
-  Type.Object({
-    code: Type.Literal('ERROR1'),
-    message: Type.String(),
-  }),
-  Type.Object({
-    code: Type.Literal('ERROR2'),
-    message: Type.String(),
-  }),
+  Type.Object(
+    {
+      code: Type.Literal('ERROR1', { description: 'An error literal' }),
+      message: Type.String({ description: 'Error message' }),
+    },
+    { description: 'One error' },
+  ),
+  Type.Object(
+    {
+      code: Type.Literal('ERROR2', { description: 'An error literal' }),
+      message: Type.String({ description: 'Error message' }),
+    },
+    { description: 'Another error' },
+  ),
 ]);
 
 const fnBody = Procedure.rpc<
@@ -30,6 +50,7 @@ const fnBody = Procedure.rpc<
   typeof output,
   typeof errors
 >({
+  description: 'A function',
   input,
   output,
   errors,

--- a/router/procedures.ts
+++ b/router/procedures.ts
@@ -1,7 +1,8 @@
-import { TObject, Static, TUnion, TNever, Type } from '@sinclair/typebox';
+import { Static, TUnion, TNever, Type } from '@sinclair/typebox';
 import type { Pushable } from 'it-pushable';
 import { ServiceContextWithTransportInfo } from './context';
 import { Result, RiverError, RiverUncaughtSchema } from './result';
+import { RiverObject } from '../types';
 
 /**
  * Brands a type to prevent it from being directly constructed.
@@ -31,7 +32,7 @@ export type ValidProcType =
 /**
  * Represents the payload type for {@link Procedure}s.
  */
-export type PayloadType = TObject | TUnion<Array<TObject>>;
+export type PayloadType = RiverObject | TUnion<Array<RiverObject>>;
 
 /**
  * Represents results from a {@link Procedure}. Might come from inside a stream or
@@ -56,6 +57,7 @@ export interface RPCProcedure<
   O extends PayloadType,
   E extends RiverError,
 > {
+  description: string;
   type: 'rpc';
   input: I;
   output: O;
@@ -240,6 +242,7 @@ export type ProcedureMap<State = object> = Record<string, AnyProcedure<State>>;
  */
 // signature: default errors
 function rpc<State, I extends PayloadType, O extends PayloadType>(def: {
+  description: string;
   input: I;
   output: O;
   errors?: never;
@@ -253,6 +256,7 @@ function rpc<
   O extends PayloadType,
   E extends RiverError,
 >(def: {
+  description: string;
   input: I;
   output: O;
   errors: E;
@@ -261,11 +265,13 @@ function rpc<
 
 // implementation
 function rpc({
+  description,
   input,
   output,
   errors = Type.Never(),
   handler,
 }: {
+  description: string;
   input: PayloadType;
   output: PayloadType;
   errors?: RiverError;
@@ -276,7 +282,7 @@ function rpc({
     RiverError
   >['handler'];
 }) {
-  return { type: 'rpc', input, output, errors, handler };
+  return { description, type: 'rpc', input, output, errors, handler };
 }
 
 /**
@@ -289,6 +295,7 @@ function upload<
   O extends PayloadType,
   Init extends PayloadType,
 >(def: {
+  description: string;
   init: Init;
   input: I;
   output: O;
@@ -304,6 +311,7 @@ function upload<
   E extends RiverError,
   Init extends PayloadType,
 >(def: {
+  description: string;
   init: Init;
   input: I;
   output: O;
@@ -327,6 +335,7 @@ function upload<
   O extends PayloadType,
   E extends RiverError,
 >(def: {
+  description: string;
   init?: never;
   input: I;
   output: O;

--- a/router/procedures.ts
+++ b/router/procedures.ts
@@ -86,6 +86,7 @@ export type UploadProcedure<
   Init extends PayloadType | null = null,
 > = Init extends PayloadType
   ? {
+      description: string;
       type: 'upload';
       init: Init;
       input: I;
@@ -98,6 +99,7 @@ export type UploadProcedure<
       ): Promise<ProcedureResult<O, E>>;
     }
   : {
+      description: string;
       type: 'upload';
       input: I;
       output: O;
@@ -122,6 +124,7 @@ export interface SubscriptionProcedure<
   O extends PayloadType,
   E extends RiverError,
 > {
+  description: string;
   type: 'subscription';
   input: I;
   output: O;
@@ -151,6 +154,7 @@ export type StreamProcedure<
   Init extends PayloadType | null = null,
 > = Init extends PayloadType
   ? {
+      description: string;
       type: 'stream';
       init: Init;
       input: I;
@@ -164,6 +168,7 @@ export type StreamProcedure<
       ): Promise<void>;
     }
   : {
+      description: string;
       type: 'stream';
       input: I;
       output: O;
@@ -321,6 +326,7 @@ function upload<
 
 // signature: no init with default errors
 function upload<State, I extends PayloadType, O extends PayloadType>(def: {
+  description: string;
   init?: never;
   input: I;
   output: O;
@@ -345,12 +351,14 @@ function upload<
 
 // implementation
 function upload({
+  description,
   init,
   input,
   output,
   errors = Type.Never(),
   handler,
 }: {
+  description: string;
   init?: PayloadType | null;
   input: PayloadType;
   output: PayloadType;
@@ -364,8 +372,8 @@ function upload({
   >['handler'];
 }) {
   return init !== undefined && init !== null
-    ? { type: 'upload', init, input, output, errors, handler }
-    : { type: 'upload', input, output, errors, handler };
+    ? { type: 'upload', description, init, input, output, errors, handler }
+    : { type: 'upload', description, input, output, errors, handler };
 }
 
 /**
@@ -377,6 +385,7 @@ function subscription<
   I extends PayloadType,
   O extends PayloadType,
 >(def: {
+  description: string;
   input: I;
   output: O;
   errors?: never;
@@ -390,6 +399,7 @@ function subscription<
   O extends PayloadType,
   E extends RiverError,
 >(def: {
+  description: string;
   input: I;
   output: O;
   errors: E;
@@ -398,11 +408,13 @@ function subscription<
 
 // implementation
 function subscription({
+  description,
   input,
   output,
   errors = Type.Never(),
   handler,
 }: {
+  description: string;
   input: PayloadType;
   output: PayloadType;
   errors?: RiverError;
@@ -413,7 +425,7 @@ function subscription({
     RiverError
   >['handler'];
 }) {
-  return { type: 'subscription', input, output, errors, handler };
+  return { type: 'subscription', description, input, output, errors, handler };
 }
 
 /**
@@ -426,6 +438,7 @@ function stream<
   O extends PayloadType,
   Init extends PayloadType,
 >(def: {
+  description: string;
   init: Init;
   input: I;
   output: O;
@@ -441,6 +454,7 @@ function stream<
   E extends RiverError,
   Init extends PayloadType,
 >(def: {
+  description: string;
   init: Init;
   input: I;
   output: O;
@@ -450,6 +464,7 @@ function stream<
 
 // signature: no init with default errors
 function stream<State, I extends PayloadType, O extends PayloadType>(def: {
+  description: string;
   init?: never;
   input: I;
   output: O;
@@ -464,6 +479,7 @@ function stream<
   O extends PayloadType,
   E extends RiverError,
 >(def: {
+  description: string;
   init?: never;
   input: I;
   output: O;
@@ -473,12 +489,14 @@ function stream<
 
 // implementation
 function stream({
+  description,
   init,
   input,
   output,
   errors = Type.Never(),
   handler,
 }: {
+  description: string;
   init?: PayloadType | null;
   input: PayloadType;
   output: PayloadType;
@@ -492,8 +510,8 @@ function stream({
   >['handler'];
 }) {
   return init !== undefined && init !== null
-    ? { type: 'stream', init, input, output, errors, handler }
-    : { type: 'stream', input, output, errors, handler };
+    ? { type: 'stream', description, init, input, output, errors, handler }
+    : { type: 'stream', description, input, output, errors, handler };
 }
 
 /**

--- a/router/services.ts
+++ b/router/services.ts
@@ -333,6 +333,7 @@ export class ServiceSchema<
         Object.entries(this.procedures).map(([procName, procDef]) => [
           procName,
           {
+            description: procDef.description,
             input: Type.Strict(procDef.input),
             output: Type.Strict(procDef.output),
             // Only add the `errors` field if it is non-never.

--- a/types.ts
+++ b/types.ts
@@ -36,7 +36,7 @@ interface RiverArrayOptions extends ArrayOptions {
   description: string;
 }
 
-function Array(schema: RiverSchema, options: RiverArrayOptions): RiverArray {
+function _Array(schema: RiverSchema, options: RiverArrayOptions): RiverArray {
   return {
     ...TypeboxType.Array(schema, options),
     description: options.description,
@@ -47,7 +47,7 @@ export interface RiverBoolean extends TBoolean {
   description: string;
 }
 
-function Boolean(options: RiverSchemaOptions): RiverBoolean {
+function _Boolean(options: RiverSchemaOptions): RiverBoolean {
   return {
     ...TypeboxType.Boolean(options),
     description: options.description,
@@ -58,7 +58,7 @@ export interface RiverLiteral<T extends TLiteralValue> extends TLiteral<T> {
   description: string;
 }
 
-function Literal<T extends TLiteralValue>(
+function _Literal<T extends TLiteralValue>(
   value: T,
   options: RiverSchemaOptions,
 ): RiverLiteral<T> {
@@ -76,7 +76,7 @@ export interface RiverNumber extends TNumber {
   description: string;
 }
 
-function Number(options: RiverNumberOptions): RiverNumber {
+function _Number(options: RiverNumberOptions): RiverNumber {
   return {
     ...TypeboxType.Number(options),
     description: options.description,
@@ -97,7 +97,7 @@ interface RiverProperties extends TProperties {
   [x: number]: RiverSchema | TUnion<Array<RiverSchema>>;
 }
 
-function Object<T extends RiverProperties>(
+function _Object<T extends RiverProperties>(
   properties: T,
   options: RiverObjectOptions,
 ): RiverObject<T> {
@@ -115,7 +115,7 @@ export interface RiverString extends TString {
   description: string;
 }
 
-function String(options: RiverStringOptions): RiverString {
+function _String(options: RiverStringOptions): RiverString {
   return {
     ...TypeboxType.String(options),
     description: options.description,
@@ -130,14 +130,14 @@ export interface RiverUint8Array extends TUint8Array {
   description: string;
 }
 
-function Uint8Array(options: RiverUint8ArrayOptions): RiverUint8Array {
+function _Uint8Array(options: RiverUint8ArrayOptions): RiverUint8Array {
   return {
     ...TypeboxType.Uint8Array(options),
     description: options.description,
   };
 }
 
-function Union<T extends Array<RiverSchema>>(
+function _Union<T extends Array<RiverSchema>>(
   schemas: [...T],
   options?: RiverSchemaOptions,
 ) {
@@ -145,13 +145,14 @@ function Union<T extends Array<RiverSchema>>(
 }
 
 export const Type = {
-  Array,
-  Boolean,
-  Literal,
-  Number,
-  Object,
+  // We prefix with `_` to avoid colliding with builtins
+  Array: _Array,
+  Boolean: _Boolean,
+  Literal: _Literal,
+  Number: _Number,
+  Object: _Object,
   Optional: TypeboxType.Optional,
-  String,
-  Uint8Array,
-  Union,
+  String: _String,
+  Uint8Array: _Uint8Array,
+  Union: _Union,
 };

--- a/types.ts
+++ b/types.ts
@@ -1,0 +1,157 @@
+import {
+  ArrayOptions,
+  NumberOptions,
+  ObjectOptions,
+  SchemaOptions,
+  StringOptions,
+  TArray,
+  TBoolean,
+  TLiteral,
+  TLiteralValue,
+  TNumber,
+  TObject,
+  TProperties,
+  TSchema,
+  TString,
+  TUint8Array,
+  TUnion,
+  Type as TypeboxType,
+  Uint8ArrayOptions,
+} from '@sinclair/typebox';
+
+export interface RiverSchema extends TSchema {
+  description: string;
+}
+
+interface RiverSchemaOptions extends SchemaOptions {
+  description: string;
+}
+
+export interface RiverArray<T extends RiverSchema = RiverSchema>
+  extends TArray<T> {
+  description: string;
+}
+
+interface RiverArrayOptions extends ArrayOptions {
+  description: string;
+}
+
+function Array(schema: RiverSchema, options: RiverArrayOptions): RiverArray {
+  return {
+    ...TypeboxType.Array(schema, options),
+    description: options.description,
+  };
+}
+
+export interface RiverBoolean extends TBoolean {
+  description: string;
+}
+
+function Boolean(options: RiverSchemaOptions): RiverBoolean {
+  return {
+    ...TypeboxType.Boolean(options),
+    description: options.description,
+  };
+}
+
+export interface RiverLiteral<T extends TLiteralValue> extends TLiteral<T> {
+  description: string;
+}
+
+function Literal<T extends TLiteralValue>(
+  value: T,
+  options: RiverSchemaOptions,
+): RiverLiteral<T> {
+  return {
+    ...TypeboxType.Literal(value, options),
+    description: options.description,
+  };
+}
+
+interface RiverNumberOptions extends NumberOptions {
+  description: string;
+}
+
+export interface RiverNumber extends TNumber {
+  description: string;
+}
+
+function Number(options: RiverNumberOptions): RiverNumber {
+  return {
+    ...TypeboxType.Number(options),
+    description: options.description,
+  };
+}
+
+interface RiverObjectOptions extends ObjectOptions {
+  description: string;
+}
+
+export interface RiverObject<T extends TProperties = TProperties>
+  extends TObject<T> {
+  description: string;
+}
+
+interface RiverProperties extends TProperties {
+  [x: string]: RiverSchema | TUnion<Array<RiverSchema>>;
+  [x: number]: RiverSchema | TUnion<Array<RiverSchema>>;
+}
+
+function Object<T extends RiverProperties>(
+  properties: T,
+  options: RiverObjectOptions,
+): RiverObject<T> {
+  return {
+    ...TypeboxType.Object(properties, options),
+    description: options.description,
+  };
+}
+
+interface RiverStringOptions extends StringOptions {
+  description: string;
+}
+
+export interface RiverString extends TString {
+  description: string;
+}
+
+function String(options: RiverStringOptions): RiverString {
+  return {
+    ...TypeboxType.String(options),
+    description: options.description,
+  };
+}
+
+interface RiverUint8ArrayOptions extends Uint8ArrayOptions {
+  description: string;
+}
+
+export interface RiverUint8Array extends TUint8Array {
+  description: string;
+}
+
+function Uint8Array(options: RiverUint8ArrayOptions): RiverUint8Array {
+  return {
+    ...TypeboxType.Uint8Array(options),
+    description: options.description,
+  };
+}
+
+function Union<T extends Array<RiverSchema>>(
+  schemas: [...T],
+  options?: RiverSchemaOptions,
+) {
+  return TypeboxType.Union(schemas, options);
+}
+
+export const Type = {
+  Array,
+  Boolean,
+  Literal,
+  Number,
+  Object,
+  Optional: TypeboxType.Optional,
+  String,
+  Uint8Array,
+  Union,
+};


### PR DESCRIPTION
Wrap and re-export typebox types to enforce us providing a "description" field for all parameters. We should now construct with `RiverType` instead of Typebox `Type`, to force us to provide a "description". This will flow through to the schema serialization.

Another idea would be to make `PayloadType` generic, which would potentially allow pid2 to enforce the description requirement instead of making it a river level construct. But frankly that seems just way more complicated, so I'm tempted to 🚢  this. Pulling it out to be a non-river level construct would mostly just to be more flexible to other non-replit users of river, which are not the priority at the moment. Relaxing the description requirement and making it generic in future releases would be backwards compat, so this is fine.

Fixed up all the tests and added one more for union becuase I wanted to make sure that worked as expected.

Not going to mark this release yet because I think there might be some other changes we want to make to serialization first.