### PR TITLE
Add generic `Output<>` type for retrieving output message type on client

### DIFF
--- a/router/index.ts
+++ b/router/index.ts
@@ -34,6 +34,13 @@ export type {
   ServiceContextWithTransportInfo,
 } from './context';
 export { Ok, Err, UNCAUGHT_ERROR, RiverUncaughtSchema } from './result';
-export type { RiverErrorSchema, RiverError, Result } from './result';
+export type {
+  RiverErrorSchema,
+  RiverError,
+  Result,
+  ResultOk,
+  ResultErr,
+  Output,
+} from './result';
 
 export { version as RIVER_VERSION } from '../package.json';

--- a/router/index.ts
+++ b/router/index.ts
@@ -38,8 +38,8 @@ export type {
   RiverErrorSchema,
   RiverError,
   Result,
-  ResultOk,
-  ResultErr,
+  ResultUnwrapOk,
+  ResultUnwrapErr,
   Output,
 } from './result';
 

--- a/router/result.ts
+++ b/router/result.ts
@@ -7,6 +7,7 @@ import {
   TUnion,
   Type,
 } from '@sinclair/typebox';
+import { Client } from './client';
 
 type TLiteralString = TLiteral<string>;
 
@@ -59,3 +60,69 @@ export function Err<const T, const E>(error: E): Result<T, E> {
     payload: error,
   };
 }
+
+/**
+ * Refine a {@link Result} type to its returned value.
+ */
+export type ResultOk<R> = R extends Result<infer __T, infer __E> & {
+  ok: true;
+  payload: infer A;
+}
+  ? A
+  : never;
+
+/**
+ * Refine a {@link Result} type to its error value.
+ */
+export type ResultErr<R> = R extends Result<infer __T, infer __E> & {
+  ok: false;
+  payload: infer A;
+}
+  ? A
+  : never;
+
+/**
+ * Retrieve the output type for a procedure, represented as a {@link Result}
+ * type.
+ * Example:
+ * ```
+ * type Message = Output<typeof client, 'serviceName', 'procedureName'>
+ * ```
+ */
+export type Output<
+  RiverClient,
+  ServiceName extends keyof RiverClient,
+  ProcedureName extends keyof RiverClient[ServiceName],
+  Procedure = RiverClient[ServiceName][ProcedureName],
+  Fn extends (...args: never) => unknown = (...args: never) => unknown,
+> = RiverClient extends Client<infer __Y>
+  ? Procedure extends object
+    ? Procedure extends object & { rpc: infer RpcHandler extends Fn }
+      ? Awaited<ReturnType<RpcHandler>>
+      : Procedure extends object & { upload: infer UploadHandler extends Fn }
+      ? Awaited<ReturnType<UploadHandler>> extends [
+          infer __UploadInputMessage,
+          infer UploadOutputMessage,
+        ]
+        ? Awaited<UploadOutputMessage>
+        : never
+      : Procedure extends object & { stream: infer StreamHandler extends Fn }
+      ? Awaited<ReturnType<StreamHandler>> extends [
+          infer __StreamInputMessage,
+          AsyncGenerator<infer StreamOutputMessage>,
+          infer __StreamCloseHandle,
+        ]
+        ? StreamOutputMessage
+        : never
+      : Procedure extends object & {
+          subscribe: infer SubscriptionHandler extends Fn;
+        }
+      ? Awaited<ReturnType<SubscriptionHandler>> extends [
+          AsyncGenerator<infer SubscriptionOutputMessage>,
+          infer __SubscriptionCloseHandle,
+        ]
+        ? SubscriptionOutputMessage
+        : never
+      : never
+    : never
+  : never;

--- a/router/result.ts
+++ b/router/result.ts
@@ -95,7 +95,7 @@ export type Output<
   ProcedureName extends keyof RiverClient[ServiceName],
   Procedure = RiverClient[ServiceName][ProcedureName],
   Fn extends (...args: never) => unknown = (...args: never) => unknown,
-> = RiverClient extends Client<infer __Y>
+> = RiverClient extends Client<infer __ServiceSchemaMap>
   ? Procedure extends object
     ? Procedure extends object & { rpc: infer RpcHandler extends Fn }
       ? Awaited<ReturnType<RpcHandler>>

--- a/router/result.ts
+++ b/router/result.ts
@@ -62,23 +62,17 @@ export function Err<const T, const E>(error: E): Result<T, E> {
 }
 
 /**
- * Refine a {@link Result} type to its returned value.
+ * Refine a {@link Result} type to its returned payload.
  */
-export type ResultOk<R> = R extends Result<infer __T, infer __E> & {
-  ok: true;
-  payload: infer A;
-}
-  ? A
+export type ResultUnwrapOk<R> = R extends Result<infer T, infer __E>
+  ? T
   : never;
 
 /**
- * Refine a {@link Result} type to its error value.
+ * Refine a {@link Result} type to its error payload.
  */
-export type ResultErr<R> = R extends Result<infer __T, infer __E> & {
-  ok: false;
-  payload: infer A;
-}
-  ? A
+export type ResultUnwrapErr<R> = R extends Result<infer __T, infer E>
+  ? E
   : never;
 
 /**


### PR DESCRIPTION
## Why

You may want to use the type of the output message on the client, like in helper functions, without pulling the typebox schema into a location that you can export and share across client and server. Instead, river can export a generic type helper you can use instead that derives the type from the client type.

As the docblock says, you can retrieve the `Result` type for the output message of any procedure by doing the following:
```typescript
type Message = Output<typeof client, 'serviceName', 'procedureName'>
```


<!-- Describe what you are trying to accomplish with this pull request -->

## What changed

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Test plan

Works with all four procedure types!
![Screen Shot 2024-05-10 at 11 49 38 AM](https://github.com/replit/river/assets/16962017/75460253-2cb5-4b1e-bffa-17be38d04d98)
![Screen Shot 2024-05-10 at 11 45 42 AM](https://github.com/replit/river/assets/16962017/07619212-62b2-4fb1-884c-9f2a3cff9bbc)
![Screen Shot 2024-05-10 at 11 45 34 AM](https://github.com/replit/river/assets/16962017/141d5532-8da3-4f0c-9045-d46e2a7eac86)
![Screen Shot 2024-05-10 at 11 45 26 AM](https://github.com/replit/river/assets/16962017/3d28051b-47b0-41c1-baef-d87884e1f762)

## Versioning



- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
