### PR TITLE
Support disposing from service state

### DIFF
--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -641,10 +641,6 @@ describe.each(testMatrix())(
         disposable: SchemaWithDisposableState(dispose),
       };
       const server = createServer(serverTransport, services);
-      const client = createClient<typeof services>(
-        clientTransport,
-        serverTransport.clientId,
-      );
       onTestFinished(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -651,13 +651,11 @@ describe.each(testMatrix())(
           serverTransport,
           server,
         });
-        expect(dispose).toBeCalledTimes(1);
       });
 
       // test
-      const result = await client.disposable.add.rpc(3);
-      assert(result.ok);
-      expect(result.payload).toStrictEqual(4);
+      await server.close();
+      expect(dispose).toBeCalledTimes(1);
     });
   },
 );

--- a/__tests__/fixtures/services.ts
+++ b/__tests__/fixtures/services.ts
@@ -252,3 +252,18 @@ export const NonObjectSchemas = ServiceSchema.define({
     },
   }),
 });
+
+export function SchemaWithDisposableState(dispose: () => void) {
+  return ServiceSchema.define(
+    { initializeState: () => ({ [Symbol.dispose]: dispose }) },
+    {
+      add: Procedure.rpc({
+        input: Type.Number(),
+        output: Type.Number(),
+        async handler(_ctx, n) {
+          return Ok(n + 1);
+        },
+      }),
+    },
+  );
+}

--- a/router/context.ts
+++ b/router/context.ts
@@ -30,7 +30,7 @@ export interface ServiceContext {}
 export type ServiceContextWithState<State> = ServiceContext & { state: State };
 
 export type ServiceContextWithTransportInfo<State> = ServiceContext & {
-  state: State;
+  state: Omit<State, typeof Symbol.dispose>;
   to: TransportClientId;
   from: TransportClientId;
   streamId: string;

--- a/router/procedures.ts
+++ b/router/procedures.ts
@@ -62,7 +62,9 @@ export interface RPCProcedure<
   errors: E;
   description?: string;
   handler(
-    context: ServiceContextWithTransportInfo<State>,
+    context: ServiceContextWithTransportInfo<
+      Omit<State, typeof Symbol.dispose>
+    >,
     input: Static<I>,
   ): Promise<ProcedureResult<O, E>>;
 }
@@ -92,7 +94,9 @@ export type UploadProcedure<
       errors: E;
       description?: string;
       handler(
-        context: ServiceContextWithTransportInfo<State>,
+        context: ServiceContextWithTransportInfo<
+          Omit<State, typeof Symbol.dispose>
+        >,
         init: Static<Init>,
         input: AsyncIterableIterator<Static<I>>,
       ): Promise<ProcedureResult<O, E>>;
@@ -104,7 +108,9 @@ export type UploadProcedure<
       errors: E;
       description?: string;
       handler(
-        context: ServiceContextWithTransportInfo<State>,
+        context: ServiceContextWithTransportInfo<
+          Omit<State, typeof Symbol.dispose>
+        >,
         input: AsyncIterableIterator<Static<I>>,
       ): Promise<ProcedureResult<O, E>>;
     };
@@ -129,7 +135,9 @@ export interface SubscriptionProcedure<
   errors: E;
   description?: string;
   handler(
-    context: ServiceContextWithTransportInfo<State>,
+    context: ServiceContextWithTransportInfo<
+      Omit<State, typeof Symbol.dispose>
+    >,
     input: Static<I>,
     output: Pushable<ProcedureResult<O, E>>,
   ): Promise<(() => void) | void>;
@@ -160,7 +168,9 @@ export type StreamProcedure<
       errors: E;
       description?: string;
       handler(
-        context: ServiceContextWithTransportInfo<State>,
+        context: ServiceContextWithTransportInfo<
+          Omit<State, typeof Symbol.dispose>
+        >,
         init: Static<Init>,
         input: AsyncIterableIterator<Static<I>>,
         output: Pushable<ProcedureResult<O, E>>,
@@ -173,7 +183,9 @@ export type StreamProcedure<
       errors: E;
       description?: string;
       handler(
-        context: ServiceContextWithTransportInfo<State>,
+        context: ServiceContextWithTransportInfo<
+          Omit<State, typeof Symbol.dispose>
+        >,
         input: AsyncIterableIterator<Static<I>>,
         output: Pushable<ProcedureResult<O, E>>,
       ): Promise<(() => void) | void>;

--- a/router/procedures.ts
+++ b/router/procedures.ts
@@ -62,9 +62,7 @@ export interface RPCProcedure<
   errors: E;
   description?: string;
   handler(
-    context: ServiceContextWithTransportInfo<
-      Omit<State, typeof Symbol.dispose>
-    >,
+    context: ServiceContextWithTransportInfo<State>,
     input: Static<I>,
   ): Promise<ProcedureResult<O, E>>;
 }
@@ -94,9 +92,7 @@ export type UploadProcedure<
       errors: E;
       description?: string;
       handler(
-        context: ServiceContextWithTransportInfo<
-          Omit<State, typeof Symbol.dispose>
-        >,
+        context: ServiceContextWithTransportInfo<State>,
         init: Static<Init>,
         input: AsyncIterableIterator<Static<I>>,
       ): Promise<ProcedureResult<O, E>>;
@@ -108,9 +104,7 @@ export type UploadProcedure<
       errors: E;
       description?: string;
       handler(
-        context: ServiceContextWithTransportInfo<
-          Omit<State, typeof Symbol.dispose>
-        >,
+        context: ServiceContextWithTransportInfo<State>,
         input: AsyncIterableIterator<Static<I>>,
       ): Promise<ProcedureResult<O, E>>;
     };
@@ -135,9 +129,7 @@ export interface SubscriptionProcedure<
   errors: E;
   description?: string;
   handler(
-    context: ServiceContextWithTransportInfo<
-      Omit<State, typeof Symbol.dispose>
-    >,
+    context: ServiceContextWithTransportInfo<State>,
     input: Static<I>,
     output: Pushable<ProcedureResult<O, E>>,
   ): Promise<(() => void) | void>;
@@ -168,9 +160,7 @@ export type StreamProcedure<
       errors: E;
       description?: string;
       handler(
-        context: ServiceContextWithTransportInfo<
-          Omit<State, typeof Symbol.dispose>
-        >,
+        context: ServiceContextWithTransportInfo<State>,
         init: Static<Init>,
         input: AsyncIterableIterator<Static<I>>,
         output: Pushable<ProcedureResult<O, E>>,
@@ -183,9 +173,7 @@ export type StreamProcedure<
       errors: E;
       description?: string;
       handler(
-        context: ServiceContextWithTransportInfo<
-          Omit<State, typeof Symbol.dispose>
-        >,
+        context: ServiceContextWithTransportInfo<State>,
         input: AsyncIterableIterator<Static<I>>,
         output: Pushable<ProcedureResult<O, E>>,
       ): Promise<(() => void) | void>;

--- a/router/server.ts
+++ b/router/server.ts
@@ -161,6 +161,15 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
     this.transport.removeEventListener('message', this.onMessage);
     this.transport.removeEventListener('sessionStatus', this.onSessionStatus);
     await Promise.all([...this.streamMap.keys()].map(this.cleanupStream));
+
+    for (const [_, context] of this.contextMap.entries()) {
+      if (Symbol.dispose in context.state) {
+        const dispose = context.state[Symbol.dispose];
+        if (typeof dispose === 'function') {
+          dispose();
+        }
+      }
+    }
   }
 
   createNewProcStream(message: OpaqueTransportMessage) {

--- a/router/server.ts
+++ b/router/server.ts
@@ -162,7 +162,7 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
     this.transport.removeEventListener('sessionStatus', this.onSessionStatus);
     await Promise.all([...this.streamMap.keys()].map(this.cleanupStream));
 
-    for (const [_, context] of this.contextMap.entries()) {
+    for (const context of this.contextMap.values()) {
       if (Symbol.dispose in context.state) {
         const dispose = context.state[Symbol.dispose];
         if (typeof dispose === 'function') {


### PR DESCRIPTION
## Why

Services might set up things that need to be disposed. We can support this in a non breaking way by not _requiring_ service context to implement `Disposable`, but if it does, we can call `[Symbol.dispose]` when the server is closing.

This follows the explicit resource management proposal https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html 

<!-- Describe what you are trying to accomplish with this pull request -->

## What changed

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Testing

CI

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
