### PR TITLE
pass conn handle instead of inferring the right conn

### DIFF
--- a/transport/session.ts
+++ b/transport/session.ts
@@ -243,30 +243,26 @@ export class Session<ConnType extends Connection> {
     this.ack = 0;
   }
 
-  sendBufferedMessages() {
-    if (!this.connection) {
-      const msg = `tried sending buffered messages without a connection (if you hit this code path something is seriously wrong)`;
-      log?.error(msg, this.loggingMetadata);
-      throw new Error(msg);
-    }
-
-    log?.info(
-      `resending ${this.sendBuffer.length} buffered messages`,
-      this.loggingMetadata,
-    );
+  sendBufferedMessages(conn: ConnType) {
+    log?.info(`resending ${this.sendBuffer.length} buffered messages`, {
+      ...this.loggingMetadata,
+      connId: conn.debugId,
+    });
     for (const msg of this.sendBuffer) {
       log?.debug(`resending msg`, {
         ...this.loggingMetadata,
         fullTransportMessage: msg,
+        connId: conn.debugId,
       });
-      const ok = this.connection.send(this.codec.toBuffer(msg));
+      const ok = conn.send(this.codec.toBuffer(msg));
       if (!ok) {
         // this should never happen unless the transport has an
         // incorrect implementation of `createNewOutgoingConnection`
-        const errMsg = `failed to send buffered message to ${this.to} (if you hit this code path something is seriously wrong)`;
+        const errMsg = `failed to send buffered message to ${this.to} (sus, this is a fresh connection)`;
         log?.error(errMsg, {
           ...this.loggingMetadata,
           fullTransportMessage: msg,
+          connId: conn.debugId,
         });
         throw new Error(errMsg);
       }
@@ -300,6 +296,7 @@ export class Session<ConnType extends Connection> {
     this.closeStaleConnection(newConn);
     this.cancelGrace();
     this.connection = newConn;
+    this.sendBufferedMessages(newConn);
   }
 
   beginGrace(cb: () => void) {

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -209,7 +209,6 @@ export abstract class Transport<ConnType extends Connection> {
     // otherwise, this is a new connection from the same user, let's consider
     // the old one as dead and call this connection canonical
     oldSession.replaceWithNewConnection(conn);
-    oldSession.sendBufferedMessages();
     oldSession.advertisedSessionId = advertisedSessionId;
     log?.info(
       `new connection for existing session to ${connectedTo}`,


### PR DESCRIPTION
## Why

It seems like there are cases where we try to send buffered messages along on a recently closed connection.

![image](https://github.com/replit/river/assets/23178940/46df27f1-c0b1-4e47-b215-ad5b33385738)


This might happen due to `sendBufferedMessages` trying to infer the right connection to send messages along instead of just taking a handle to the connection it should use

<!-- Describe what you are trying to accomplish with this pull request -->

## What changed

- Pass the connection to `sendBufferedMessages`
- Also adds `connId` so we can trace this stuff better
- Move `sendBufferedMessages` inside `replaceWithNewConnection` as that's the only callsite

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
