### PR TITLE
Allow intersection types as payload, and nesting payloads

### DIFF
--- a/router/procedures.ts
+++ b/router/procedures.ts
@@ -28,10 +28,37 @@ export type ValidProcType =
   // Bidirectional stream (potentially preceded by an initialization message) (n:n).
   | 'stream';
 
+type PayloadType0 =
+  | TObject
+  | TUnion<Array<TObject>>
+  | TIntersect<Array<TObject>>;
+
+type PayloadType1 =
+  | TObject
+  | TUnion<Array<PayloadType0>>
+  | TIntersect<Array<PayloadType0>>;
+
+type PayloadType2 =
+  | TObject
+  | TUnion<Array<PayloadType1>>
+  | TIntersect<Array<PayloadType1>>;
+
 /**
  * Represents the payload type for {@link Procedure}s.
+ * We expect one of the following typebox schemas:
+ * - Type.Object
+ * - Type.Union (containing a nested valid payload)
+ * - Type.Intersect (containing a nested valid payload)
+ *
+ * Due to typescript limitations, we only allow a three
+ * layers of payload nesting inside intersection and
+ * unions. If you require more nesting, submit a PR to
+ * add another layer :(
  */
-export type PayloadType = TObject | TUnion<Array<TObject>>;
+type PayloadType =
+  | TObject
+  | TUnion<Array<PayloadType2>>
+  | TIntersect<Array<PayloadType2>>;
 
 /**
  * Represents results from a {@link Procedure}. Might come from inside a stream or

--- a/router/procedures.ts
+++ b/router/procedures.ts
@@ -1,4 +1,4 @@
-import { Static, TUnion, TNever, Type, TObject } from '@sinclair/typebox';
+import { Static, TUnion, TNever, Type, TObject, TIntersect } from '@sinclair/typebox';
 import type { Pushable } from 'it-pushable';
 import { ServiceContextWithTransportInfo } from './context';
 import { Result, RiverError, RiverUncaughtSchema } from './result';

--- a/router/procedures.ts
+++ b/router/procedures.ts
@@ -1,4 +1,11 @@
-import { Static, TUnion, TNever, Type, TObject, TIntersect } from '@sinclair/typebox';
+import {
+  Static,
+  TUnion,
+  TNever,
+  Type,
+  TObject,
+  TIntersect,
+} from '@sinclair/typebox';
 import type { Pushable } from 'it-pushable';
 import { ServiceContextWithTransportInfo } from './context';
 import { Result, RiverError, RiverUncaughtSchema } from './result';

--- a/router/procedures.ts
+++ b/router/procedures.ts
@@ -55,7 +55,7 @@ type PayloadType2 =
  * unions. If you require more nesting, submit a PR to
  * add another layer :(
  */
-type PayloadType =
+export type PayloadType =
   | TObject
   | TUnion<Array<PayloadType2>>
   | TIntersect<Array<PayloadType2>>;


### PR DESCRIPTION
Intersection of objects is useful when defining a schema.

There's also the issue that you can't nest unions (or intersections), ideally we write our types to allow infinite nesting as long as it bottoms out at objects, but that leads to infinite type checker recursion.
i.e. we can't do this
```ts
type PayloadType =
  | TObject
  | TUnion<Array<PayloadType>>
  | TIntersect<Array<PayloadType>>;
```

So wrote the nesting manual to allow 3 layers, hopefully that's enough for most schemas.

(courtesy of @Monkatraz)