### PR TITLE
Make defining a client type more ergonomic

### DIFF
--- a/__tests__/bandwidth.bench.ts
+++ b/__tests__/bandwidth.bench.ts
@@ -25,8 +25,9 @@ describe('bandwidth', async () => {
 
     const clientTransport = getClientTransport('client');
     const serverTransport = getServerTransport();
-    const server = createServer(serverTransport, { test: TestServiceSchema });
-    const client = createClient<typeof server>(
+    const services = { test: TestServiceSchema };
+    createServer(serverTransport, services);
+    const client = createClient<typeof services>(
       clientTransport,
       serverTransport.clientId,
     );

--- a/__tests__/cleanup.test.ts
+++ b/__tests__/cleanup.test.ts
@@ -35,8 +35,9 @@ describe.each(testMatrix())(
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, { test: TestServiceSchema });
-      const client = createClient<typeof server>(
+      const services = { test: TestServiceSchema };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
         clientTransport,
         serverTransport.clientId,
       );
@@ -74,8 +75,9 @@ describe.each(testMatrix())(
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, { test: TestServiceSchema });
-      const client = createClient<typeof server>(
+      const services = { test: TestServiceSchema };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
         clientTransport,
         serverTransport.clientId,
       );
@@ -113,8 +115,9 @@ describe.each(testMatrix())(
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, { test: TestServiceSchema });
-      const client = createClient<typeof server>(
+      const services = { test: TestServiceSchema };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
         clientTransport,
         serverTransport.clientId,
       );
@@ -159,8 +162,9 @@ describe.each(testMatrix())(
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, { test: TestServiceSchema });
-      const client = createClient<typeof server>(
+      const services = { test: TestServiceSchema };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
         clientTransport,
         serverTransport.clientId,
       );
@@ -226,10 +230,11 @@ describe.each(testMatrix())(
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, {
+      const services = {
         subscribable: SubscribableServiceSchema,
-      });
-      const client = createClient<typeof server>(
+      };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
         clientTransport,
         serverTransport.clientId,
       );
@@ -288,10 +293,9 @@ describe.each(testMatrix())(
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, {
-        uploadable: UploadableServiceSchema,
-      });
-      const client = createClient<typeof server>(
+      const services = { uploadable: UploadableServiceSchema };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
         clientTransport,
         serverTransport.clientId,
       );
@@ -344,8 +348,9 @@ describe.each(testMatrix())(
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, { test: TestServiceSchema });
-      const client = createClient<typeof server>(
+      const services = { test: TestServiceSchema };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
         clientTransport,
         serverTransport.clientId,
       );

--- a/__tests__/disconnects.test.ts
+++ b/__tests__/disconnects.test.ts
@@ -33,8 +33,9 @@ describe.each(testMatrix())(
     test('rpc', async () => {
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, { test: TestServiceSchema });
-      const client = createClient<typeof server>(
+      const services = { test: TestServiceSchema };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
         clientTransport,
         serverTransport.clientId,
       );
@@ -75,8 +76,9 @@ describe.each(testMatrix())(
     test('stream', async () => {
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, { test: TestServiceSchema });
-      const client = createClient<typeof server>(
+      const services = { test: TestServiceSchema };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
         clientTransport,
         serverTransport.clientId,
       );
@@ -123,14 +125,15 @@ describe.each(testMatrix())(
       const client2Transport = getClientTransport('client2');
       const serverTransport = getServerTransport();
 
-      const server = createServer(serverTransport, {
+      const services = {
         subscribable: SubscribableServiceSchema,
-      });
-      const client1 = createClient<typeof server>(
+      };
+      const server = createServer(serverTransport, services);
+      const client1 = createClient<typeof services>(
         client1Transport,
         serverTransport.clientId,
       );
-      const client2 = createClient<typeof server>(
+      const client2 = createClient<typeof services>(
         client2Transport,
         serverTransport.clientId,
       );
@@ -211,10 +214,11 @@ describe.each(testMatrix())(
     test('upload', async () => {
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, {
+      const services = {
         uploadable: UploadableServiceSchema,
-      });
-      const client = createClient<typeof server>(
+      };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
         clientTransport,
         serverTransport.clientId,
       );

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -41,8 +41,9 @@ describe.each(testMatrix())(
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, { test: TestServiceSchema });
-      const client = createClient<typeof server>(
+      const services = { test: TestServiceSchema };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
         clientTransport,
         serverTransport.clientId,
       );
@@ -64,10 +65,11 @@ describe.each(testMatrix())(
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, {
+      const services = {
         fallible: FallibleServiceSchema,
-      });
-      const client = createClient<typeof server>(
+      };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
         clientTransport,
         serverTransport.clientId,
       );
@@ -98,10 +100,11 @@ describe.each(testMatrix())(
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, {
+      const services = {
         bin: BinaryFileServiceSchema,
-      });
-      const client = createClient<typeof server>(
+      };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
         clientTransport,
         serverTransport.clientId,
       );
@@ -126,8 +129,9 @@ describe.each(testMatrix())(
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, { test: TestServiceSchema });
-      const client = createClient<typeof server>(
+      const services = { test: TestServiceSchema };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
         clientTransport,
         serverTransport.clientId,
       );
@@ -169,8 +173,9 @@ describe.each(testMatrix())(
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, { test: TestServiceSchema });
-      const client = createClient<typeof server>(
+      const services = { test: TestServiceSchema };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
         clientTransport,
         serverTransport.clientId,
       );
@@ -206,10 +211,11 @@ describe.each(testMatrix())(
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, {
+      const services = {
         fallible: FallibleServiceSchema,
-      });
-      const client = createClient<typeof server>(
+      };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
         clientTransport,
         serverTransport.clientId,
       );
@@ -248,10 +254,11 @@ describe.each(testMatrix())(
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, {
+      const services = {
         subscribable: SubscribableServiceSchema,
-      });
-      const client = createClient<typeof server>(
+      };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
         clientTransport,
         serverTransport.clientId,
       );
@@ -292,10 +299,11 @@ describe.each(testMatrix())(
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, {
+      const services = {
         uploadable: UploadableServiceSchema,
-      });
-      const client = createClient<typeof server>(
+      };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
         clientTransport,
         serverTransport.clientId,
       );
@@ -322,10 +330,11 @@ describe.each(testMatrix())(
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, {
+      const services = {
         uploadable: UploadableServiceSchema,
-      });
-      const client = createClient<typeof server>(
+      };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
         clientTransport,
         serverTransport.clientId,
       );
@@ -354,10 +363,11 @@ describe.each(testMatrix())(
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, {
+      const services = {
         test: OrderingServiceSchema,
-      });
-      const client = createClient<typeof server>(
+      };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
         clientTransport,
         serverTransport.clientId,
       );
@@ -403,10 +413,11 @@ describe.each(testMatrix())(
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, {
+      const services = {
         test: OrderingServiceSchema,
-      });
-      const client = createClient<typeof server>(
+      };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
         clientTransport,
         serverTransport.clientId,
       );
@@ -435,8 +446,9 @@ describe.each(testMatrix())(
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, { test: TestServiceSchema });
-      const client = createClient<typeof server>(
+      const services = { test: TestServiceSchema };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
         clientTransport,
         serverTransport.clientId,
       );
@@ -480,8 +492,9 @@ describe.each(testMatrix())(
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, { test: TestServiceSchema });
-      createClient<typeof server>(clientTransport, serverTransport.clientId, {
+      const services = { test: TestServiceSchema };
+      const server = createServer(serverTransport, services);
+      createClient<typeof services>(clientTransport, serverTransport.clientId, {
         eagerlyConnect: true,
       });
 
@@ -502,8 +515,9 @@ describe.each(testMatrix())(
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, { test: TestServiceSchema });
-      const client = createClient<typeof server>(
+      const services = { test: TestServiceSchema };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
         clientTransport,
         serverTransport.clientId,
         { connectOnInvoke: true },
@@ -544,8 +558,9 @@ describe.each(testMatrix())(
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, { test: TestServiceSchema });
-      const client = createClient<typeof server>(
+      const services = { test: TestServiceSchema };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
         clientTransport,
         serverTransport.clientId,
         {
@@ -584,10 +599,11 @@ describe.each(testMatrix())(
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      const server = createServer(serverTransport, {
+      const services = {
         nonObject: NonObjectSchemas,
-      });
-      const client = createClient<typeof server>(
+      };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
         clientTransport,
         serverTransport.clientId,
       );

--- a/__tests__/fixtures/cleanup.ts
+++ b/__tests__/fixtures/cleanup.ts
@@ -2,7 +2,7 @@ import { expect, vi } from 'vitest';
 import { Connection, OpaqueTransportMessage, Transport } from '../../transport';
 import { Server } from '../../router';
 import { log } from '../../logging';
-import { ServiceSchemaMap } from '../../router/services';
+import { AnyServiceSchemaMap } from '../../router/services';
 import { testingSessionOptions } from '../../util/testHelpers';
 
 const waitUntilOptions = {
@@ -93,7 +93,7 @@ export async function ensureTransportBuffersAreEventuallyEmpty(
   );
 }
 
-export async function ensureServerIsClean(s: Server<ServiceSchemaMap>) {
+export async function ensureServerIsClean(s: Server<AnyServiceSchemaMap>) {
   return waitFor(() =>
     expect(
       s.streams,
@@ -109,7 +109,7 @@ export async function testFinishesCleanly({
 }: Partial<{
   clientTransports: Array<Transport<Connection>>;
   serverTransport: Transport<Connection>;
-  server: Server<ServiceSchemaMap>;
+  server: Server<AnyServiceSchemaMap>;
 }>) {
   log?.info('*** end of test cleanup ***');
   vi.useFakeTimers({ shouldAdvanceTime: true });

--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -68,13 +68,14 @@ test('ws <-> uds proxy works', async () => {
     'uds',
     { codec: BinaryCodec },
   );
-  const server = createServer(serverTransport, { test: TestServiceSchema });
+  const services = { test: TestServiceSchema };
+  const server = createServer(serverTransport, services);
   const clientTransport = new WebSocketClientTransport(
     () => Promise.resolve(createLocalWebSocketClient(port)),
     'ws',
     { codec: BinaryCodec },
   );
-  const client = createClient<typeof server>(
+  const client = createClient<typeof services>(
     clientTransport,
     serverTransport.clientId,
   );

--- a/__tests__/typescript-stress.test.ts
+++ b/__tests__/typescript-stress.test.ts
@@ -124,7 +124,7 @@ describe("ensure typescript doesn't give up trying to infer the types for large 
   });
 
   test('server client should support many services with many procedures', () => {
-    const server = createServer(new MockServerTransport('SERVER'), {
+    const services = {
       a: StupidlyLargeServiceSchema,
       b: StupidlyLargeServiceSchema,
       c: StupidlyLargeServiceSchema,
@@ -178,9 +178,10 @@ describe("ensure typescript doesn't give up trying to infer the types for large 
       y1: StupidlyLargeServiceSchema,
       z1: StupidlyLargeServiceSchema,
       test: TestServiceSchema,
-    });
+    };
+    const server = createServer(new MockServerTransport('SERVER'), services);
 
-    const client = createClient<typeof server>(
+    const client = createClient<typeof services>(
       new MockClientTransport('client'),
       'SERVER',
       { eagerlyConnect: false },

--- a/router/client.ts
+++ b/router/client.ts
@@ -7,11 +7,11 @@ import {
   ProcInput,
   ProcOutput,
   ProcType,
-  ServiceSchemaMap,
+  AnyServiceSchemaMap,
+  InstantiatedServiceSchemaMap,
 } from './services';
 import { pushable } from 'it-pushable';
 import type { Pushable } from 'it-pushable';
-import { Server } from './server';
 import {
   OpaqueTransportMessage,
   ControlFlags,
@@ -128,8 +128,12 @@ type ServiceClient<Router extends AnyService> = {
  * Defines a type that represents a client for a server with a set of services.
  * @template Srv - The type of the server.
  */
-export type ServerClient<Srv extends Server<ServiceSchemaMap>> = {
-  [SvcName in keyof Srv['services']]: ServiceClient<Srv['services'][SvcName]>;
+export type ServerClient<
+  ServiceSchemaMap extends AnyServiceSchemaMap,
+  Services extends
+    InstantiatedServiceSchemaMap<ServiceSchemaMap> = InstantiatedServiceSchemaMap<ServiceSchemaMap>,
+> = {
+  [SvcName in keyof Services]: ServiceClient<Services[SvcName]>;
 };
 
 interface ProxyCallbackOptions {
@@ -186,7 +190,7 @@ const defaultClientOptions: ClientOptions = {
  * @param {Transport} transport - The transport to use for communication.
  * @returns The client for the server.
  */
-export const createClient = <Srv extends Server<ServiceSchemaMap>>(
+export const createClient = <ServiceSchemaMap extends AnyServiceSchemaMap>(
   transport: ClientTransport<Connection>,
   serverId: TransportClientId,
   providedClientOptions: Partial<ClientOptions> = {},
@@ -252,7 +256,7 @@ export const createClient = <Srv extends Server<ServiceSchemaMap>>(
     } else {
       throw new Error(`invalid river call, unknown procedure type ${procType}`);
     }
-  }, []) as ServerClient<Srv>;
+  }, []) as ServerClient<ServiceSchemaMap>;
 };
 
 function createSessionDisconnectHandler(

--- a/router/client.ts
+++ b/router/client.ts
@@ -128,12 +128,12 @@ type ServiceClient<Router extends AnyService> = {
  * Defines a type that represents a client for a server with a set of services.
  * @template Srv - The type of the server.
  */
-export type ServerClient<
-  ServiceSchemaMap extends AnyServiceSchemaMap,
-  Services extends
-    InstantiatedServiceSchemaMap<ServiceSchemaMap> = InstantiatedServiceSchemaMap<ServiceSchemaMap>,
+export type Client<
+  Services extends AnyServiceSchemaMap,
+  IS extends
+    InstantiatedServiceSchemaMap<Services> = InstantiatedServiceSchemaMap<Services>,
 > = {
-  [SvcName in keyof Services]: ServiceClient<Services[SvcName]>;
+  [SvcName in keyof IS]: ServiceClient<IS[SvcName]>;
 };
 
 interface ProxyCallbackOptions {
@@ -194,7 +194,7 @@ export const createClient = <ServiceSchemaMap extends AnyServiceSchemaMap>(
   transport: ClientTransport<Connection>,
   serverId: TransportClientId,
   providedClientOptions: Partial<ClientOptions> = {},
-) => {
+): Client<ServiceSchemaMap> => {
   const options = { ...defaultClientOptions, ...providedClientOptions };
   if (options.eagerlyConnect) {
     void transport.connect(serverId);
@@ -256,7 +256,7 @@ export const createClient = <ServiceSchemaMap extends AnyServiceSchemaMap>(
     } else {
       throw new Error(`invalid river call, unknown procedure type ${procType}`);
     }
-  }, []) as ServerClient<ServiceSchemaMap>;
+  }, []) as Client<ServiceSchemaMap>;
 };
 
 function createSessionDisconnectHandler(

--- a/router/index.ts
+++ b/router/index.ts
@@ -21,7 +21,7 @@ export type {
 } from './procedures';
 export { Procedure } from './procedures';
 export { createClient } from './client';
-export type { ServerClient } from './client';
+export type { Client } from './client';
 export { createServer } from './server';
 export type { Server } from './server';
 export type {

--- a/router/server.ts
+++ b/router/server.ts
@@ -5,7 +5,7 @@ import {
   AnyService,
   InstantiatedServiceSchemaMap,
   SerializedServiceSchema,
-  ServiceSchemaMap,
+  AnyServiceSchemaMap,
 } from './services';
 import { pushable } from 'it-pushable';
 import type { Pushable } from 'it-pushable';
@@ -39,7 +39,7 @@ import { coerceErrorString } from '../util/stringify';
  * Represents a server with a set of services. Use {@link createServer} to create it.
  * @template Services - The type of services provided by the server.
  */
-export interface Server<Services extends ServiceSchemaMap> {
+export interface Server<Services extends AnyServiceSchemaMap> {
   services: InstantiatedServiceSchemaMap<Services>;
   streams: Map<string, ProcStream>;
   serialize(): SerializedServerSchema;
@@ -60,7 +60,7 @@ interface ProcStream {
 
 type SerializedServerSchema = Record<string, SerializedServiceSchema>;
 
-class RiverServer<Services extends ServiceSchemaMap> {
+class RiverServer<Services extends AnyServiceSchemaMap> {
   transport: Transport<Connection>;
   private serviceDefs: Services;
   services: InstantiatedServiceSchemaMap<Services>;
@@ -479,7 +479,7 @@ class RiverServer<Services extends ServiceSchemaMap> {
  * @param extendedContext - An optional object containing additional context to be passed to all services.
  * @returns A promise that resolves to a server instance with the registered services.
  */
-export function createServer<Services extends ServiceSchemaMap>(
+export function createServer<Services extends AnyServiceSchemaMap>(
   transport: ServerTransport<Connection>,
   services: Services,
   extendedContext?: Omit<ServiceContext, 'state'>,

--- a/router/services.ts
+++ b/router/services.ts
@@ -34,13 +34,13 @@ export type AnyServiceSchema = ServiceSchema<object, ProcedureMap>;
 /**
  * A dictionary of {@link ServiceSchema}s, where the key is the service name.
  */
-export type ServiceSchemaMap = Record<string, AnyServiceSchema>;
+export type AnyServiceSchemaMap = Record<string, AnyServiceSchema>;
 
 /**
- * Takes a {@link ServiceSchemaMap} and returns a dictionary of instantiated
+ * Takes a {@link AnyServiceSchemaMap} and returns a dictionary of instantiated
  * services.
  */
-export type InstantiatedServiceSchemaMap<T extends ServiceSchemaMap> = {
+export type InstantiatedServiceSchemaMap<T extends AnyServiceSchemaMap> = {
   [K in keyof T]: T[K] extends ServiceSchema<infer S, infer P>
     ? Service<S, P>
     : never;

--- a/router/services.ts
+++ b/router/services.ts
@@ -36,6 +36,9 @@ export type AnyServiceSchema = ServiceSchema<object, ProcedureMap>;
  */
 export type AnyServiceSchemaMap = Record<string, AnyServiceSchema>;
 
+// This has the secret sauce to keep go to definition working, the structure is
+// somewhat delicate, so be careful when modifying it. Would be nice to add a
+// static
 /**
  * Takes a {@link AnyServiceSchemaMap} and returns a dictionary of instantiated
  * services.

--- a/router/services.ts
+++ b/router/services.ts
@@ -38,7 +38,7 @@ export type AnyServiceSchemaMap = Record<string, AnyServiceSchema>;
 
 // This has the secret sauce to keep go to definition working, the structure is
 // somewhat delicate, so be careful when modifying it. Would be nice to add a
-// static
+// static test for this.
 /**
  * Takes a {@link AnyServiceSchemaMap} and returns a dictionary of instantiated
  * services.


### PR DESCRIPTION
## Why

<!-- Describe what you are trying to accomplish with this pull request -->

![image](https://github.com/replit/river/assets/1994028/ad393199-3c98-4c07-bfbe-aa787aff0bce)

Defining a client type is a little ugly.

## What changed

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

- Appropriately rename `ServiceSchemaMap` to `AnyServiceSchemaMap` (it's not a generic)
- `ServerClient` renamed to `Client` and now takes a `SerivceSchemaMap`
- Fix tests

![image](https://github.com/replit/river/assets/1994028/caf72a78-6a06-4391-a418-4c8545553ef9)
drake.jpg


## Versioning

- [ ] Breaking protocol change
- [x] Breaking ts/js API change 
types only breaking

<!-- Kind reminder to add tests and updated documentation if needed -->