### PR TITLE
[o11y] Add opentelemetry tracing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "node": ">=16"
       },
       "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0",
         "@sinclair/typebox": "~0.32.8",
         "isomorphic-ws": "^5.0.0",
         "ws": "^8.13.0"
@@ -609,6 +610,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.7.0.tgz",
+      "integrity": "sha512-AdY5wvN0P2vXBi3b29hxZgSFvdhdxPB9+f0B6s//P9Q8nibRWeA3cHm8UmLpio9ABigkVHJ5NMPk+Mz8VCCyrw==",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@pkgr/core": {
@@ -4834,6 +4844,12 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@opentelemetry/api": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.7.0.tgz",
+      "integrity": "sha512-AdY5wvN0P2vXBi3b29hxZgSFvdhdxPB9+f0B6s//P9Q8nibRWeA3cHm8UmLpio9ABigkVHJ5NMPk+Mz8VCCyrw==",
+      "peer": true
     },
     "@pkgr/core": {
       "version": "0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.19.3",
+  "version": "0.20.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.19.3",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.19.3",
+  "version": "0.20.0",
   "type": "module",
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "peerDependencies": {
     "@sinclair/typebox": "~0.32.8",
+    "@opentelemetry/api": "^1.7.0",
     "isomorphic-ws": "^5.0.0",
     "ws": "^8.13.0"
   },

--- a/tracing/index.ts
+++ b/tracing/index.ts
@@ -1,0 +1,4 @@
+import { trace } from '@opentelemetry/api';
+
+const tracer = trace.getTracer('river');
+export default tracer;

--- a/transport/message.ts
+++ b/transport/message.ts
@@ -130,6 +130,12 @@ export const TransportMessageSchema = <T extends TSchema>(t: T) =>
     procedureName: Type.Optional(Type.String()),
     streamId: Type.String(),
     controlFlags: Type.Integer(),
+    tracing: Type.Optional(
+      Type.Object({
+        traceparent: Type.String(),
+        tracestate: Type.String(),
+      }),
+    ),
     payload: t,
   });
 
@@ -213,6 +219,7 @@ export interface TransportMessage<Payload = unknown> {
   procedureName?: string;
   streamId: string;
   controlFlags: number;
+  tracing?: { traceparent: string; tracestate: string };
   payload: Payload;
 }
 
@@ -226,6 +233,7 @@ export function handshakeRequestMessage(
   to: TransportClientId,
   sessionId: string,
   metadata?: HandshakeRequestMetadata,
+  tracing?: { traceparent: string; tracestate: string },
 ): TransportMessage<Static<typeof ControlMessageHandshakeRequestSchema>> {
   return {
     id: nanoid(),
@@ -235,6 +243,7 @@ export function handshakeRequestMessage(
     ack: 0,
     streamId: nanoid(),
     controlFlags: 0,
+    tracing,
     payload: {
       type: 'HANDSHAKE_REQ',
       protocolVersion: PROTOCOL_VERSION,


### PR DESCRIPTION
## Why

We want to be able to know what pid2 is doing, and one good way of achieving that is through tracing.

This change is better reviewed with [whitespace turned off :sunglasses:](https://github.com/replit/river/pull/120/files?diff=split&w=1).

part of https://linear.app/replit/issue/WS-3107/pid2-spans

## What changed

This change adds opentelemetry tracing to river so that we know what's going on.

https://app.datadoghq.com/apm/traces?query=service%3Apid2%20-%40component%3Adns&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&colsTraces=service%2Cresource_name%2C%40duration%2C%40_span.count%2C%40_duration.by_service&fromUser=true&graphType=flamegraph&historicalData=true&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=time&spanType=all&spanViewType=metadata&target-span=a&tq_query_translation_version=v0&traceQuery=a&view=spans&viz=stream&start=1715557200000&end=1715557260000&paused=true

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change