### PR TITLE
Allow description types for procedures

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
+.cache
 node_modules

--- a/__tests__/fixtures/services.ts
+++ b/__tests__/fixtures/services.ts
@@ -53,6 +53,33 @@ const testServiceProcedures = TestServiceScaffold.procedures({
       }
     },
   }),
+
+  echoUnion: Procedure.rpc({
+    description: 'Echos back whatever we sent',
+    input: Type.Union([
+      Type.Object(
+        { a: Type.Number({ description: 'A number' }) },
+        { description: 'A' },
+      ),
+      Type.Object(
+        { b: Type.String({ description: 'A string' }) },
+        { description: 'B' },
+      ),
+    ]),
+    output: Type.Union([
+      Type.Object(
+        { a: Type.Number({ description: 'A number' }) },
+        { description: 'A' },
+      ),
+      Type.Object(
+        { b: Type.String({ description: 'A string' }) },
+        { description: 'B' },
+      ),
+    ]),
+    async handler(_, input) {
+      return Ok(input);
+    },
+  }),
 });
 
 export const TestServiceSchema = TestServiceScaffold.finalize({

--- a/__tests__/serialize.test.ts
+++ b/__tests__/serialize.test.ts
@@ -10,17 +10,20 @@ describe('serialize service to jsonschema', () => {
     expect(TestServiceSchema.serialize()).toStrictEqual({
       procedures: {
         add: {
+          description: 'Adds two numbers and returns a value',
           input: {
             properties: {
-              n: { type: 'number' },
+              n: { description: 'A number', type: 'number' },
             },
+            description: 'An input object',
             required: ['n'],
             type: 'object',
           },
           output: {
             properties: {
-              result: { type: 'number' },
+              result: { description: 'A number', type: 'number' },
             },
+            description: 'An output object',
             required: ['result'],
             type: 'object',
           },
@@ -30,18 +33,21 @@ describe('serialize service to jsonschema', () => {
           type: 'rpc',
         },
         echo: {
+          description: 'Streams an echo back',
           input: {
+            description: 'A request that echos',
             properties: {
-              msg: { type: 'string' },
-              ignore: { type: 'boolean' },
-              end: { type: 'boolean' },
+              msg: { description: 'A string', type: 'string' },
+              ignore: { description: 'A boolean', type: 'boolean' },
+              end: { description: 'A boolean', type: 'boolean' },
             },
             required: ['msg', 'ignore'],
             type: 'object',
           },
           output: {
+            description: 'A response from an echo',
             properties: {
-              response: { type: 'string' },
+              response: { description: 'A string', type: 'string' },
             },
             required: ['response'],
             type: 'object',
@@ -52,12 +58,15 @@ describe('serialize service to jsonschema', () => {
           type: 'stream',
         },
         echoWithPrefix: {
+          description: 'Streams an echo back',
           errors: {
             not: {},
           },
           init: {
+            description: 'An init object',
             properties: {
               prefix: {
+                description: 'A prefix',
                 type: 'string',
               },
             },
@@ -65,14 +74,18 @@ describe('serialize service to jsonschema', () => {
             type: 'object',
           },
           input: {
+            description: 'A request that echos',
             properties: {
               end: {
+                description: 'A boolean',
                 type: 'boolean',
               },
               ignore: {
+                description: 'A boolean',
                 type: 'boolean',
               },
               msg: {
+                description: 'A string',
                 type: 'string',
               },
             },
@@ -80,8 +93,10 @@ describe('serialize service to jsonschema', () => {
             type: 'object',
           },
           output: {
+            description: 'A response from an echo',
             properties: {
               response: {
+                description: 'A string',
                 type: 'string',
               },
             },
@@ -89,6 +104,65 @@ describe('serialize service to jsonschema', () => {
             type: 'object',
           },
           type: 'stream',
+        },
+        echoUnion: {
+          description: 'Echos back whatever we sent',
+          errors: {
+            not: {},
+          },
+          input: {
+            anyOf: [
+              {
+                description: 'A',
+                properties: {
+                  a: {
+                    description: 'A number',
+                    type: 'number',
+                  },
+                },
+                required: ['a'],
+                type: 'object',
+              },
+              {
+                description: 'B',
+                properties: {
+                  b: {
+                    description: 'A string',
+                    type: 'string',
+                  },
+                },
+                required: ['b'],
+                type: 'object',
+              },
+            ],
+          },
+          output: {
+            anyOf: [
+              {
+                description: 'A',
+                properties: {
+                  a: {
+                    description: 'A number',
+                    type: 'number',
+                  },
+                },
+                required: ['a'],
+                type: 'object',
+              },
+              {
+                description: 'B',
+                properties: {
+                  b: {
+                    description: 'A string',
+                    type: 'string',
+                  },
+                },
+                required: ['b'],
+                type: 'object',
+              },
+            ],
+          },
+          type: 'rpc',
         },
       },
     });
@@ -98,12 +172,15 @@ describe('serialize service to jsonschema', () => {
     expect(BinaryFileServiceSchema.serialize()).toStrictEqual({
       procedures: {
         getFile: {
+          description: 'Retrieves a file from a path',
           errors: {
             not: {},
           },
           input: {
+            description: 'An input object',
             properties: {
               file: {
+                description: 'A file path',
                 type: 'string',
               },
             },
@@ -111,8 +188,10 @@ describe('serialize service to jsonschema', () => {
             type: 'object',
           },
           output: {
+            description: 'An output object',
             properties: {
               contents: {
+                description: 'File contents',
                 type: 'Uint8Array',
               },
             },
@@ -129,28 +208,38 @@ describe('serialize service to jsonschema', () => {
     expect(FallibleServiceSchema.serialize()).toStrictEqual({
       procedures: {
         divide: {
+          description: 'Divide one number by another number',
           input: {
+            description: 'An input object',
             properties: {
-              a: { type: 'number' },
-              b: { type: 'number' },
+              a: { description: 'A number', type: 'number' },
+              b: { description: 'A number', type: 'number' },
             },
             required: ['a', 'b'],
             type: 'object',
           },
           output: {
+            description: 'An output object',
             properties: {
-              result: { type: 'number' },
+              result: { description: 'A result', type: 'number' },
             },
             required: ['result'],
             type: 'object',
           },
           errors: {
+            description: 'An error object',
             properties: {
-              code: { const: 'DIV_BY_ZERO', type: 'string' },
-              message: { type: 'string' },
+              code: {
+                description: 'A literal',
+                const: 'DIV_BY_ZERO',
+                type: 'string',
+              },
+              message: { description: 'A message', type: 'string' },
               extras: {
+                description: 'A set of extras',
                 properties: {
                   test: {
+                    description: 'A test string',
                     type: 'string',
                   },
                 },
@@ -164,39 +253,34 @@ describe('serialize service to jsonschema', () => {
           type: 'rpc',
         },
         echo: {
+          description: 'Streams an echo back',
           errors: {
+            description: 'An error',
             properties: {
               code: {
                 const: 'STREAM_ERROR',
+                description: 'A literal code',
                 type: 'string',
               },
-              message: {
-                type: 'string',
-              },
+              message: { description: 'A message', type: 'string' },
             },
             required: ['code', 'message'],
             type: 'object',
           },
           input: {
+            description: 'An input',
             properties: {
-              msg: {
-                type: 'string',
-              },
-              throwError: {
-                type: 'boolean',
-              },
-              throwResult: {
-                type: 'boolean',
-              },
+              msg: { description: 'The message', type: 'string' },
+              throwError: { description: 'Throw on error', type: 'boolean' },
+              throwResult: { description: 'Throw on result', type: 'boolean' },
             },
             required: ['msg', 'throwResult', 'throwError'],
             type: 'object',
           },
           output: {
+            description: 'An output',
             properties: {
-              response: {
-                type: 'string',
-              },
+              response: { description: 'A response', type: 'string' },
             },
             required: ['response'],
             type: 'object',

--- a/__tests__/serialize.test.ts
+++ b/__tests__/serialize.test.ts
@@ -97,6 +97,65 @@ describe('serialize server to jsonschema', () => {
             },
             type: 'stream',
           },
+          echoUnion: {
+            description: 'Echos back whatever we sent',
+            errors: {
+              not: {},
+            },
+            input: {
+              anyOf: [
+                {
+                  description: 'A',
+                  properties: {
+                    a: {
+                      description: 'A number',
+                      type: 'number',
+                    },
+                  },
+                  required: ['a'],
+                  type: 'object',
+                },
+                {
+                  description: 'B',
+                  properties: {
+                    b: {
+                      description: 'A string',
+                      type: 'string',
+                    },
+                  },
+                  required: ['b'],
+                  type: 'object',
+                },
+              ],
+            },
+            output: {
+              anyOf: [
+                {
+                  description: 'A',
+                  properties: {
+                    a: {
+                      description: 'A number',
+                      type: 'number',
+                    },
+                  },
+                  required: ['a'],
+                  type: 'object',
+                },
+                {
+                  description: 'B',
+                  properties: {
+                    b: {
+                      description: 'A string',
+                      type: 'string',
+                    },
+                  },
+                  required: ['b'],
+                  type: 'object',
+                },
+              ],
+            },
+            type: 'rpc',
+          },
         },
       },
     });

--- a/__tests__/serialize.test.ts
+++ b/__tests__/serialize.test.ts
@@ -10,20 +10,17 @@ describe('serialize service to jsonschema', () => {
     expect(TestServiceSchema.serialize()).toStrictEqual({
       procedures: {
         add: {
-          description: 'Adds two numbers and returns a value',
           input: {
             properties: {
-              n: { description: 'A number', type: 'number' },
+              n: { type: 'number' },
             },
-            description: 'An input object',
             required: ['n'],
             type: 'object',
           },
           output: {
             properties: {
-              result: { description: 'A number', type: 'number' },
+              result: { type: 'number' },
             },
-            description: 'An output object',
             required: ['result'],
             type: 'object',
           },
@@ -33,21 +30,18 @@ describe('serialize service to jsonschema', () => {
           type: 'rpc',
         },
         echo: {
-          description: 'Streams an echo back',
           input: {
-            description: 'A request that echos',
             properties: {
-              msg: { description: 'A string', type: 'string' },
-              ignore: { description: 'A boolean', type: 'boolean' },
-              end: { description: 'A boolean', type: 'boolean' },
+              msg: { type: 'string' },
+              ignore: { type: 'boolean' },
+              end: { type: 'boolean' },
             },
             required: ['msg', 'ignore'],
             type: 'object',
           },
           output: {
-            description: 'A response from an echo',
             properties: {
-              response: { description: 'A string', type: 'string' },
+              response: { type: 'string' },
             },
             required: ['response'],
             type: 'object',
@@ -58,15 +52,12 @@ describe('serialize service to jsonschema', () => {
           type: 'stream',
         },
         echoWithPrefix: {
-          description: 'Streams an echo back',
           errors: {
             not: {},
           },
           init: {
-            description: 'An init object',
             properties: {
               prefix: {
-                description: 'A prefix',
                 type: 'string',
               },
             },
@@ -74,18 +65,14 @@ describe('serialize service to jsonschema', () => {
             type: 'object',
           },
           input: {
-            description: 'A request that echos',
             properties: {
               end: {
-                description: 'A boolean',
                 type: 'boolean',
               },
               ignore: {
-                description: 'A boolean',
                 type: 'boolean',
               },
               msg: {
-                description: 'A string',
                 type: 'string',
               },
             },
@@ -93,10 +80,8 @@ describe('serialize service to jsonschema', () => {
             type: 'object',
           },
           output: {
-            description: 'A response from an echo',
             properties: {
               response: {
-                description: 'A string',
                 type: 'string',
               },
             },
@@ -172,15 +157,12 @@ describe('serialize service to jsonschema', () => {
     expect(BinaryFileServiceSchema.serialize()).toStrictEqual({
       procedures: {
         getFile: {
-          description: 'Retrieves a file from a path',
           errors: {
             not: {},
           },
           input: {
-            description: 'An input object',
             properties: {
               file: {
-                description: 'A file path',
                 type: 'string',
               },
             },
@@ -188,10 +170,8 @@ describe('serialize service to jsonschema', () => {
             type: 'object',
           },
           output: {
-            description: 'An output object',
             properties: {
               contents: {
-                description: 'File contents',
                 type: 'Uint8Array',
               },
             },
@@ -208,38 +188,28 @@ describe('serialize service to jsonschema', () => {
     expect(FallibleServiceSchema.serialize()).toStrictEqual({
       procedures: {
         divide: {
-          description: 'Divide one number by another number',
           input: {
-            description: 'An input object',
             properties: {
-              a: { description: 'A number', type: 'number' },
-              b: { description: 'A number', type: 'number' },
+              a: { type: 'number' },
+              b: { type: 'number' },
             },
             required: ['a', 'b'],
             type: 'object',
           },
           output: {
-            description: 'An output object',
             properties: {
-              result: { description: 'A result', type: 'number' },
+              result: { type: 'number' },
             },
             required: ['result'],
             type: 'object',
           },
           errors: {
-            description: 'An error object',
             properties: {
-              code: {
-                description: 'A literal',
-                const: 'DIV_BY_ZERO',
-                type: 'string',
-              },
-              message: { description: 'A message', type: 'string' },
+              code: { const: 'DIV_BY_ZERO', type: 'string' },
+              message: { type: 'string' },
               extras: {
-                description: 'A set of extras',
                 properties: {
                   test: {
-                    description: 'A test string',
                     type: 'string',
                   },
                 },
@@ -253,34 +223,39 @@ describe('serialize service to jsonschema', () => {
           type: 'rpc',
         },
         echo: {
-          description: 'Streams an echo back',
           errors: {
-            description: 'An error',
             properties: {
               code: {
                 const: 'STREAM_ERROR',
-                description: 'A literal code',
                 type: 'string',
               },
-              message: { description: 'A message', type: 'string' },
+              message: {
+                type: 'string',
+              },
             },
             required: ['code', 'message'],
             type: 'object',
           },
           input: {
-            description: 'An input',
             properties: {
-              msg: { description: 'The message', type: 'string' },
-              throwError: { description: 'Throw on error', type: 'boolean' },
-              throwResult: { description: 'Throw on result', type: 'boolean' },
+              msg: {
+                type: 'string',
+              },
+              throwError: {
+                type: 'boolean',
+              },
+              throwResult: {
+                type: 'boolean',
+              },
             },
             required: ['msg', 'throwResult', 'throwError'],
             type: 'object',
           },
           output: {
-            description: 'An output',
             properties: {
-              response: { description: 'A response', type: 'string' },
+              response: {
+                type: 'string',
+              },
             },
             required: ['response'],
             type: 'object',

--- a/router/procedures.ts
+++ b/router/procedures.ts
@@ -60,7 +60,7 @@ export interface RPCProcedure<
   input: I;
   output: O;
   errors: E;
-  description: string | undefined;
+  description?: string;
   handler(
     context: ServiceContextWithTransportInfo<State>,
     input: Static<I>,
@@ -90,7 +90,7 @@ export type UploadProcedure<
       input: I;
       output: O;
       errors: E;
-      description: string | undefined;
+      description?: string;
       handler(
         context: ServiceContextWithTransportInfo<State>,
         init: Static<Init>,
@@ -102,7 +102,7 @@ export type UploadProcedure<
       input: I;
       output: O;
       errors: E;
-      description: string | undefined;
+      description?: string;
       handler(
         context: ServiceContextWithTransportInfo<State>,
         input: AsyncIterableIterator<Static<I>>,
@@ -127,7 +127,7 @@ export interface SubscriptionProcedure<
   input: I;
   output: O;
   errors: E;
-  description: string | undefined;
+  description?: string;
   handler(
     context: ServiceContextWithTransportInfo<State>,
     input: Static<I>,
@@ -158,7 +158,7 @@ export type StreamProcedure<
       input: I;
       output: O;
       errors: E;
-      description: string | undefined;
+      description?: string;
       handler(
         context: ServiceContextWithTransportInfo<State>,
         init: Static<Init>,
@@ -171,7 +171,7 @@ export type StreamProcedure<
       input: I;
       output: O;
       errors: E;
-      description: string | undefined;
+      description?: string;
       handler(
         context: ServiceContextWithTransportInfo<State>,
         input: AsyncIterableIterator<Static<I>>,
@@ -286,7 +286,14 @@ function rpc({
     RiverError
   >['handler'];
 }) {
-  return { description, type: 'rpc', input, output, errors, handler };
+  return {
+    ...(description ? { description } : {}),
+    type: 'rpc',
+    input,
+    output,
+    errors,
+    handler,
+  };
 }
 
 /**
@@ -371,8 +378,23 @@ function upload({
   >['handler'];
 }) {
   return init !== undefined && init !== null
-    ? { type: 'upload', description, init, input, output, errors, handler }
-    : { type: 'upload', description, input, output, errors, handler };
+    ? {
+        type: 'upload',
+        ...(description ? { description } : {}),
+        init,
+        input,
+        output,
+        errors,
+        handler,
+      }
+    : {
+        type: 'upload',
+        ...(description ? { description } : {}),
+        input,
+        output,
+        errors,
+        handler,
+      };
 }
 
 /**
@@ -424,7 +446,14 @@ function subscription({
     RiverError
   >['handler'];
 }) {
-  return { type: 'subscription', description, input, output, errors, handler };
+  return {
+    type: 'subscription',
+    ...(description ? { description } : {}),
+    input,
+    output,
+    errors,
+    handler,
+  };
 }
 
 /**
@@ -509,8 +538,23 @@ function stream({
   >['handler'];
 }) {
   return init !== undefined && init !== null
-    ? { type: 'stream', description, init, input, output, errors, handler }
-    : { type: 'stream', description, input, output, errors, handler };
+    ? {
+        type: 'stream',
+        ...(description ? { description } : {}),
+        init,
+        input,
+        output,
+        errors,
+        handler,
+      }
+    : {
+        type: 'stream',
+        ...(description ? { description } : {}),
+        input,
+        output,
+        errors,
+        handler,
+      };
 }
 
 /**

--- a/router/procedures.ts
+++ b/router/procedures.ts
@@ -1,4 +1,4 @@
-import { TObject, Static, TUnion, TNever, Type } from '@sinclair/typebox';
+import { Static, TUnion, TNever, Type, TObject } from '@sinclair/typebox';
 import type { Pushable } from 'it-pushable';
 import { ServiceContextWithTransportInfo } from './context';
 import { Result, RiverError, RiverUncaughtSchema } from './result';
@@ -60,6 +60,7 @@ export interface RPCProcedure<
   input: I;
   output: O;
   errors: E;
+  description: string | undefined;
   handler(
     context: ServiceContextWithTransportInfo<State>,
     input: Static<I>,
@@ -89,6 +90,7 @@ export type UploadProcedure<
       input: I;
       output: O;
       errors: E;
+      description: string | undefined;
       handler(
         context: ServiceContextWithTransportInfo<State>,
         init: Static<Init>,
@@ -100,6 +102,7 @@ export type UploadProcedure<
       input: I;
       output: O;
       errors: E;
+      description: string | undefined;
       handler(
         context: ServiceContextWithTransportInfo<State>,
         input: AsyncIterableIterator<Static<I>>,
@@ -124,6 +127,7 @@ export interface SubscriptionProcedure<
   input: I;
   output: O;
   errors: E;
+  description: string | undefined;
   handler(
     context: ServiceContextWithTransportInfo<State>,
     input: Static<I>,
@@ -154,6 +158,7 @@ export type StreamProcedure<
       input: I;
       output: O;
       errors: E;
+      description: string | undefined;
       handler(
         context: ServiceContextWithTransportInfo<State>,
         init: Static<Init>,
@@ -166,6 +171,7 @@ export type StreamProcedure<
       input: I;
       output: O;
       errors: E;
+      description: string | undefined;
       handler(
         context: ServiceContextWithTransportInfo<State>,
         input: AsyncIterableIterator<Static<I>>,
@@ -243,6 +249,7 @@ function rpc<State, I extends PayloadType, O extends PayloadType>(def: {
   input: I;
   output: O;
   errors?: never;
+  description?: string;
   handler: RPCProcedure<State, I, O, TNever>['handler'];
 }): Branded<RPCProcedure<State, I, O, TNever>>;
 
@@ -256,6 +263,7 @@ function rpc<
   input: I;
   output: O;
   errors: E;
+  description?: string;
   handler: RPCProcedure<State, I, O, E>['handler'];
 }): Branded<RPCProcedure<State, I, O, E>>;
 
@@ -264,11 +272,13 @@ function rpc({
   input,
   output,
   errors = Type.Never(),
+  description,
   handler,
 }: {
   input: PayloadType;
   output: PayloadType;
   errors?: RiverError;
+  description?: string;
   handler: RPCProcedure<
     object,
     PayloadType,
@@ -276,7 +286,7 @@ function rpc({
     RiverError
   >['handler'];
 }) {
-  return { type: 'rpc', input, output, errors, handler };
+  return { description, type: 'rpc', input, output, errors, handler };
 }
 
 /**
@@ -293,6 +303,7 @@ function upload<
   input: I;
   output: O;
   errors?: never;
+  description?: string;
   handler: UploadProcedure<State, I, O, TNever, Init>['handler'];
 }): Branded<UploadProcedure<State, I, O, TNever, Init>>;
 
@@ -308,6 +319,7 @@ function upload<
   input: I;
   output: O;
   errors: E;
+  description?: string;
   handler: UploadProcedure<State, I, O, E, Init>['handler'];
 }): Branded<UploadProcedure<State, I, O, E, Init>>;
 
@@ -317,6 +329,7 @@ function upload<State, I extends PayloadType, O extends PayloadType>(def: {
   input: I;
   output: O;
   errors?: never;
+  description?: string;
   handler: UploadProcedure<State, I, O, TNever>['handler'];
 }): Branded<UploadProcedure<State, I, O, TNever>>;
 
@@ -331,6 +344,7 @@ function upload<
   input: I;
   output: O;
   errors: E;
+  description?: string;
   handler: UploadProcedure<State, I, O, E>['handler'];
 }): Branded<UploadProcedure<State, I, O, E>>;
 
@@ -340,12 +354,14 @@ function upload({
   input,
   output,
   errors = Type.Never(),
+  description,
   handler,
 }: {
   init?: PayloadType | null;
   input: PayloadType;
   output: PayloadType;
   errors?: RiverError;
+  description?: string;
   handler: UploadProcedure<
     object,
     PayloadType,
@@ -355,8 +371,8 @@ function upload({
   >['handler'];
 }) {
   return init !== undefined && init !== null
-    ? { type: 'upload', init, input, output, errors, handler }
-    : { type: 'upload', input, output, errors, handler };
+    ? { type: 'upload', description, init, input, output, errors, handler }
+    : { type: 'upload', description, input, output, errors, handler };
 }
 
 /**
@@ -371,6 +387,7 @@ function subscription<
   input: I;
   output: O;
   errors?: never;
+  description?: string;
   handler: SubscriptionProcedure<State, I, O, TNever>['handler'];
 }): Branded<SubscriptionProcedure<State, I, O, TNever>>;
 
@@ -384,6 +401,7 @@ function subscription<
   input: I;
   output: O;
   errors: E;
+  description?: string;
   handler: SubscriptionProcedure<State, I, O, E>['handler'];
 }): Branded<SubscriptionProcedure<State, I, O, E>>;
 
@@ -392,11 +410,13 @@ function subscription({
   input,
   output,
   errors = Type.Never(),
+  description,
   handler,
 }: {
   input: PayloadType;
   output: PayloadType;
   errors?: RiverError;
+  description?: string;
   handler: SubscriptionProcedure<
     object,
     PayloadType,
@@ -404,7 +424,7 @@ function subscription({
     RiverError
   >['handler'];
 }) {
-  return { type: 'subscription', input, output, errors, handler };
+  return { type: 'subscription', description, input, output, errors, handler };
 }
 
 /**
@@ -421,6 +441,7 @@ function stream<
   input: I;
   output: O;
   errors?: never;
+  description?: string;
   handler: StreamProcedure<State, I, O, TNever, Init>['handler'];
 }): Branded<StreamProcedure<State, I, O, TNever, Init>>;
 
@@ -436,6 +457,7 @@ function stream<
   input: I;
   output: O;
   errors: E;
+  description?: string;
   handler: StreamProcedure<State, I, O, E, Init>['handler'];
 }): Branded<StreamProcedure<State, I, O, E, Init>>;
 
@@ -445,6 +467,7 @@ function stream<State, I extends PayloadType, O extends PayloadType>(def: {
   input: I;
   output: O;
   errors?: never;
+  description?: string;
   handler: StreamProcedure<State, I, O, TNever>['handler'];
 }): Branded<StreamProcedure<State, I, O, TNever>>;
 
@@ -459,6 +482,7 @@ function stream<
   input: I;
   output: O;
   errors: E;
+  description?: string;
   handler: StreamProcedure<State, I, O, E>['handler'];
 }): Branded<StreamProcedure<State, I, O, E>>;
 
@@ -468,12 +492,14 @@ function stream({
   input,
   output,
   errors = Type.Never(),
+  description,
   handler,
 }: {
   init?: PayloadType | null;
   input: PayloadType;
   output: PayloadType;
   errors?: RiverError;
+  description?: string;
   handler: StreamProcedure<
     object,
     PayloadType,
@@ -483,8 +509,8 @@ function stream({
   >['handler'];
 }) {
   return init !== undefined && init !== null
-    ? { type: 'stream', init, input, output, errors, handler }
-    : { type: 'stream', input, output, errors, handler };
+    ? { type: 'stream', description, init, input, output, errors, handler }
+    : { type: 'stream', description, input, output, errors, handler };
 }
 
 /**

--- a/router/services.ts
+++ b/router/services.ts
@@ -333,6 +333,7 @@ export class ServiceSchema<
         Object.entries(this.procedures).map(([procName, procDef]) => [
           procName,
           {
+            description: procDef.description,
             input: Type.Strict(procDef.input),
             output: Type.Strict(procDef.output),
             // Only add the `errors` field if it is non-never.

--- a/router/services.ts
+++ b/router/services.ts
@@ -335,11 +335,9 @@ export class ServiceSchema<
           {
             input: Type.Strict(procDef.input),
             output: Type.Strict(procDef.output),
-            // Only add `description` field if it is non-never.
-            ...('description' in procDef && procDef.description
-              ? {
-                  description: procDef.description,
-                }
+            // Only add `description` field if the type declares it.
+            ...('description' in procDef
+              ? { description: procDef.description }
               : {}),
             // Only add the `errors` field if it is non-never.
             ...('errors' in procDef

--- a/router/services.ts
+++ b/router/services.ts
@@ -336,9 +336,9 @@ export class ServiceSchema<
             input: Type.Strict(procDef.input),
             output: Type.Strict(procDef.output),
             // Only add `description` field if it is non-never.
-            ...('description' in procDef
+            ...('description' in procDef && procDef.description
               ? {
-                  description: Type.Strict(procDef.description),
+                  description: procDef.description,
                 }
               : {}),
             // Only add the `errors` field if it is non-never.

--- a/router/services.ts
+++ b/router/services.ts
@@ -333,9 +333,14 @@ export class ServiceSchema<
         Object.entries(this.procedures).map(([procName, procDef]) => [
           procName,
           {
-            description: procDef.description,
             input: Type.Strict(procDef.input),
             output: Type.Strict(procDef.output),
+            // Only add `description` field if it is non-never.
+            ...('description' in procDef
+              ? {
+                  description: Type.Strict(procDef.description),
+                }
+              : {}),
             // Only add the `errors` field if it is non-never.
             ...('errors' in procDef
               ? {


### PR DESCRIPTION
This allows you to provide a description to procedures, which matches json schema. This will flow down to the serialized schema