### PR TITLE
[WS-3468] River-side changes for Option A of identity work

### DIFF
--- a/__tests__/cleanup.test.ts
+++ b/__tests__/cleanup.test.ts
@@ -28,7 +28,7 @@ describe.each(testMatrix())(
   async ({ transport, codec }) => {
     const opts = { codec: codec.codec };
     const { getClientTransport, getServerTransport, cleanup } =
-      await transport.setup(opts);
+      await transport.setup({ client: opts, server: opts });
     afterAll(cleanup);
 
     test('closing a transport from the client cleans up connection on the server', async () => {

--- a/__tests__/disconnects.test.ts
+++ b/__tests__/disconnects.test.ts
@@ -27,7 +27,7 @@ describe.each(testMatrix())(
   async ({ transport, codec }) => {
     const opts = { codec: codec.codec };
     const { getClientTransport, getServerTransport, cleanup } =
-      await transport.setup(opts);
+      await transport.setup({ client: opts, server: opts });
     afterAll(cleanup);
 
     test('rpc', async () => {

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -34,7 +34,7 @@ describe.each(testMatrix())(
   async ({ transport, codec }) => {
     const opts = { codec: codec.codec };
     const { getClientTransport, getServerTransport, cleanup } =
-      await transport.setup(opts);
+      await transport.setup({ client: opts, server: opts });
     afterAll(cleanup);
 
     test('rpc', async () => {

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -22,13 +22,15 @@ import {
   NonObjectSchemas,
   SchemaWithDisposableState,
 } from './fixtures/services';
-import { UNCAUGHT_ERROR } from '../router/result';
+import { Ok, UNCAUGHT_ERROR } from '../router/result';
 import {
   advanceFakeTimersBySessionGrace,
   testFinishesCleanly,
   waitFor,
 } from './fixtures/cleanup';
 import { testMatrix } from './fixtures/matrix';
+import { Type } from '@sinclair/typebox';
+import { Procedure, ServiceSchema } from '../router';
 
 describe.each(testMatrix())(
   'client <-> server integration test ($transport.name transport, $codec.name codec)',
@@ -652,6 +654,89 @@ describe.each(testMatrix())(
       // test
       await server.close();
       expect(dispose).toBeCalledTimes(1);
+    });
+  },
+);
+
+describe.each(testMatrix())(
+  'client <-> server with handshake tests ($transport.name transport, $codec.name codec)',
+  async ({ transport, codec }) => {
+    const requestSchema = Type.Object({
+      data: Type.String(),
+    });
+
+    const parsedSchema = Type.Object({
+      data: Type.String(),
+      extra: Type.Number(),
+    });
+
+    const { getClientTransport, getServerTransport, cleanup } =
+      await transport.setup({
+        client: {
+          codec: codec.codec,
+          handshake: {
+            schema: requestSchema,
+            get: () => ({ data: 'foobar' }),
+          },
+        },
+
+        server: {
+          codec: codec.codec,
+          handshake: {
+            requestSchema,
+            parsedSchema,
+            parse: (metadata) => {
+              return {
+                // @ts-expect-error we haven't extended the interface
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                data: metadata.data,
+                extra: 42,
+              };
+            },
+          },
+        },
+      });
+
+    afterAll(cleanup);
+
+    test('procedure can use metadata', async () => {
+      // setup
+      const clientTransport = getClientTransport('client');
+      const serverTransport = getServerTransport();
+      const services = {
+        test: ServiceSchema.define({
+          getData: Procedure.rpc({
+            input: Type.Object({}),
+            output: Type.Object({
+              data: Type.String(),
+              extra: Type.Number(),
+            }),
+            handler: async (ctx) => {
+              // we haven't extended the interface, so we need to suppress the error
+              // with a cast
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              return Ok({ ...ctx.session.metadata } as any);
+            },
+          }),
+        }),
+      };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
+        clientTransport,
+        serverTransport.clientId,
+      );
+      onTestFinished(async () => {
+        await testFinishesCleanly({
+          clientTransports: [clientTransport],
+          serverTransport,
+          server,
+        });
+      });
+
+      // test
+      const result = await client.test.getData.rpc({});
+      assert(result.ok);
+      expect(result.payload).toStrictEqual({ data: 'foobar', extra: 42 });
     });
   },
 );

--- a/__tests__/fixtures/matrix.ts
+++ b/__tests__/fixtures/matrix.ts
@@ -5,14 +5,17 @@ import {
   ServerTransport,
   TransportClientId,
 } from '../../transport';
-import { ProvidedTransportOptions } from '../../transport/transport';
 import { ValidCodecs, codecs } from './codec';
-import { ValidTransports, transports } from './transports';
+import {
+  TestTransportOptions,
+  ValidTransports,
+  transports,
+} from './transports';
 
 interface TestMatrixEntry {
   transport: {
     name: string;
-    setup: (opts?: ProvidedTransportOptions) => Promise<{
+    setup: (opts?: TestTransportOptions) => Promise<{
       simulatePhantomDisconnect: () => void;
       getClientTransport: (
         id: TransportClientId,

--- a/__tests__/fixtures/transports.ts
+++ b/__tests__/fixtures/transports.ts
@@ -15,14 +15,23 @@ import {
 } from '../../util/testHelpers';
 import { UnixDomainSocketClientTransport } from '../../transport/impls/uds/client';
 import { UnixDomainSocketServerTransport } from '../../transport/impls/uds/server';
-import { ProvidedTransportOptions } from '../../transport/transport';
+import {
+  ProvidedClientTransportOptions,
+  ProvidedServerTransportOptions,
+} from '../../transport/transport';
 import { WebSocketClientTransport } from '../../transport/impls/ws/client';
 import { WebSocketServerTransport } from '../../transport/impls/ws/server';
 
 export type ValidTransports = 'ws' | 'unix sockets';
+
+export interface TestTransportOptions {
+  client?: ProvidedClientTransportOptions;
+  server?: ProvidedServerTransportOptions;
+}
+
 export const transports: Array<{
   name: ValidTransports;
-  setup: (opts?: ProvidedTransportOptions) => Promise<{
+  setup: (opts?: TestTransportOptions) => Promise<{
     getClientTransport: (id: TransportClientId) => ClientTransport<Connection>;
     getServerTransport: () => ServerTransport<Connection>;
     simulatePhantomDisconnect: () => void;
@@ -52,7 +61,7 @@ export const transports: Array<{
           const clientTransport = new WebSocketClientTransport(
             () => Promise.resolve(createLocalWebSocketClient(port)),
             id,
-            opts,
+            opts?.client,
           );
           void clientTransport.connect('SERVER');
           transports.push(clientTransport);
@@ -62,7 +71,7 @@ export const transports: Array<{
           const serverTransport = new WebSocketServerTransport(
             wss,
             'SERVER',
-            opts,
+            opts?.server,
           );
           transports.push(serverTransport);
           return serverTransport;
@@ -113,7 +122,7 @@ export const transports: Array<{
           const clientTransport = new UnixDomainSocketClientTransport(
             socketPath,
             id,
-            opts,
+            opts?.client,
           );
           void clientTransport.connect('SERVER');
           transports.push(clientTransport);
@@ -123,7 +132,7 @@ export const transports: Array<{
           const serverTransport = new UnixDomainSocketServerTransport(
             server,
             'SERVER',
-            opts,
+            opts?.server,
           );
           transports.push(serverTransport);
           return serverTransport;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.18.5",
+  "version": "0.19.0",
   "type": "module",
   "exports": {
     ".": {

--- a/router/context.ts
+++ b/router/context.ts
@@ -1,3 +1,10 @@
+import {
+  Connection,
+  ParsedHandshakeMetadata,
+  Session,
+  TransportClientId,
+} from '../transport';
+
 /**
  * The context for services/procedures. This is used only on
  * the server.
@@ -18,9 +25,6 @@
  * }
  * ```
  */
-
-import { Connection, Session, TransportClientId } from '../transport';
-
 /* eslint-disable-next-line @typescript-eslint/no-empty-interface */
 export interface ServiceContext {}
 
@@ -34,5 +38,5 @@ export type ServiceContextWithTransportInfo<State> = ServiceContext & {
   to: TransportClientId;
   from: TransportClientId;
   streamId: string;
-  session: Session<Connection>;
+  session: Session<Connection> & { handshakeMetadata: ParsedHandshakeMetadata };
 };

--- a/router/context.ts
+++ b/router/context.ts
@@ -38,5 +38,5 @@ export type ServiceContextWithTransportInfo<State> = ServiceContext & {
   to: TransportClientId;
   from: TransportClientId;
   streamId: string;
-  session: Session<Connection> & { handshakeMetadata: ParsedHandshakeMetadata };
+  session: Session<Connection> & { metadata: ParsedHandshakeMetadata };
 };

--- a/router/server.ts
+++ b/router/server.ts
@@ -265,7 +265,7 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
     // by this point, our sessions should always have their handshake metadata
     if (session.metadata === undefined) {
       log?.error(
-        `session ${message.from} doesn't have handshake metadata, can't proceed with procedure`,
+        `(invariant violation) session doesn't have handshake metadata`,
         session.loggingMetadata,
       );
       return;

--- a/router/server.ts
+++ b/router/server.ts
@@ -269,6 +269,15 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
       );
     };
 
+    // by this point, our sessions should always have their handshake metadata
+    if (session.handshakeMetadata === undefined) {
+      log?.error(
+        `session ${message.from} doesn't have handshake metadata, can't proceed with procedure`,
+        session.loggingMetadata,
+      );
+      return;
+    }
+
     // pump incoming message stream -> handler -> outgoing message stream
     let inputHandler: Promise<unknown>;
     const procHasInitMessage = 'init' in procedure;
@@ -278,7 +287,8 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
         to: message.to,
         from: message.from,
         streamId: message.streamId,
-        session,
+        // we've already validated that the session has handshake metadata
+        session: session as ServiceContextWithTransportInfo<object>['session'],
       };
 
     switch (procedure.type) {

--- a/router/server.ts
+++ b/router/server.ts
@@ -263,7 +263,7 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
     };
 
     // by this point, our sessions should always have their handshake metadata
-    if (session.handshakeMetadata === undefined) {
+    if (session.metadata === undefined) {
       log?.error(
         `session ${message.from} doesn't have handshake metadata, can't proceed with procedure`,
         session.loggingMetadata,

--- a/transport/impls/uds/server.ts
+++ b/transport/impls/uds/server.ts
@@ -1,5 +1,8 @@
 import { type Server, type Socket } from 'node:net';
-import { ServerTransport, ProvidedTransportOptions } from '../../transport';
+import {
+  ServerTransport,
+  ProvidedServerTransportOptions,
+} from '../../transport';
 import { TransportClientId } from '../../message';
 import { UdsConnection } from './connection';
 
@@ -9,7 +12,7 @@ export class UnixDomainSocketServerTransport extends ServerTransport<UdsConnecti
   constructor(
     server: Server,
     clientId: TransportClientId,
-    providedOptions?: Partial<ProvidedTransportOptions>,
+    providedOptions?: Partial<ProvidedServerTransportOptions>,
   ) {
     super(clientId, providedOptions);
     this.server = server;

--- a/transport/impls/ws/server.ts
+++ b/transport/impls/ws/server.ts
@@ -1,5 +1,8 @@
 import { TransportClientId } from '../../message';
-import { ServerTransport, ProvidedTransportOptions } from '../../transport';
+import {
+  ServerTransport,
+  ProvidedServerTransportOptions,
+} from '../../transport';
 import { WebSocketServer } from 'ws';
 import { WebSocket } from 'isomorphic-ws';
 import { WebSocketConnection } from './connection';
@@ -10,7 +13,7 @@ export class WebSocketServerTransport extends ServerTransport<WebSocketConnectio
   constructor(
     wss: WebSocketServer,
     clientId: TransportClientId,
-    providedOptions?: ProvidedTransportOptions,
+    providedOptions?: ProvidedServerTransportOptions,
   ) {
     super(clientId, providedOptions);
     this.wss = wss;

--- a/transport/index.ts
+++ b/transport/index.ts
@@ -2,6 +2,7 @@ export { Transport, ClientTransport, ServerTransport } from './transport';
 export type {
   ProvidedTransportOptions as TransportOptions,
   ProvidedClientTransportOptions as ClientTransportOptions,
+  ProvidedServerTransportOptions as ServerTransportOptions,
   TransportStatus,
 } from './transport';
 export { Connection, Session } from './session';

--- a/transport/index.ts
+++ b/transport/index.ts
@@ -14,6 +14,10 @@ export type {
   TransportMessage,
   OpaqueTransportMessage,
   TransportClientId,
+  HandshakeRequestMetadata,
+  ParsedHandshakeMetadata,
+  ClientHandshakeOptions,
+  ServerHandshakeOptions,
   isStreamOpen,
   isStreamClose,
 } from './message';

--- a/transport/message.ts
+++ b/transport/message.ts
@@ -1,5 +1,6 @@
 import { Type, TSchema, Static } from '@sinclair/typebox';
 import { nanoid } from 'nanoid';
+import { Connection, Session } from './session';
 
 /**
  * Control flags for transport messages.
@@ -12,6 +13,102 @@ export const enum ControlFlags {
   AckBit = 0b0001,
   StreamOpenBit = 0b0010,
   StreamClosedBit = 0b0100,
+}
+
+/**
+ * Metadata associated with a handshake request, as sent by the client.
+ *
+ * You should use declaration merging to extend this interface
+ * with whatever you need. For example, if you need to store an
+ * identifier for the client, you could do:
+ * ```
+ * declare module '@replit/river' {
+ *   interface HandshakeMetadataClient {
+ *     id: string;
+ *   }
+ * }
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface HandshakeRequestMetadata {}
+
+/**
+ * Metadata associated with a handshake response, after the server
+ * has processed the data in {@link HandshakeRequestMetadata}. This
+ * is a separate interface for multiple reasons, but one of the main
+ * ones is that the server should remove any sensitive data from the
+ * client's request metadata before storing it in the session, that
+ * way no secrets are persisted in memory.
+ *
+ * You should use declaration merging to extend this interface
+ * with whatever you need. For example, if you need to store an
+ * identifier for the client, you could do:
+ * ```
+ * declare module '@replit/river' {
+ *   interface HandshakeMetadataServer {
+ *     id: string;
+ *   }
+ * }
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ParsedHandshakeMetadata {}
+
+/**
+ * Options for extending the client handshake process.
+ */
+export interface ClientHandshakeOptions {
+  /**
+   * Schema for the metadata that the client sends to the server
+   * during the handshake.
+   *
+   * Needs to match {@link HandshakeRequestMetadata}.
+   */
+  schema: TSchema;
+
+  /**
+   * Gets the {@link HandshakeRequestMetadata} to send to the server.
+   */
+  get: () => HandshakeRequestMetadata | Promise<HandshakeRequestMetadata>;
+}
+
+/**
+ * Options for extending the server handshake process.
+ */
+export interface ServerHandshakeOptions {
+  /**
+   * Schema for the metadata that the server receives from the client
+   * during the handshake.
+   *
+   * Needs to match {@link HandshakeRequestMetadata}.
+   */
+  requestSchema: TSchema;
+
+  /**
+   * Schema for the transformed metadata that is then associated with the
+   * client's session.
+   *
+   * Needs to match {@link ParsedHandshakeMetadata}.
+   */
+  parsedSchema: TSchema;
+
+  /**
+   * Parses the {@link HandshakeRequestMetadata} sent by the client, transforming
+   * it into {@link ParsedHandshakeMetadata}.
+   *
+   * May return `false` if the client should be rejected.
+   *
+   * @param metadata - The metadata sent by the client.
+   * @param session - The session this client was already associated with (reconnects),
+   *                  if any.
+   */
+  parse: (
+    metadata: HandshakeRequestMetadata,
+    session: Session<Connection> | null,
+  ) =>
+    | false
+    | ParsedHandshakeMetadata
+    | Promise<false | ParsedHandshakeMetadata>;
 }
 
 /**
@@ -56,6 +153,7 @@ export const ControlMessageHandshakeRequestSchema = Type.Object({
   type: Type.Literal('HANDSHAKE_REQ'),
   protocolVersion: Type.String(),
   sessionId: Type.String(),
+  metadata: Type.Optional(Type.Unknown()),
 });
 
 export const ControlMessageHandshakeResponseSchema = Type.Object({
@@ -125,6 +223,7 @@ export function handshakeRequestMessage(
   from: TransportClientId,
   to: TransportClientId,
   sessionId: string,
+  metadata?: HandshakeRequestMetadata,
 ): TransportMessage<Static<typeof ControlMessageHandshakeRequestSchema>> {
   return {
     id: nanoid(),

--- a/transport/message.ts
+++ b/transport/message.ts
@@ -99,12 +99,14 @@ export interface ServerHandshakeOptions {
    * May return `false` if the client should be rejected.
    *
    * @param metadata - The metadata sent by the client.
-   * @param session - The session this client was already associated with (reconnects),
-   *                  if any.
+   * @param session - The session that the client would be associated with.
+   * @param isReconnect - Whether the client is reconnecting to the session,
+   *                      or if this is a new session.
    */
   parse: (
     metadata: HandshakeRequestMetadata,
-    session: Session<Connection> | null,
+    session: Session<Connection>,
+    isReconnect: boolean,
   ) =>
     | false
     | ParsedHandshakeMetadata

--- a/transport/message.ts
+++ b/transport/message.ts
@@ -237,6 +237,7 @@ export function handshakeRequestMessage(
       type: 'HANDSHAKE_REQ',
       protocolVersion: PROTOCOL_VERSION,
       sessionId,
+      metadata,
     } satisfies Static<typeof ControlMessageHandshakeRequestSchema>,
   };
 }

--- a/transport/session.ts
+++ b/transport/session.ts
@@ -128,7 +128,7 @@ export class Session<ConnType extends Connection> {
    *
    * Will only ever be populated on the server side.
    */
-  handshakeMetadata?: ParsedHandshakeMetadata;
+  metadata?: ParsedHandshakeMetadata;
 
   /**
    * Number of messages we've sent along this session (excluding handshake and acks)

--- a/transport/session.ts
+++ b/transport/session.ts
@@ -3,6 +3,7 @@ import {
   ControlFlags,
   ControlMessageAckSchema,
   OpaqueTransportMessage,
+  ParsedHandshakeMetadata,
   PartialTransportMessage,
   TransportClientId,
   TransportMessage,
@@ -121,6 +122,11 @@ export class Session<ConnType extends Connection> {
    * for this session.
    */
   advertisedSessionId?: string;
+
+  /**
+   * The metadata for this session, as parsed from the handshake.
+   */
+  handshakeMetadata?: ParsedHandshakeMetadata;
 
   /**
    * Number of messages we've sent along this session (excluding handshake and acks)

--- a/transport/session.ts
+++ b/transport/session.ts
@@ -125,6 +125,8 @@ export class Session<ConnType extends Connection> {
 
   /**
    * The metadata for this session, as parsed from the handshake.
+   *
+   * Will only ever be populated on the server side.
    */
   handshakeMetadata?: ParsedHandshakeMetadata;
 

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -793,7 +793,7 @@ describe.each(testMatrix())(
 
       const session = serverTransport.sessions.get(clientTransport.clientId);
       assert(session);
-      expect(session.handshakeMetadata).toEqual({ kept: 'kept' });
+      expect(session.metadata).toEqual({ kept: 'kept' });
     });
 
     test('client checks request schema', async () => {
@@ -1164,15 +1164,17 @@ describe.each(testMatrix())(
 
       const get = vi.fn(async () => ({ foo: 'foo' }));
 
-      const parse = vi.fn(async (metadata: unknown, session: unknown) => {
-        if (session) {
-          return false;
-        }
+      const parse = vi.fn(
+        async (metadata: unknown, _session: unknown, isReconnect: boolean) => {
+          if (isReconnect) {
+            return false;
+          }
 
-        // @ts-expect-error - we haven't extended the global type here
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        return { foo: metadata.foo };
-      });
+          // @ts-expect-error - we haven't extended the global type here
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          return { foo: metadata.foo };
+        },
+      );
 
       const opts: TestTransportOptions = {
         client: {

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -13,7 +13,7 @@ import {
   waitForMessage,
   testingSessionOptions,
 } from '../util/testHelpers';
-import { EventMap } from '../transport/events';
+import { EventMap, ProtocolError } from '../transport/events';
 import {
   advanceFakeTimersBySessionGrace,
   testFinishesCleanly,
@@ -841,7 +841,7 @@ describe.each(testMatrix())(
 
       const clientHandshakeFailed = vi.fn();
       const clientHandshakeFailedHandler = (evt: EventMap['protocolError']) => {
-        if (evt.type === 'handshake_failed') {
+        if (evt.type === ProtocolError.HandshakeFailed) {
           clientHandshakeFailed();
         }
       };
@@ -852,7 +852,7 @@ describe.each(testMatrix())(
 
       const serverHandshakeFailed = vi.fn();
       const serverHandshakeFailedHandler = (evt: EventMap['protocolError']) => {
-        if (evt.type === 'handshake_failed') {
+        if (evt.type === ProtocolError.HandshakeFailed) {
           serverHandshakeFailed();
         }
       };
@@ -935,7 +935,7 @@ describe.each(testMatrix())(
 
       const clientHandshakeFailed = vi.fn();
       const clientHandshakeFailedHandler = (evt: EventMap['protocolError']) => {
-        if (evt.type === 'handshake_failed') {
+        if (evt.type === ProtocolError.HandshakeFailed) {
           clientHandshakeFailed();
         }
       };
@@ -946,7 +946,7 @@ describe.each(testMatrix())(
 
       const serverHandshakeFailed = vi.fn();
       const serverHandshakeFailedHandler = (evt: EventMap['protocolError']) => {
-        if (evt.type === 'handshake_failed') {
+        if (evt.type === ProtocolError.HandshakeFailed) {
           serverHandshakeFailed();
         }
       };
@@ -1020,7 +1020,7 @@ describe.each(testMatrix())(
 
       const clientHandshakeFailed = vi.fn();
       const clientHandshakeFailedHandler = (evt: EventMap['protocolError']) => {
-        if (evt.type === 'handshake_failed') {
+        if (evt.type === ProtocolError.HandshakeFailed) {
           clientHandshakeFailed();
         }
       };
@@ -1031,7 +1031,7 @@ describe.each(testMatrix())(
 
       const serverHandshakeFailed = vi.fn();
       const serverHandshakeFailedHandler = (evt: EventMap['protocolError']) => {
-        if (evt.type === 'handshake_failed') {
+        if (evt.type === ProtocolError.HandshakeFailed) {
           serverHandshakeFailed();
         }
       };
@@ -1104,7 +1104,7 @@ describe.each(testMatrix())(
 
       const clientHandshakeFailed = vi.fn();
       const clientHandshakeFailedHandler = (evt: EventMap['protocolError']) => {
-        if (evt.type === 'handshake_failed') {
+        if (evt.type === ProtocolError.HandshakeFailed) {
           clientHandshakeFailed();
         }
       };
@@ -1118,7 +1118,7 @@ describe.each(testMatrix())(
         evt: EventMap['protocolError'],
       ) => {
         if (
-          evt.type === 'handshake_failed' &&
+          evt.type === ProtocolError.HandshakeFailed &&
           evt.message.includes('rejected by server')
         ) {
           serverRejectedConnection();
@@ -1203,7 +1203,7 @@ describe.each(testMatrix())(
 
       const clientHandshakeFailed = vi.fn();
       const clientHandshakeFailedHandler = (evt: EventMap['protocolError']) => {
-        if (evt.type === 'handshake_failed') {
+        if (evt.type === ProtocolError.HandshakeFailed) {
           clientHandshakeFailed();
         }
       };
@@ -1217,7 +1217,7 @@ describe.each(testMatrix())(
         evt: EventMap['protocolError'],
       ) => {
         if (
-          evt.type === 'handshake_failed' &&
+          evt.type === ProtocolError.HandshakeFailed &&
           evt.message.includes('rejected by server')
         ) {
           serverRejectedConnection();

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -1,4 +1,12 @@
-import { describe, test, expect, afterAll, vi, onTestFinished } from 'vitest';
+import {
+  describe,
+  test,
+  expect,
+  afterAll,
+  vi,
+  onTestFinished,
+  assert,
+} from 'vitest';
 import {
   createDummyTransportMessage,
   payloadToTransportMessage,
@@ -13,6 +21,8 @@ import {
 } from '../__tests__/fixtures/cleanup';
 import { testMatrix } from '../__tests__/fixtures/matrix';
 import { PartialTransportMessage } from './message';
+import { TestTransportOptions } from '../__tests__/fixtures/transports';
+import { Type } from '@sinclair/typebox';
 
 describe.each(testMatrix())(
   'transport connection behaviour tests ($transport.name transport, $codec.name codec)',
@@ -725,6 +735,528 @@ describe.each(testMatrix())(
       await expect(
         waitForMessage(serverTransport, (recv) => recv.id === msg2Id),
       ).resolves.toStrictEqual(msg2.payload);
+    });
+  },
+);
+
+describe.each(testMatrix())(
+  'transport handshake tests ($transport.name transport, $codec.name codec)',
+  ({ transport, codec }) => {
+    test('handshakes and stores parsed metadata in session', async () => {
+      const requestSchema = Type.Object({
+        kept: Type.String(),
+        discarded: Type.String(),
+      });
+
+      const parsedSchema = Type.Object({
+        kept: Type.String(),
+      });
+
+      const get = vi.fn(async () => ({ kept: 'kept', discarded: 'discarded' }));
+
+      const parse = vi.fn(async (metadata: unknown) => ({
+        // @ts-expect-error - we haven't extended the global type here
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        kept: metadata.kept,
+      }));
+
+      const opts: TestTransportOptions = {
+        client: {
+          codec: codec.codec,
+          handshake: {
+            schema: requestSchema,
+            get,
+          },
+        },
+        server: {
+          codec: codec.codec,
+          handshake: {
+            requestSchema,
+            parsedSchema,
+            parse,
+          },
+        },
+      };
+
+      const { getClientTransport, getServerTransport, cleanup } =
+        await transport.setup(opts);
+      onTestFinished(cleanup);
+
+      const clientTransport = getClientTransport('client');
+      const serverTransport = getServerTransport();
+
+      await waitFor(() => {
+        expect(serverTransport.sessions.size).toBe(1);
+        expect(get).toHaveBeenCalledTimes(1);
+        expect(parse).toHaveBeenCalledTimes(1);
+      });
+
+      const session = serverTransport.sessions.get(clientTransport.clientId);
+      assert(session);
+      expect(session.handshakeMetadata).toEqual({ kept: 'kept' });
+    });
+
+    test('client checks request schema', async () => {
+      const requestSchema = Type.Object({
+        foo: Type.String(),
+      });
+
+      const parsedSchema = Type.Object({
+        foo: Type.String(),
+      });
+
+      // wrong
+      const get = vi.fn(async () => ({ foo: false }));
+
+      const parse = vi.fn(async (metadata: unknown) => ({
+        // @ts-expect-error - we haven't extended the global type here
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        foo: metadata.foo,
+      }));
+
+      const opts: TestTransportOptions = {
+        client: {
+          codec: codec.codec,
+          handshake: {
+            schema: requestSchema,
+            get,
+          },
+        },
+        server: {
+          codec: codec.codec,
+          handshake: {
+            requestSchema,
+            parsedSchema,
+            parse,
+          },
+        },
+      };
+
+      const { getClientTransport, getServerTransport, cleanup } =
+        await transport.setup(opts);
+      onTestFinished(cleanup);
+
+      const clientTransport = getClientTransport('client');
+      const serverTransport = getServerTransport();
+
+      const clientHandshakeFailed = vi.fn();
+      const clientHandshakeFailedHandler = (evt: EventMap['protocolError']) => {
+        if (evt.type === 'handshake_failed') {
+          clientHandshakeFailed();
+        }
+      };
+      clientTransport.addEventListener(
+        'protocolError',
+        clientHandshakeFailedHandler,
+      );
+
+      const serverHandshakeFailed = vi.fn();
+      const serverHandshakeFailedHandler = (evt: EventMap['protocolError']) => {
+        if (evt.type === 'handshake_failed') {
+          serverHandshakeFailed();
+        }
+      };
+      serverTransport.addEventListener(
+        'protocolError',
+        serverHandshakeFailedHandler,
+      );
+
+      onTestFinished(async () => {
+        clientTransport.removeEventListener(
+          'protocolError',
+          clientHandshakeFailedHandler,
+        );
+        serverTransport.removeEventListener(
+          'protocolError',
+          serverHandshakeFailedHandler,
+        );
+
+        await testFinishesCleanly({
+          clientTransports: [clientTransport],
+          serverTransport,
+        });
+      });
+
+      await waitFor(() => {
+        expect(get).toHaveBeenCalledTimes(1);
+        expect(clientHandshakeFailed).toHaveBeenCalledTimes(1);
+        // should never get to the server
+        expect(parse).toHaveBeenCalledTimes(0);
+        expect(serverHandshakeFailed).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    test('server checks request schema', async () => {
+      const requestSchemaClient = Type.Object({
+        foo: Type.Boolean(),
+      });
+
+      const requestSchemaServer = Type.Object({
+        foo: Type.String(),
+      });
+
+      const parsedSchema = Type.Object({
+        foo: Type.String(),
+      });
+
+      // correct on client, wrong on server
+      const get = vi.fn(async () => ({ foo: false }));
+
+      const parse = vi.fn(async (metadata: unknown) => ({
+        // @ts-expect-error - we haven't extended the global type here
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        foo: metadata.foo,
+      }));
+
+      const opts: TestTransportOptions = {
+        client: {
+          codec: codec.codec,
+          handshake: {
+            schema: requestSchemaClient,
+            get,
+          },
+        },
+        server: {
+          codec: codec.codec,
+          handshake: {
+            requestSchema: requestSchemaServer,
+            parsedSchema,
+            parse,
+          },
+        },
+      };
+
+      const { getClientTransport, getServerTransport, cleanup } =
+        await transport.setup(opts);
+      onTestFinished(cleanup);
+
+      const clientTransport = getClientTransport('client');
+      const serverTransport = getServerTransport();
+
+      const clientHandshakeFailed = vi.fn();
+      const clientHandshakeFailedHandler = (evt: EventMap['protocolError']) => {
+        if (evt.type === 'handshake_failed') {
+          clientHandshakeFailed();
+        }
+      };
+      clientTransport.addEventListener(
+        'protocolError',
+        clientHandshakeFailedHandler,
+      );
+
+      const serverHandshakeFailed = vi.fn();
+      const serverHandshakeFailedHandler = (evt: EventMap['protocolError']) => {
+        if (evt.type === 'handshake_failed') {
+          serverHandshakeFailed();
+        }
+      };
+      serverTransport.addEventListener(
+        'protocolError',
+        serverHandshakeFailedHandler,
+      );
+
+      onTestFinished(async () => {
+        clientTransport.removeEventListener(
+          'protocolError',
+          clientHandshakeFailedHandler,
+        );
+        serverTransport.removeEventListener(
+          'protocolError',
+          serverHandshakeFailedHandler,
+        );
+
+        await testFinishesCleanly({
+          clientTransports: [clientTransport],
+          serverTransport,
+        });
+      });
+
+      await waitFor(() => {
+        expect(get).toHaveBeenCalledTimes(1);
+        expect(clientHandshakeFailed).toHaveBeenCalledTimes(1);
+        expect(parse).toHaveBeenCalledTimes(0);
+        expect(serverHandshakeFailed).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    test('server checks parse schema', async () => {
+      const requestSchema = Type.Object({
+        foo: Type.String(),
+      });
+
+      const parsedSchema = Type.Object({
+        foo: Type.String(),
+      });
+
+      const get = vi.fn(async () => ({ foo: 'foo' }));
+
+      // wrong
+      const parse = vi.fn(async () => ({ foo: false }));
+
+      const opts: TestTransportOptions = {
+        client: {
+          codec: codec.codec,
+          handshake: {
+            schema: requestSchema,
+            get,
+          },
+        },
+        server: {
+          codec: codec.codec,
+          handshake: {
+            requestSchema,
+            parsedSchema,
+            parse,
+          },
+        },
+      };
+
+      const { getClientTransport, getServerTransport, cleanup } =
+        await transport.setup(opts);
+      onTestFinished(cleanup);
+
+      const clientTransport = getClientTransport('client');
+      const serverTransport = getServerTransport();
+
+      const clientHandshakeFailed = vi.fn();
+      const clientHandshakeFailedHandler = (evt: EventMap['protocolError']) => {
+        if (evt.type === 'handshake_failed') {
+          clientHandshakeFailed();
+        }
+      };
+      clientTransport.addEventListener(
+        'protocolError',
+        clientHandshakeFailedHandler,
+      );
+
+      const serverHandshakeFailed = vi.fn();
+      const serverHandshakeFailedHandler = (evt: EventMap['protocolError']) => {
+        if (evt.type === 'handshake_failed') {
+          serverHandshakeFailed();
+        }
+      };
+      serverTransport.addEventListener(
+        'protocolError',
+        serverHandshakeFailedHandler,
+      );
+
+      onTestFinished(async () => {
+        clientTransport.removeEventListener(
+          'protocolError',
+          clientHandshakeFailedHandler,
+        );
+        serverTransport.removeEventListener(
+          'protocolError',
+          serverHandshakeFailedHandler,
+        );
+
+        await testFinishesCleanly({
+          clientTransports: [clientTransport],
+          serverTransport,
+        });
+      });
+
+      await waitFor(() => {
+        expect(get).toHaveBeenCalledTimes(1);
+        expect(clientHandshakeFailed).toHaveBeenCalledTimes(1);
+        expect(parse).toHaveBeenCalledTimes(1);
+        expect(serverHandshakeFailed).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    test('parse can reject connection', async () => {
+      const requestSchema = Type.Object({
+        foo: Type.String(),
+      });
+
+      const parsedSchema = Type.Object({
+        foo: Type.String(),
+      });
+
+      const get = vi.fn(async () => ({ foo: 'foo' }));
+
+      const parse = vi.fn(async () => false);
+
+      const opts: TestTransportOptions = {
+        client: {
+          codec: codec.codec,
+          handshake: {
+            schema: requestSchema,
+            get,
+          },
+        },
+        server: {
+          codec: codec.codec,
+          handshake: {
+            requestSchema,
+            parsedSchema,
+            parse,
+          },
+        },
+      };
+
+      const { getClientTransport, getServerTransport, cleanup } =
+        await transport.setup(opts);
+      onTestFinished(cleanup);
+
+      const clientTransport = getClientTransport('client');
+      const serverTransport = getServerTransport();
+
+      const clientHandshakeFailed = vi.fn();
+      const clientHandshakeFailedHandler = (evt: EventMap['protocolError']) => {
+        if (evt.type === 'handshake_failed') {
+          clientHandshakeFailed();
+        }
+      };
+      clientTransport.addEventListener(
+        'protocolError',
+        clientHandshakeFailedHandler,
+      );
+
+      const serverRejectedConnection = vi.fn();
+      const serverRejectedConnectionHandler = (
+        evt: EventMap['protocolError'],
+      ) => {
+        if (
+          evt.type === 'handshake_failed' &&
+          evt.message.includes('rejected by server')
+        ) {
+          serverRejectedConnection();
+        }
+      };
+      serverTransport.addEventListener(
+        'protocolError',
+        serverRejectedConnectionHandler,
+      );
+
+      onTestFinished(async () => {
+        clientTransport.removeEventListener(
+          'protocolError',
+          clientHandshakeFailedHandler,
+        );
+        serverTransport.removeEventListener(
+          'protocolError',
+          serverRejectedConnectionHandler,
+        );
+
+        await testFinishesCleanly({
+          clientTransports: [clientTransport],
+          serverTransport,
+        });
+      });
+
+      await waitFor(() => {
+        expect(get).toHaveBeenCalledTimes(1);
+        expect(clientHandshakeFailed).toHaveBeenCalledTimes(1);
+        expect(parse).toHaveBeenCalledTimes(1);
+        expect(serverRejectedConnection).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    test('parse can reject reconnect', async () => {
+      const requestSchema = Type.Object({
+        foo: Type.String(),
+      });
+
+      const parsedSchema = Type.Object({
+        foo: Type.String(),
+      });
+
+      const get = vi.fn(async () => ({ foo: 'foo' }));
+
+      const parse = vi.fn(async (metadata: unknown, session: unknown) => {
+        if (session) {
+          return false;
+        }
+
+        // @ts-expect-error - we haven't extended the global type here
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        return { foo: metadata.foo };
+      });
+
+      const opts: TestTransportOptions = {
+        client: {
+          codec: codec.codec,
+          handshake: {
+            schema: requestSchema,
+            get,
+          },
+        },
+        server: {
+          codec: codec.codec,
+          handshake: {
+            requestSchema,
+            parsedSchema,
+            parse,
+          },
+        },
+      };
+
+      const { getClientTransport, getServerTransport, cleanup } =
+        await transport.setup(opts);
+      onTestFinished(cleanup);
+
+      const clientTransport = getClientTransport('client');
+      const serverTransport = getServerTransport();
+
+      const clientHandshakeFailed = vi.fn();
+      const clientHandshakeFailedHandler = (evt: EventMap['protocolError']) => {
+        if (evt.type === 'handshake_failed') {
+          clientHandshakeFailed();
+        }
+      };
+      clientTransport.addEventListener(
+        'protocolError',
+        clientHandshakeFailedHandler,
+      );
+
+      const serverRejectedConnection = vi.fn();
+      const serverRejectedConnectionHandler = (
+        evt: EventMap['protocolError'],
+      ) => {
+        if (
+          evt.type === 'handshake_failed' &&
+          evt.message.includes('rejected by server')
+        ) {
+          serverRejectedConnection();
+        }
+      };
+      serverTransport.addEventListener(
+        'protocolError',
+        serverRejectedConnectionHandler,
+      );
+
+      onTestFinished(async () => {
+        clientTransport.removeEventListener(
+          'protocolError',
+          clientHandshakeFailedHandler,
+        );
+        serverTransport.removeEventListener(
+          'protocolError',
+          serverRejectedConnectionHandler,
+        );
+
+        await testFinishesCleanly({
+          clientTransports: [clientTransport],
+          serverTransport,
+        });
+      });
+
+      // should connect
+      await waitFor(() => {
+        expect(clientHandshakeFailed).toHaveBeenCalledTimes(0);
+        expect(serverRejectedConnection).toHaveBeenCalledTimes(0);
+        expect(clientTransport.connections.size).toBe(1);
+        expect(serverTransport.connections.size).toBe(1);
+      });
+
+      // reconnect, should fail
+      clientTransport.reconnectOnConnectionDrop = true;
+      clientTransport.connections.forEach((conn) => conn.close());
+      await waitFor(() => {
+        expect(clientHandshakeFailed).toHaveBeenCalledTimes(1);
+        expect(serverRejectedConnection).toHaveBeenCalledTimes(1);
+      });
     });
   },
 );

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -19,7 +19,7 @@ describe.each(testMatrix())(
   async ({ transport, codec }) => {
     const opts = { codec: codec.codec };
     const { getClientTransport, getServerTransport, cleanup } =
-      await transport.setup(opts);
+      await transport.setup({ client: opts, server: opts });
     afterAll(cleanup);
 
     test('connection is recreated after clean client disconnect', async () => {
@@ -405,7 +405,7 @@ describe.each(testMatrix())(
     test('messages should not be resent when the client loses all state and reconnects to the server', async () => {
       const opts = { codec: codec.codec };
       const { getClientTransport, getServerTransport, cleanup } =
-        await transport.setup(opts);
+        await transport.setup({ client: opts, server: opts });
       onTestFinished(cleanup);
 
       let clientTransport = getClientTransport('client');
@@ -497,7 +497,7 @@ describe.each(testMatrix())(
     test('messages should not be resent when client reconnects to a different instance of the server', async () => {
       const opts = { codec: codec.codec };
       const { getClientTransport, getServerTransport, restartServer, cleanup } =
-        await transport.setup(opts);
+        await transport.setup({ client: opts, server: opts });
       onTestFinished(cleanup);
 
       const clientTransport = getClientTransport('client');
@@ -604,7 +604,7 @@ describe.each(testMatrix())(
         getServerTransport,
         simulatePhantomDisconnect,
         cleanup,
-      } = await transport.setup(opts);
+      } = await transport.setup({ client: opts, server: opts });
       onTestFinished(cleanup);
       vi.useFakeTimers({ shouldAdvanceTime: true });
       const clientTransport = getClientTransport('client');

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -13,6 +13,8 @@ import {
   ControlMessagePayloadSchema,
   isAck,
   PROTOCOL_VERSION,
+  ClientHandshakeOptions,
+  ServerHandshakeOptions,
 } from './message';
 import { log } from '../logging/log';
 import {
@@ -36,7 +38,10 @@ import { NaiveJsonCodec } from '../codec';
  */
 export type TransportStatus = 'open' | 'closed' | 'destroyed';
 
+// -- base transport options
+
 type TransportOptions = SessionOptions;
+
 export type ProvidedTransportOptions = Partial<TransportOptions>;
 
 export const defaultTransportOptions: TransportOptions = {
@@ -46,7 +51,11 @@ export const defaultTransportOptions: TransportOptions = {
   codec: NaiveJsonCodec,
 };
 
-type ClientTransportOptions = SessionOptions & ConnectionRetryOptions;
+// -- client transport options
+
+type ClientTransportOptions = TransportOptions &
+  ConnectionRetryOptions & { handshake?: ClientHandshakeOptions };
+
 export type ProvidedClientTransportOptions = Partial<ClientTransportOptions>;
 
 const defaultConnectionRetryOptions: ConnectionRetryOptions = {
@@ -62,7 +71,12 @@ const defaultClientTransportOptions: ClientTransportOptions = {
   ...defaultConnectionRetryOptions,
 };
 
-type ServerTransportOptions = TransportOptions;
+// -- server transport options
+
+type ServerTransportOptions = TransportOptions & {
+  handshake?: ServerHandshakeOptions;
+};
+
 export type ProvidedServerTransportOptions = Partial<ServerTransportOptions>;
 
 const defaultServerTransportOptions: ServerTransportOptions = {

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -16,7 +16,6 @@ import {
   ClientHandshakeOptions,
   ServerHandshakeOptions,
   HandshakeRequestMetadata,
-  ParsedHandshakeMetadata,
 } from './message';
 import { log } from '../logging/log';
 import {

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -206,7 +206,6 @@ export abstract class Transport<ConnType extends Connection> {
 
     if (isReconnect) {
       session.replaceWithNewConnection(conn);
-      session.sendBufferedMessages();
       log?.info(`reconnected to ${connectedTo}`, session.loggingMetadata);
     }
   }

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -38,6 +38,7 @@ export type TransportStatus = 'open' | 'closed' | 'destroyed';
 
 type TransportOptions = SessionOptions;
 export type ProvidedTransportOptions = Partial<TransportOptions>;
+
 export const defaultTransportOptions: TransportOptions = {
   heartbeatIntervalMs: 1_000,
   heartbeatsUntilDead: 2,
@@ -45,8 +46,8 @@ export const defaultTransportOptions: TransportOptions = {
   codec: NaiveJsonCodec,
 };
 
-export type ProvidedClientTransportOptions = Partial<ClientTransportOptions>;
 type ClientTransportOptions = SessionOptions & ConnectionRetryOptions;
+export type ProvidedClientTransportOptions = Partial<ClientTransportOptions>;
 
 const defaultConnectionRetryOptions: ConnectionRetryOptions = {
   baseIntervalMs: 250,
@@ -61,9 +62,16 @@ const defaultClientTransportOptions: ClientTransportOptions = {
   ...defaultConnectionRetryOptions,
 };
 
+type ServerTransportOptions = TransportOptions;
+export type ProvidedServerTransportOptions = Partial<ServerTransportOptions>;
+
+const defaultServerTransportOptions: ServerTransportOptions = {
+  ...defaultTransportOptions,
+};
+
 /**
  * Transports manage the lifecycle (creation/deletion) of sessions and connections. Its responsibilities include:
- * 
+ *
  *  1) Constructing a new {@link Session} and {@link Connection} on {@link TransportMessage}s from new clients.
  *     After constructing the {@link Connection}, {@link onConnect} is called which adds it to the connection map.
  *  2) Delegating message listening of the connection to the newly created {@link Connection}.
@@ -735,11 +743,20 @@ export abstract class ClientTransport<
 export abstract class ServerTransport<
   ConnType extends Connection,
 > extends Transport<ConnType> {
+  /**
+   * The options for this transport.
+   */
+  protected options: ServerTransportOptions;
+
   constructor(
     clientId: TransportClientId,
-    providedOptions?: ProvidedTransportOptions,
+    providedOptions?: ProvidedServerTransportOptions,
   ) {
     super(clientId, providedOptions);
+    this.options = {
+      ...defaultServerTransportOptions,
+      ...providedOptions,
+    };
     log?.info(`initiated server transport`, {
       clientId: this.clientId,
       protocolVersion: PROTOCOL_VERSION,

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -923,7 +923,7 @@ export abstract class ServerTransport<
       conn.send(this.codec.toBuffer(responseMsg));
       // note: do _not_ log the payload, it may contain secrets
       const logData =
-        typeof parsed.payload === 'object' && parsed.payload !== null
+        typeof parsed.payload === 'object'
           ? { ...parsed, payload: { ...parsed.payload, metadata: 'redacted' } }
           : { ...parsed };
       log?.warn(`${reason}: ${JSON.stringify(logData)}`, {

--- a/util/testHelpers.ts
+++ b/util/testHelpers.ts
@@ -166,7 +166,7 @@ function dummyCtx<State>(
     to: session.to,
     from: session.from,
     streamId: nanoid(),
-    session,
+    session: session as ServiceContextWithTransportInfo<State>['session'],
   };
 }
 


### PR DESCRIPTION
## Why
We want identity/auth support in River.

## What changed
Made it so that client and server transports can extend the data in the handshake. An example works best:
```ts
// add our handshake types
declare module "@replit/river" {
  interface HandshakeRequestMetadata {
    username: string
    secret: string
  }
  
  interface ParsedHandshakeMetadata {
    username: string
  }
}

const clientTransport = new MyClientTransport('client', {
  handshake: {
    // runtime validates the result of `get`
    schema: Type.Object({
      username: Type.String(),
      secret: Type.string(),
    }),
    get: async () => {
      return await getClientHandshakeMetadata()
    }
  }
})

const serverTransport = new MyServerTransport('server', {
  handshake: {
    // runtime validates the metadata in the handshake request
    requestSchema: Type.Object({
      username: Type.String(),
      secret: Type.string(),
    }),

    // runtime validates the parsed metadata
    parsedSchema: Type.Object({
      username: Type.String(),
    }),
    
    // session will not be null if this is a reconnect
    parse: async (metadata, session, isReconnect) => {
      // reject connection
      if (await isInvalidAuth(metadata)) {
        return false
      }
      
      // reject reconnection
      if (isReconnect && session.metadata?.username !== metadata.username) {
        return false
      }
      
      // stored on sessions
      return { username: metadata.username }
    }
  }
})

const MyService = ServiceSchema.define({
  foo: Procedure.rpc({
    // ...
    async handler(ctx, _input) {
      // guaranteed to not be undefined
      const username = ctx.session.metadata.username
      return Ok(`your name is ${username}`)
    }
  })
})
```

I think there are some open questions about the names of things and the ergonomics of this, but this should be everything we need.

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [x] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
