### PR TITLE
[protocol v2] RFC PROTOCOL V2

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -150,7 +150,7 @@ The `controlFlags` property is a [bit field](https://en.wikipedia.org/wiki/Bit_f
 - The `StreamOpenBit` (`0b00010`) MUST be set for the first message of a new stream.
 - The `StreamClosedBit` (`0b00100`) MUST be set for the last message of a stream.
 - Bits `0b01000` and `0b10000` are reserved for future use and are currently unused.
-  - `0b10000` will likely be used to signal `StreamAbort` (i.e., the client is aborting the stream)
+  - `0b01000` will likely be used to signal `StreamAbort` (i.e., the client is aborting the stream)
 
 All messages MUST have no control flags set (i.e., the `controlFlags` field is `0b00000`) unless:
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -96,7 +96,7 @@ interface BaseError {
 }
 ```
 
-The `Result` type must conform to:
+The `Result` type MUST conform to:
 
 ```ts
 type Result<T, E extends BaseError> =

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -245,7 +245,7 @@ When a message is received, it MUST be validated before being processed.
 - Have the expected `seq` number (see the 'Handling Transparent Reconnections' heading for more information on seq/ack).
 - Is not an explicit heartbeat (i.e. the `AckBit` is not set).
 - Either side can initiate a close by sending a message with a `StreamClosedBit`
-  - The closing side goes into a half-closed state, meaning they're MUST NOT send any more messages.
+  - The closing side goes into a half-closed state, meaning they MUST NOT send any more messages.
   - To get a full close, the other side MUST respond with a `StreamClosedBit` acknowledging the close.
 
 When a message is validated at this level, the implementor must update the bookkeeping information for the session (see the 'Transparent Reconnections' heading for more information).

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -104,7 +104,7 @@ type Result<T, E extends BaseError> =
   | { ok: false; payload: E };
 ```
 
-The messages server must also contain additional information so that the server knows where to route the message payload. This wrapper message is referred to as a `TransportMessage` and its payload can be a `Control`, a `Result`, an `Input`, or an `Output`. The schema for the transport message is as follows:
+The messages in either direction must also contain additional information so that the server knows where to route the message payload. This wrapper message is referred to as a `TransportMessage` and its payload can be a `Control`, a `Result`, an `Input`, or an `Output`. The schema for the transport message is as follows:
 
 ```ts
 interface TransportMessage<Payload> {

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -79,7 +79,7 @@ The type signatures (in TypeScript) for the handlers of each of the procedure ty
 
 Note that any procedure that has a client-to-server procedure stream (i.e. `stream` and `upload`) can optionally define a single initialization message to be sent to the server before the client starts sending the actual `Input` messages.
 
-The types of `Input`, `Init`, and `Output` MUST be representable as JSON schema..
+The types of `Input`, `Init`, and `Output` MUST be representable as JSON schema.
 In the official TypeScript implementation, this is done via [TypeBox](https://github.com/sinclairzx81/typebox).
 The server is responsible for doing run-time type validation on incoming messages to ensure they match the handler's type signature before passing it to the handler.
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -220,7 +220,7 @@ For an incoming message to be considered valid on the server, the transport mess
 - If this is the first message of the stream AND the associated procedure declares an `Init` message, the internal payload of the message should match the JSON schema for the `Init` type of the associated handler, and the server should pass the `Init` message to the handler.
 - If this is not the first message of the stream OR the associated procedure *does not* declare an `Init` message, the internal payload of the message should match the JSON schema for the `Input` type of the associated handler, and the server should pass the `Input` message to the handler.
 
-If the message is invalid, the server will discard the message and send back an error message `{ ok: false, payload: { code: 'INVALID_REQUEST', message: 'could be anything' } }` and a `StreamClosedBit`.
+If the message is invalid, the server MUST discard the message and send back an error message `{ ok: false, payload: { code: 'INVALID_REQUEST', message: 'could be anything' } }` and a `StreamClosedBit`.
 Otherwise, the message is a normal message. Unwrap the payload and pass it to the handler associated with the `streamId` of the message.
 
 In the special case that the message payload matches the `ControlMessagePayloadSchema` and has the `StreamClosedBit` set, the server should close the input stream for the handler. The message MUST NOT be passed to the handler.

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -257,7 +257,7 @@ Then, depending on whether this is a client or server, the message must undergo 
 For an incoming message to be considered valid on the client, the transport message MUST fulfill the following criteria:
 
 - It should have a `streamId` that the client recognizes. That is, there MUST already be a message listener waiting for messages on the `streamId` of the original request message (recall that streams are only initiated by clients).
-- If a server sends an `ProtocolError` message the client MUST NOT send any further messages to the server including a `ControlClose` message.
+- If a server sends an `ProtocolError` message the client MUST NOT send any further messages to the server for that stream including a `ControlClose` message.
 
 If the message is invalid, the client MUST silently discard the message.
 Otherwise, this is a normal message. Unwrap the payload and return it to the caller of the original procedure.

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -257,7 +257,7 @@ Then, depending on whether this is a client or server, the message must undergo 
 For an incoming message to be considered valid on the client, the transport message MUST fulfill the following criteria:
 
 - It should have a `streamId` that the client recognizes. That is, there MUST already be a message listener waiting for messages on the `streamId` of the original request message (recall that streams are only initiated by clients).
-- If a server sends an `INVALID_REQUEST` message with a `StreamClosdeBit` the client MUST NOT send any further messages to the server including a close response.
+- If a server sends an `ProtocolError` message the client MUST NOT send any further messages to the server including a `ControlClose` message.
 
 If the message is invalid, the client MUST silently discard the message.
 Otherwise, this is a normal message. Unwrap the payload and return it to the caller of the original procedure.

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -300,12 +300,14 @@ As other `Control` messages are unrelated to the stream lifecycle, they will not
 An `rpc` procedure starts with the client sending a single message with `StreamOpenBit` set and `StreamClosedBit` set and waits for a response message which MUST contain a `StreamClosedBit`.
 
 Typical request:
+
 ```
 client: x
 server:  <
 ```
 
 Protocol error:
+
 ```
 client: x
 server:  !
@@ -318,18 +320,21 @@ A `stream` procedure starts with the client sending a single message with the `S
 Note that either side may choose to independently send a message at any time while their side is still open.
 
 Client initiated close:
+
 ```
 client: > --  - {
 server:  -  -- - -- {
 ```
 
 Server initiated close:
+
 ```
 client: > --  -- -- {
 server:  -  --  {
 ```
 
 Protocol error (abrupt close):
+
 ```
 client: > --  -   (any further messages are ignored)
 server:  -  -- - !
@@ -340,18 +345,21 @@ server:  -  -- - !
 An `upload` procedure starts with the client sending a single message with `StreamOpenBit` set and remains open until the client manually closes the input stream by sending `CloseControl` message. The server MUST send a final `Result` message with the `StreamClosedBit`.
 
 Client finalizes upload:
+
 ```
 client: > --  - {
 server:          <
 ```
 
 Protocol error (abrupt close):
+
 ```
 client: > --  -   (any further messages are ignored)
 server:         !
 ```
 
 Client finalizes upload, leading to a protocol error (abrupt close):
+
 ```
 client: > --  - {
 server:          !
@@ -362,18 +370,21 @@ server:          !
 A `subscription` procedure starts with the client sending a single message with the `StreamOpenBit` set and remains open until either side ends the stream by sending a `ControlClose` message. The party receiving the `ControlClose` message must respond with a final `CloseControl` message.
 
 Client initiated close:
+
 ```
 client: >       {
 server:  -  -- - {
 ```
 
 Server ends subscription:
+
 ```
 client: >       {
 server:  -  -- - {
 ```
 
 Protocol error (abrupt close):
+
 ```
 client: >       (any further messages are ignored)
 server:  -  -- !
@@ -562,5 +573,3 @@ This explicit ack serves three purposes:
 1. It keeps the connection alive by preventing the underlying transport from timing out.
 2. It allows the session to detect when the underlying transport has been lost, even in cases where the transport does not emit a close event.
 3. It provides an upper bound on how many messages the session buffers in the case of a reconnection (consider the case where an upload procedure is really long-lived and the server doesn't send any messages until the upload is finished. Without these explicit heartbeats, the client will buffer everything!).
-
----

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -79,7 +79,7 @@ The type signatures (in TypeScript) for the handlers of each of the procedure ty
 
 Note that any procedure that has a client-to-server procedure stream (i.e. `stream` and `upload`) can optionally define a single initialization message to be sent to the server before the client starts sending the actual `Input` messages.
 
-The types of `Input`, `Init`, and `Output` MUST be representable as JSON schema.
+The types of `Input`, `Init`, `Output`, and `Error` MUST be representable as JSON schema.
 In the official TypeScript implementation, this is done via [TypeBox](https://github.com/sinclairzx81/typebox).
 The server is responsible for doing run-time type validation on incoming messages to ensure they match the handler's type signature before passing it to the handler.
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -367,13 +367,13 @@ server:          !
 
 ##### Subscription
 
-A `subscription` procedure starts with the client sending a single message with the `StreamOpenBit` set and remains open until either side ends the stream by sending a `ControlClose` message. The party receiving the `ControlClose` message must respond with a final `CloseControl` message.
+A `subscription` procedure starts with the client sending a single message with the `StreamOpenBit` set and remains open until either side ends the stream by sending a `ControlClose` message. The party receiving the `ControlClose` message must respond with a final `CloseControl` message, but may choose to continue to send messages.
 
 Client initiated close:
 
 ```
 client: >       {
-server:  -  -- - {
+server:  -  -- - -- {
 ```
 
 Server initiated close:

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -288,7 +288,7 @@ The legend is as follows:
 
 - `>` represents an `Input` or `Init` message with the `StreamOpenBit` set.
 - `x` represents an `Input` or `Init` message with both `StreamOpenBit`and `StreamClosedBit` set.
-- `<` represents a `Result` message with the `StreamClosedBit`, errors in this message are only service-level errors.
+- `<` represents a `Result` message with the `StreamClosedBit` set, errors in this message are only service-level errors.
 - `!` represents a `Result` message with the `StreamClosedBit` set and a `ProtocolError` in the payload (`{ ok: false, payload: ProtocolError }`).
 - `{` represents a `ControlClose` message.
 - `-` represents any message with no control flags set.

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -367,7 +367,7 @@ server:          !
 
 ##### Subscription
 
-A `subscription` procedure starts with the client sending a single message with the `StreamOpenBit` set and remains open until either side ends the stream by sending a `ControlClose` message. The party receiving the `ControlClose` message must respond with a final `CloseControl` message, but may choose to continue to send messages.
+A `subscription` procedure starts with the client sending a single message with the `StreamOpenBit` set and remains open until either side ends the stream by sending a `ControlClose` message. The party receiving the `ControlClose` message must respond with a final `CloseControl` message. If the client initiates the closing, it MUST continue to accept data until the other side sends a `ControlClose` message.
 
 Client initiated close:
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -245,7 +245,7 @@ When a message is received, it MUST be validated before being processed.
 - Have the expected `seq` number (see the 'Handling Transparent Reconnections' heading for more information on seq/ack).
 - Is not an explicit heartbeat (i.e. the `AckBit` is not set).
 - Either side can initiate a close by sending a message with a `StreamClosedBit`
-  - The closing side goes into a half-closed state, meaning they MUST NOT send any more messages.
+  - The closing party goes into a half-closed state, meaning they MUST NOT send any more messages.
   - To get a full close, the other side MUST respond with a `StreamClosedBit` acknowledging the close.
 
 When a message is validated at this level, the implementor must update the bookkeeping information for the session (see the 'Transparent Reconnections' heading for more information).

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -104,7 +104,7 @@ type Result<T, E extends BaseError> =
   | { ok: false; payload: E };
 ```
 
-The messages in either direction must also contain additional information so that the server knows where to route the message payload. This wrapper message is referred to as a `TransportMessage` and its payload can be a `Control`, a `Result`, an `Input`, or an `Output`. The schema for the transport message is as follows:
+The messages in either direction must also contain additional information so that the receiving party knows where to route the message payload. This wrapper message is referred to as a `TransportMessage` and its payload can be a `Control`, a `Result`, an `Input`, or an `Output`. The schema for the transport message is as follows:
 
 ```ts
 interface TransportMessage<Payload> {

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -278,7 +278,7 @@ If the message is invalid, the server MUST discard the message and send back an 
 
 Otherwise, the message is a normal message. Unwrap the payload and pass it to the handler associated with the `streamId` of the message.
 
-In the special case that the message payload matches the `ControlClose` and has the `StreamClosedBit` set, the server should close the input stream for the handler. The message MUST NOT be passed to the handler.
+In cases where the incoming message is a `ControlClose` message, the server should close the input stream for the handler. The message MUST NOT be passed to the handler.
 
 #### Lifetime of streams
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -262,7 +262,7 @@ For an incoming message to be considered valid on the client, the transport mess
 If the message is invalid, the client MUST silently discard the message.
 Otherwise, this is a normal message. Unwrap the payload and return it to the caller of the original procedure.
 
-In cases where the incoming transport message has a `ControlClose` payload, the client MUST end the user-facing output stream (see the section below on 'Lifetime of Streams' for more information on when these explicit close messages are sent). The message MUST NOT be passed to the user-facing output stream.
+In cases where the incoming message is a `ControlClose` message, the client MUST end the user-facing output stream (see the section below on 'Lifetime of Streams' for more information on when these explicit close messages are sent). The message MUST NOT be passed to the user-facing output stream.
 
 #### On the server
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -376,10 +376,10 @@ client: >       {
 server:  -  -- - {
 ```
 
-Server ends subscription:
+Server initiated close:
 
 ```
-client: >       {
+client: >         {
 server:  -  -- - {
 ```
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -83,7 +83,7 @@ The types of `Input`, `Init`, and `Output` MUST be representable as JSON schema.
 In the official TypeScript implementation, this is done via [TypeBox](https://github.com/sinclairzx81/typebox).
 The server is responsible for doing run-time type validation on incoming messages to ensure they match the handler's type signature before passing it to the handler.
 
-The type of `Error` must extend the `BaseError` type:
+Additionally, the type of `Error` MUST implement the `BaseError` type:
 
 ```ts
 interface BaseError {

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -221,7 +221,6 @@ type Control =
 
 `Control` is a payload that is wrapped with `TransportMessage`.
 
-
 ## Streams
 
 Streams tie together a series of messages into a single logical 'stream' of communication associated with a single remote procedure invocation.

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -221,7 +221,6 @@ type Control =
 
 `Control` is a payload that is wrapped with `TransportMessage`.
 
-??? TODO Faris: there's no differentiation between a `Control` in the protocol and an `Input` message with the the same schema. Yikes. Should probably fix this in this protocol bump.
 
 ## Streams
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -312,7 +312,7 @@ A `subscription` procedure starts with the client sending a single message with 
 
 ```
 client: >       {
-server:  -  -- - {
+server:  -  -- -
 ```
 or
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -245,7 +245,7 @@ When a message is received, it MUST be validated before being processed.
 - Have the expected `seq` number (see the 'Handling Transparent Reconnections' heading for more information on seq/ack).
 - Is not an explicit heartbeat (i.e. the `AckBit` is not set).
 - Either side can initiate a close by sending a message with a `StreamClosedBit`
-  - The closing party goes into a half-closed state, meaning they MUST NOT send any more messages.
+  - The closing party MUST NOT send any more messages.
   - To get a full close, the other side MUST respond with a `StreamClosedBit` acknowledging the close.
 
 When a message is validated at this level, the implementor must update the bookkeeping information for the session (see the 'Transparent Reconnections' heading for more information).


### PR DESCRIPTION
## Why
Currently half-closes initiated by the server are not documented and sort of undefined behavior in the implementation. This is critical to adding `INVALID_REQUEST` errors.

## What changed

- Document `Error` type more explicitly
- Document `Result` type more explicitly
- Document `Control` type more explicitly
- Propose protocol errors
- Proposed changes for server initiated closes
  - These can either be normal closure or a protocol error closure
- Document reader and writer semantics

The changes should be somewhat backwards compatible, existing servers should be able to serve new clients with the exception of server initiated closes/protocol errors, I don't anticipate us needing to do a crazy migration to handle these changes.

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
