### PR TITLE
Add overloading to bindLogger

### DIFF
--- a/logging/log.ts
+++ b/logging/log.ts
@@ -84,6 +84,9 @@ export const jsonLogger: LogFn = (msg, ctx, level) => {
 };
 
 export let log: Logger | undefined = undefined;
+
+export function bindLogger(fn: undefined, level?: LoggingLevel): undefined;
+export function bindLogger(fn: LogFn | Logger, level?: LoggingLevel): Logger;
 export function bindLogger(
   fn: LogFn | Logger | undefined,
   level?: LoggingLevel,

--- a/logging/log.ts
+++ b/logging/log.ts
@@ -15,7 +15,7 @@ export type LogFn = (
   level?: LoggingLevel,
 ) => void;
 export type Logger = {
-  [key in LoggingLevel]: LogFn;
+  [key in LoggingLevel]: (msg: string, metadata?: MessageMetadata) => void;
 };
 
 export type MessageMetadata = Record<string, unknown> &
@@ -91,11 +91,6 @@ export function bindLogger(
   fn: LogFn | Logger | undefined,
   level?: LoggingLevel,
 ): Logger | undefined {
-  if (!fn) {
-    log = undefined;
-    return;
-  }
-
   if (typeof fn === 'function') {
     log = new BaseLogger(fn, level);
     return log;


### PR DESCRIPTION
## Why

`const log: Logger = bindLogger(logfn, 'info')` returns a type that's `Logger | undefined`

## What changed

- Add overloading so that we can get instance of loggers easily.
- Remove logging level from `Logger` interface

## Versioning

- [ ] Breaking protocol change
- [x] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
