### PR TITLE
RFC: handle bad messages

### DIFF
--- a/router/result.ts
+++ b/router/result.ts
@@ -28,10 +28,12 @@ export type RiverError =
 
 export const UNCAUGHT_ERROR = 'UNCAUGHT_ERROR';
 export const UNEXPECTED_DISCONNECT = 'UNEXPECTED_DISCONNECT';
+export const INVALID_REQUEST = 'INVALID_REQUEST';
 export const RiverUncaughtSchema = Type.Object({
   code: Type.Union([
     Type.Literal(UNCAUGHT_ERROR),
     Type.Literal(UNEXPECTED_DISCONNECT),
+    Type.Literal(INVALID_REQUEST),
   ]),
   message: Type.String(),
 });

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -283,6 +283,8 @@ export abstract class Transport<ConnType extends Connection> {
       log?.error(
         `${this.clientId} -- received malformed msg, killing conn: ${decodedBuffer}`,
       );
+      // This is a bad client or server
+      // TODO handle, probably disconnect the session, clients might want to retry?
       return null;
     }
 
@@ -292,6 +294,8 @@ export abstract class Transport<ConnType extends Connection> {
           parsedMsg,
         )}`,
       );
+      // This is a bad client or server
+      // TODO handle, probably disconnect the session, clients might want to retry?
       return null;
     }
 
@@ -309,6 +313,8 @@ export abstract class Transport<ConnType extends Connection> {
     if (!session) {
       const err = `${this.clientId} -- (invariant violation) no existing session for ${msg.from}`;
       log?.error(err);
+      // This is a bad client or server
+      // TODO handle, probably disconnect where-ever this is coming from, clients might want to retry?
       return;
     }
 
@@ -325,6 +331,8 @@ export abstract class Transport<ConnType extends Connection> {
             msg,
           )}`,
         );
+        // This is a bad client or server
+        // TODO handle, probably disconnect the session, clients might want to retry?
       } else {
         const errMsg = `received out-of-order msg (got seq: ${msg.seq}, wanted seq: ${session.nextExpectedSeq})`;
         log?.error(


### PR DESCRIPTION
I ran into a situation where my pid2 didn't have a procedure I was using on the client, and things just hanged :(.

Just an RFC, no implementation.

Left comments and suggestions. But here's a summary:
- We add a new error `INVALID_REQUEST`. We use it to respond to bad requests
- We start aggressively disconnecting clients that are misbehave