### PR TITLE
kill hanging connections that dont send a heartbeat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "type": "module",
   "exports": {
     ".": {

--- a/router/server.ts
+++ b/router/server.ts
@@ -1,5 +1,5 @@
 import { Static } from '@sinclair/typebox';
-import { ServerTransport, Transport } from '../transport/transport';
+import { ServerTransport } from '../transport/transport';
 import { AnyProcedure, PayloadType } from './procedures';
 import {
   AnyService,
@@ -61,7 +61,7 @@ interface ProcStream {
 type SerializedServerSchema = Record<string, SerializedServiceSchema>;
 
 class RiverServer<Services extends AnyServiceSchemaMap> {
-  transport: Transport<Connection>;
+  transport: ServerTransport<Connection>;
   private serviceDefs: Services;
   services: InstantiatedServiceSchemaMap<Services>;
   contextMap: Map<AnyService, ServiceContextWithState<object>>;
@@ -72,7 +72,7 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
   disconnectedSessions: Set<TransportClientId>;
 
   constructor(
-    transport: Transport<Connection>,
+    transport: ServerTransport<Connection>,
     services: Services,
     extendedContext?: Omit<ServiceContext, 'state'>,
   ) {

--- a/transport/impls/uds/uds.test.ts
+++ b/transport/impls/uds/uds.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, afterAll, onTestFinished } from 'vitest';
+import { describe, test, expect, afterAll, onTestFinished, vi } from 'vitest';
 import { UnixDomainSocketClientTransport } from './client';
 import { UnixDomainSocketServerTransport } from './server';
 import {
@@ -7,7 +7,10 @@ import {
   payloadToTransportMessage,
   waitForMessage,
 } from '../../../util/testHelpers';
-import { testFinishesCleanly } from '../../../__tests__/fixtures/cleanup';
+import {
+  advanceFakeTimersBySessionGrace,
+  testFinishesCleanly,
+} from '../../../__tests__/fixtures/cleanup';
 import net from 'node:net';
 
 describe('sending and receiving across unix sockets works', async () => {
@@ -55,5 +58,50 @@ describe('sending and receiving across unix sockets works', async () => {
         waitForMessage(serverTransport, (incoming) => incoming.id === msgId),
       ).resolves.toStrictEqual(transportMessage.payload);
     }
+  });
+});
+
+describe('network edge cases', async () => {
+  const socketPath = getUnixSocketPath();
+  const server = net.createServer();
+  await onUdsServeReady(server, socketPath);
+
+  afterAll(() => {
+    server.close();
+  });
+
+  test('hanging uds connection with no handshake is cleaned up after grace', async () => {
+    const serverTransport = new UnixDomainSocketServerTransport(
+      server,
+      'SERVER',
+    );
+    onTestFinished(async () => {
+      await testFinishesCleanly({
+        clientTransports: [],
+        serverTransport,
+      });
+    });
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const sock = await new Promise<net.Socket>((resolve, reject) => {
+      const sock = new net.Socket();
+      sock.on('connect', () => resolve(sock));
+      sock.on('error', (err) => reject(err));
+      sock.connect(socketPath);
+    });
+
+    expect(sock.readyState).toBe('open');
+
+    // we never sent a handshake so there should be no connections or sessions
+    expect(serverTransport.connections.size).toBe(0);
+    expect(serverTransport.sessions.size).toBe(0);
+
+    // advance time past the grace period
+    await advanceFakeTimersBySessionGrace();
+
+    // the connection should have been cleaned up
+    expect(serverTransport.connections.size).toBe(0);
+    expect(serverTransport.sessions.size).toBe(0);
+    expect(sock.readyState).toBe('closed');
   });
 });


### PR DESCRIPTION
## Why

- we used to wait forever to receive a handshake

## What changed

- let's not do that and kill connections after the session grace expires
- added tests to make sure this works with both ws + uds


## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
