### PR TITLE
export some more things, accept broader log interface

### DIFF
--- a/logging/index.ts
+++ b/logging/index.ts
@@ -4,4 +4,4 @@ export {
   jsonLogger,
   bindLogger,
 } from './log';
-export type { LogFn, MessageMetadata } from './log';
+export type { Logger, LogFn, MessageMetadata } from './log';

--- a/logging/log.ts
+++ b/logging/log.ts
@@ -29,7 +29,7 @@ export type MessageMetadata = Record<string, unknown> &
     partialTransportMessage: Partial<PartialTransportMessage>;
   }>;
 
-class BaseLogger {
+class BaseLogger implements Logger {
   minLevel: LoggingLevel;
   private output: LogFn;
 
@@ -83,21 +83,21 @@ export const jsonLogger: LogFn = (msg, ctx, level) => {
   console.log(JSON.stringify({ msg, ctx, level }));
 };
 
-export let log: BaseLogger | undefined = undefined;
+export let log: Logger | undefined = undefined;
 export function bindLogger(
-  fn: LogFn | BaseLogger | undefined,
+  fn: LogFn | Logger | undefined,
   level?: LoggingLevel,
-) {
+): Logger | undefined {
   if (!fn) {
     log = undefined;
     return;
   }
 
-  if (fn instanceof BaseLogger) {
-    log = fn;
-    return fn;
+  if (fn instanceof Function) {
+    log = new BaseLogger(fn, level);
+    return log;
   }
 
-  log = new BaseLogger(fn, level);
-  return log;
+  log = fn;
+  return fn;
 }


### PR DESCRIPTION
## Why

<!-- Describe what you are trying to accomplish with this pull request -->

- old required you to pass in an explicit BaseLogger, let's just accept anything that satisfies Logger

## What changed

- accept Logger instead of BaseLogger
- export Logger interface

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [x] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
