### PR TITLE
Add INVALID_REQUEST to RiverUncaughtSchema

### DIFF
--- a/router/result.ts
+++ b/router/result.ts
@@ -28,10 +28,12 @@ export type RiverError =
 
 export const UNCAUGHT_ERROR = 'UNCAUGHT_ERROR';
 export const UNEXPECTED_DISCONNECT = 'UNEXPECTED_DISCONNECT';
+export const INVALID_REQUEST = 'INVALID_REQUEST';
 export const RiverUncaughtSchema = Type.Object({
   code: Type.Union([
     Type.Literal(UNCAUGHT_ERROR),
     Type.Literal(UNEXPECTED_DISCONNECT),
+    Type.Literal(INVALID_REQUEST),
   ]),
   message: Type.String(),
 });


### PR DESCRIPTION
## Why

Starting implementation for #98

## What changed

Just updating the error the request in this PR.

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

This is technically backwards compatible, but it is a protocol addition

<!-- Kind reminder to add tests and updated documentation if needed -->
