### PR TITLE
better session cleanup

### DIFF
--- a/flake.sh
+++ b/flake.sh
@@ -1,1 +1,4 @@
-for run in {1..50}; do npm run test:single || { echo 'flake detected :((' ; exit 1; }; done
+for run in {1..50}; do
+  npm run test:single || { echo 'flake detected :((' ; exit 1; };
+  sleep 0.5;
+done

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "release": "npm publish --access public",
     "test:ui": "echo \"remember to go to /__vitest__ in the webview\" && vitest --ui --api.host 0.0.0.0 --api.port 3000",
     "test": "vitest --test-timeout=500",
-    "test:single": "vitest run --test-timeout=500",
+    "test:single": "vitest run --test-timeout=500 --reporter=dot",
     "test:flake": "./flake.sh",
     "bench": "vitest bench"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "type": "module",
   "exports": {
     ".": {

--- a/transport/impls/uds/server.ts
+++ b/transport/impls/uds/server.ts
@@ -1,4 +1,3 @@
-import { log } from '../../../logging';
 import { type Server, type Socket } from 'node:net';
 import { ServerTransport, ProvidedTransportOptions } from '../../transport';
 import { TransportClientId } from '../../message';
@@ -15,9 +14,6 @@ export class UnixDomainSocketServerTransport extends ServerTransport<UdsConnecti
     super(clientId, providedOptions);
     this.server = server;
     server.addListener('connection', this.connectionHandler);
-    server.on('listening', () => {
-      log?.info(`${this.clientId} -- server is listening`);
-    });
   }
 
   connectionHandler = (sock: Socket) => {

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -685,7 +685,6 @@ describe.each(testMatrix())(
       });
 
       const msg1 = createDummyTransportMessage();
-
       const msg1Id = clientTransport.send(serverTransport.clientId, msg1);
       await expect(
         waitForMessage(serverTransport, (recv) => recv.id === msg1Id),
@@ -709,6 +708,7 @@ describe.each(testMatrix())(
         );
       }
 
+      // should have reconnected by now
       await waitFor(() => expect(clientConnStart).toHaveBeenCalledTimes(2));
       await waitFor(() => expect(serverConnStart).toHaveBeenCalledTimes(2));
       await waitFor(() => expect(clientConnStop).toHaveBeenCalledTimes(1));
@@ -718,6 +718,13 @@ describe.each(testMatrix())(
       await waitFor(() => expect(serverSessStart).toHaveBeenCalledTimes(1));
       await waitFor(() => expect(clientSessStop).toHaveBeenCalledTimes(0));
       await waitFor(() => expect(serverSessStop).toHaveBeenCalledTimes(0));
+
+      // ensure sending across the connection still works
+      const msg2 = createDummyTransportMessage();
+      const msg2Id = clientTransport.send(serverTransport.clientId, msg2);
+      await expect(
+        waitForMessage(serverTransport, (recv) => recv.id === msg2Id),
+      ).resolves.toStrictEqual(msg2.payload);
     });
   },
 );


### PR DESCRIPTION
- old phantom disconnect test did not catch whether it was still sendable across the connection lol
- this means that we could get stuck with a stale + borked websocket
- we also know that if we session disconnect due to heartbeat misses, we forget to remove the conn from `inflightConnectionPromises` so the reconnect will use the old websocket!

this pr changes 2 things:
- let's properly cleanup the session when we delete the session from our map entry
- let's delete the inflight request on session deletion