### PR TITLE
protocol: > instead of >= for heartbeat miss check

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -325,7 +325,7 @@ The process differs slightly between the client and server:
     - Send a successful protocol handshake response back to the client.
 - A close event listener is attached to the `Connection` to handle unexpected closures. This event listener should:
   - Close the underlying wire connection if still open.
-  - Initiate the grace period for the associated `Session`'s destruction (this code path is identical to the client). 
+  - Initiate the grace period for the associated `Session`'s destruction (this code path is identical to the client).
 
 ### Handshake
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.17.3",
+      "version": "0.17.4",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "type": "module",
   "exports": {
     ".": {

--- a/transport/session.ts
+++ b/transport/session.ts
@@ -197,10 +197,12 @@ export class Session<ConnType extends Connection> {
   }
 
   sendHeartbeat() {
-    if (this.heartbeatMisses >= this.options.heartbeatsUntilDead) {
+    const misses = this.heartbeatMisses;
+    const missDuration = misses * this.options.heartbeatIntervalMs;
+    if (misses > this.options.heartbeatsUntilDead) {
       if (this.connection) {
         log?.info(
-          `${this.from} -- closing connection (id: ${this.connection.debugId}) to ${this.to} due to inactivity`,
+          `${this.from} -- closing connection (id: ${this.connection.debugId}) to ${this.to} due to inactivity (missed ${misses} heartbeats which is ${missDuration}ms)`,
         );
         this.closeStaleConnection();
       }

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -702,9 +702,9 @@ describe.each(testMatrix())(
       // now, let's wait until the connection is considered dead
       simulatePhantomDisconnect();
       await vi.runOnlyPendingTimersAsync();
-      for (let i = 0; i < testingSessionOptions.heartbeatsUntilDead; i++) {
+      for (let i = 0; i < testingSessionOptions.heartbeatsUntilDead + 1; i++) {
         await vi.advanceTimersByTimeAsync(
-          testingSessionOptions.heartbeatIntervalMs + 1,
+          testingSessionOptions.heartbeatIntervalMs,
         );
       }
 


### PR DESCRIPTION
- we used to increment heartbeat miss immediately but ALSO check if heartbeat misses >= heartbeatsUntilDead which meant that we actually had 1x less heartbeat buffer than we thought
- this combined with the fact that the default number of heartbeat misses is 2 meant that if we had bad network latency for even a single request it would die

also updated docs :)