### PR TITLE
Remove const modifier from result type

### DIFF
--- a/router/result.ts
+++ b/router/result.ts
@@ -46,14 +46,14 @@ export type Result<T, E> =
       payload: E;
     };
 
-export function Ok<const T, const E>(payload: T): Result<T, E> {
+export function Ok<T, E>(payload: T): Result<T, E> {
   return {
     ok: true,
     payload,
   };
 }
 
-export function Err<const T, const E>(error: E): Result<T, E> {
+export function Err<T, E>(error: E): Result<T, E> {
   return {
     ok: false,
     payload: error,


### PR DESCRIPTION
Adding `const` generic modifier to our result functions makes it so that it's not possible to pass in arrays (possibly other things that are affected) to `Ok` (or `Err`).

For example

```ts
import {
  ServiceSchema,
  RiverUncaughtSchema,
  Procedure,
  Ok,
} from '@replit/river';
import { Type } from '@sinclair/typebox';

const SomethingWithArray = Type.Object({
  arr: Type.Array(Type.String()),
});

export const Service = ServiceSchema.define(
  {
    initializeState: () => ({}),
  },
  {
    initialize: Procedure.subscription({
      input: Type.Object({}),
      output: SomethingWithArray,
      errors: RiverUncaughtSchema,
      async handler(ctx, input, outputStream) {
        outputStream.push(
          Ok({
            arr: ['a', 'b'],
//         ^ ERROR, arr is not readonly
          }),
        );
      },
    }),
  },
);
```

I honestly don't understand what's going on here, and why we added the const modifier in the first place, so let me know if we should find another way to fix this.

Maybe we meant to do this instead? Produce a read-only result.

```
export function Ok<T, E>(payload: T): Result<const T, const E> {
  return {
    ok: true,
    payload,
  };
}
```

