### PR TITLE
serialize without needing to instantiate server

### DIFF
--- a/__tests__/serialize.test.ts
+++ b/__tests__/serialize.test.ts
@@ -4,16 +4,12 @@ import {
   FallibleServiceSchema,
   TestServiceSchema,
 } from './fixtures/services';
-import { createServer } from '../router/server';
-import { MockServerTransport } from './typescript-stress.test';
+import { serializeSchema } from '../router/server';
 
 describe('serialize server to jsonschema', () => {
-  test('serialize basic server', () => {
-    const server = createServer(new MockServerTransport('mock'), {
-      test: TestServiceSchema,
-    });
-
-    expect(server.serialize()).toStrictEqual({
+  test('serialize entire service schema', () => {
+    const schema = { test: TestServiceSchema };
+    expect(serializeSchema(schema)).toStrictEqual({
       test: {
         procedures: {
           add: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.18.3",
+      "version": "0.18.4",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Why

<!-- Describe what you are trying to accomplish with this pull request -->

it's dumb to need to instantiate a server to get the serialized schema, let's not do that

## What changed

provide `serializeSchema` and remove `serialize` from `Server`

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [x] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
