### PR TITLE
add `serialize()` to server

### DIFF
--- a/__tests__/serialize.test.ts
+++ b/__tests__/serialize.test.ts
@@ -4,6 +4,104 @@ import {
   FallibleServiceSchema,
   TestServiceSchema,
 } from './fixtures/services';
+import { createServer } from '../router/server';
+import { MockServerTransport } from './typescript-stress.test';
+
+describe('serialize server to jsonschema', () => {
+  test('serialize basic server', () => {
+    const server = createServer(new MockServerTransport('mock'), {
+      test: TestServiceSchema,
+    });
+
+    expect(server.serialize()).toStrictEqual({
+      test: {
+        procedures: {
+          add: {
+            input: {
+              properties: {
+                n: { type: 'number' },
+              },
+              required: ['n'],
+              type: 'object',
+            },
+            output: {
+              properties: {
+                result: { type: 'number' },
+              },
+              required: ['result'],
+              type: 'object',
+            },
+            errors: {
+              not: {},
+            },
+            type: 'rpc',
+          },
+          echo: {
+            input: {
+              properties: {
+                msg: { type: 'string' },
+                ignore: { type: 'boolean' },
+                end: { type: 'boolean' },
+              },
+              required: ['msg', 'ignore'],
+              type: 'object',
+            },
+            output: {
+              properties: {
+                response: { type: 'string' },
+              },
+              required: ['response'],
+              type: 'object',
+            },
+            errors: {
+              not: {},
+            },
+            type: 'stream',
+          },
+          echoWithPrefix: {
+            errors: {
+              not: {},
+            },
+            init: {
+              properties: {
+                prefix: {
+                  type: 'string',
+                },
+              },
+              required: ['prefix'],
+              type: 'object',
+            },
+            input: {
+              properties: {
+                end: {
+                  type: 'boolean',
+                },
+                ignore: {
+                  type: 'boolean',
+                },
+                msg: {
+                  type: 'string',
+                },
+              },
+              required: ['msg', 'ignore'],
+              type: 'object',
+            },
+            output: {
+              properties: {
+                response: {
+                  type: 'string',
+                },
+              },
+              required: ['response'],
+              type: 'object',
+            },
+            type: 'stream',
+          },
+        },
+      },
+    });
+  });
+});
 
 describe('serialize service to jsonschema', () => {
   test('serialize basic service', () => {

--- a/router/services.ts
+++ b/router/services.ts
@@ -1,6 +1,12 @@
 import { TObject, Type, TUnion } from '@sinclair/typebox';
-import { RiverUncaughtSchema } from './result';
-import { Branded, ProcedureMap, Unbranded, AnyProcedure } from './procedures';
+import { RiverError, RiverUncaughtSchema } from './result';
+import {
+  Branded,
+  ProcedureMap,
+  Unbranded,
+  AnyProcedure,
+  PayloadType,
+} from './procedures';
 
 /**
  * An instantiated service, probably from a {@link ServiceSchema}.
@@ -126,6 +132,19 @@ export interface ServiceConfiguration<State extends object> {
    * A factory function for creating a fresh state.
    */
   initializeState: () => State;
+}
+
+export interface SerializedServiceSchema {
+  procedures: Record<
+    string,
+    {
+      input: PayloadType;
+      output: PayloadType;
+      errors?: RiverError;
+      type: 'rpc' | 'subscription' | 'upload' | 'stream';
+      init?: PayloadType;
+    }
+  >;
 }
 
 /**
@@ -327,7 +346,7 @@ export class ServiceSchema<
   /**
    * Serializes this schema's procedures into a plain object that is JSON compatible.
    */
-  serialize(): object {
+  serialize(): SerializedServiceSchema {
     return {
       procedures: Object.fromEntries(
         Object.entries(this.procedures).map(([procName, procDef]) => [
@@ -335,7 +354,7 @@ export class ServiceSchema<
           {
             input: Type.Strict(procDef.input),
             output: Type.Strict(procDef.output),
-            // Only add the `errors` field if it is non-never.
+            // Only add the `errors` field if the type declares it.
             ...('errors' in procDef
               ? {
                   errors: Type.Strict(procDef.errors),


### PR DESCRIPTION
so we can avoid 

```
Object.entries(services).map(([name, value]) => ({
  name,
  ...value.serialize(),
})),
```