### PR TITLE
ReadStream implementation

### DIFF
--- a/__tests__/streams.test.ts
+++ b/__tests__/streams.test.ts
@@ -37,14 +37,6 @@ describe('ReadStream unit', () => {
     stream.triggerClose();
   });
 
-  it.fails('should synchronously lock the stream when tee() is called', () => {
-    const stream = new ReadStreamImpl<number>(noopCb);
-    stream.tee();
-    expect(stream.isLocked()).toBe(true);
-    expect(() => stream.iter()).toThrowError(TypeError);
-    stream.triggerClose();
-  });
-
   it('should iterate over the values pushed to the stream', async () => {
     const stream = new ReadStreamImpl<number>(noopCb);
     const iterator = stream.iter()[Symbol.asyncIterator]();

--- a/__tests__/streams.test.ts
+++ b/__tests__/streams.test.ts
@@ -9,15 +9,15 @@ describe('ReadStream unit', () => {
     stream.triggerClose();
     expect(stream.isClosed()).toBe(true);
 
-    const iterator = stream.iter()[Symbol.asyncIterator]();
+    const iterator = stream[Symbol.asyncIterator]();
     expect((await iterator.next()).done).toBe(true);
   });
 
-  it('should synchronously lock the stream when iter() is called', () => {
+  it('should synchronously lock the stream when Symbol.asyncIterable is called', () => {
     const stream = new ReadStreamImpl<number>(noopCb);
-    stream.iter();
+    stream[Symbol.asyncIterator]();
     expect(stream.isLocked()).toBe(true);
-    expect(() => stream.iter()).toThrowError(TypeError);
+    expect(() => stream[Symbol.asyncIterator]()).toThrowError(TypeError);
     stream.triggerClose();
   });
 
@@ -25,7 +25,7 @@ describe('ReadStream unit', () => {
     const stream = new ReadStreamImpl<number>(noopCb);
     void stream.asArray();
     expect(stream.isLocked()).toBe(true);
-    expect(() => stream.iter()).toThrowError(TypeError);
+    expect(() => stream[Symbol.asyncIterator]()).toThrowError(TypeError);
     stream.triggerClose();
   });
 
@@ -33,13 +33,13 @@ describe('ReadStream unit', () => {
     const stream = new ReadStreamImpl<number>(noopCb);
     stream.drain();
     expect(stream.isLocked()).toBe(true);
-    expect(() => stream.iter()).toThrowError(TypeError);
+    expect(() => stream[Symbol.asyncIterator]()).toThrowError(TypeError);
     stream.triggerClose();
   });
 
   it('should iterate over the values pushed to the stream', async () => {
     const stream = new ReadStreamImpl<number>(noopCb);
-    const iterator = stream.iter()[Symbol.asyncIterator]();
+    const iterator = stream[Symbol.asyncIterator]();
 
     stream.pushValue(1);
     expect((await iterator.next()).value).toBe(1);
@@ -53,7 +53,7 @@ describe('ReadStream unit', () => {
 
   it('should iterate over the values push to the stream after close', async () => {
     const stream = new ReadStreamImpl<number>(noopCb);
-    const iterator = stream.iter()[Symbol.asyncIterator]();
+    const iterator = stream[Symbol.asyncIterator]();
 
     stream.pushValue(1);
     stream.pushValue(2);
@@ -67,7 +67,7 @@ describe('ReadStream unit', () => {
 
   it('should handle eager iterations gracefully', async () => {
     const stream = new ReadStreamImpl<number>(noopCb);
-    const iterator = stream.iter()[Symbol.asyncIterator]();
+    const iterator = stream[Symbol.asyncIterator]();
 
     const next1 = iterator.next();
     const next2 = iterator.next();
@@ -86,7 +86,7 @@ describe('ReadStream unit', () => {
   it('should not resolve iterator until value is pushed or stream is closed', async () => {
     const stream = new ReadStreamImpl<number>(noopCb);
 
-    const iterator = stream.iter()[Symbol.asyncIterator]();
+    const iterator = stream[Symbol.asyncIterator]();
 
     const nextValueP = iterator.next();
     expect(
@@ -235,30 +235,29 @@ describe('ReadStream unit', () => {
   it('should support for-await-of with iter', async () => {
     const stream = new ReadStreamImpl<number>(noopCb);
 
-    const iterable = stream.iter();
-
     stream.pushValue(1);
-    for await (const value of iterable) {
-      expect(value).toBe(1);
-      break;
+    let i = 0;
+    const values = [];
+    for await (const value of stream) {
+      i++;
+      values.push(value);
+
+      if (i === 1) {
+        stream.pushValue(2);
+      } else if (i === 2) {
+        stream.triggerClose();
+      } else {
+        expect.fail('expected iteration to stop');
+      }
     }
 
-    stream.pushValue(2);
-    for await (const value of iterable) {
-      expect(value).toBe(2);
-      break;
-    }
-
-    stream.triggerClose();
-    for await (const value of iterable) {
-      expect.fail('did not expect value, got: ' + value);
-    }
+    expect(values).toEqual([1, 2]);
   });
 
   describe('drain', () => {
     it('should reject the next stream iteration', async () => {
       const stream = new ReadStreamImpl<number>(noopCb);
-      const iterator = stream.iter()[Symbol.asyncIterator]();
+      const iterator = stream[Symbol.asyncIterator]();
       stream.drain();
       await expect(async () => iterator.next()).rejects.toThrow(
         InterruptedStreamError,
@@ -268,7 +267,7 @@ describe('ReadStream unit', () => {
 
     it('should reject the pending stream iteration', async () => {
       const stream = new ReadStreamImpl<number>(noopCb);
-      const iterator = stream.iter()[Symbol.asyncIterator]();
+      const iterator = stream[Symbol.asyncIterator]();
       const pending = iterator.next();
       stream.drain();
       await expect(async () => pending).rejects.toThrow(InterruptedStreamError);
@@ -277,7 +276,7 @@ describe('ReadStream unit', () => {
 
     it('should reject the next stream iteration wtih a queued up value', async () => {
       const stream = new ReadStreamImpl<number>(noopCb);
-      const iterator = stream.iter()[Symbol.asyncIterator]();
+      const iterator = stream[Symbol.asyncIterator]();
       stream.pushValue(1);
       stream.drain();
       await expect(async () => iterator.next()).rejects.toThrow(
@@ -288,7 +287,7 @@ describe('ReadStream unit', () => {
 
     it('should reject the next stream iteration with a queued up value after stream is closed', async () => {
       const stream = new ReadStreamImpl<number>(noopCb);
-      const iterator = stream.iter()[Symbol.asyncIterator]();
+      const iterator = stream[Symbol.asyncIterator]();
       stream.pushValue(1);
       stream.triggerClose();
       stream.drain();
@@ -299,7 +298,7 @@ describe('ReadStream unit', () => {
 
     it('should not reject the next stream iteration with an empty queue after stream is closed', async () => {
       const stream = new ReadStreamImpl<number>(noopCb);
-      const iterator = stream.iter()[Symbol.asyncIterator]();
+      const iterator = stream[Symbol.asyncIterator]();
       stream.triggerClose();
       stream.drain();
       expect((await iterator.next()).done).toEqual(true);
@@ -307,7 +306,7 @@ describe('ReadStream unit', () => {
 
     it('should reject the next stream iteration wtih a queued up value', async () => {
       const stream = new ReadStreamImpl<number>(noopCb);
-      const iterator = stream.iter()[Symbol.asyncIterator]();
+      const iterator = stream[Symbol.asyncIterator]();
       stream.pushValue(1);
       stream.drain();
       await expect(async () => iterator.next()).rejects.toThrow(

--- a/__tests__/streams.test.ts
+++ b/__tests__/streams.test.ts
@@ -232,7 +232,7 @@ describe('ReadStream unit', () => {
     expect(() => stream.triggerClose()).toThrowError(Error);
   });
 
-  it('should support for-await-of with iter', async () => {
+  it('should support for-await-of', async () => {
     const stream = new ReadStreamImpl<number>(noopCb);
 
     stream.pushValue(1);
@@ -252,6 +252,22 @@ describe('ReadStream unit', () => {
     }
 
     expect(values).toEqual([1, 2]);
+  });
+
+  it('should support for-await-of with break', async () => {
+    const stream = new ReadStreamImpl<number>(noopCb);
+
+    stream.pushValue(1);
+    stream.pushValue(2);
+
+    expect(stream.hasValuesInQueue()).toBeTruthy();
+
+    for await (const value of stream) {
+      expect(value).toEqual(1);
+      break;
+    }
+
+    expect(stream.hasValuesInQueue()).toBeFalsy();
   });
 
   describe('drain', () => {
@@ -278,7 +294,9 @@ describe('ReadStream unit', () => {
       const stream = new ReadStreamImpl<number>(noopCb);
       const iterator = stream[Symbol.asyncIterator]();
       stream.pushValue(1);
+      expect(stream.hasValuesInQueue()).toBeTruthy();
       stream.drain();
+      expect(stream.hasValuesInQueue()).toBeFalsy();
       await expect(async () => iterator.next()).rejects.toThrow(
         InterruptedStreamError,
       );

--- a/__tests__/streams.test.ts
+++ b/__tests__/streams.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect, vi } from 'vitest';
+import { InterruptedStreamError, ReadStreamImpl } from '../router/streams';
+
+const noopCb = () => undefined;
+
+describe('ReadStream unit', () => {
+  it('should close the stream', async () => {
+    const stream = new ReadStreamImpl<number>(noopCb);
+    stream.triggerClose();
+    expect(stream.isClosed()).toBe(true);
+
+    const iterator = stream.iter()[Symbol.asyncIterator]();
+    expect((await iterator.next()).done).toBe(true);
+  });
+
+  it('should synchronously lock the stream when iter() is called', () => {
+    const stream = new ReadStreamImpl<number>(noopCb);
+    stream.iter();
+    expect(stream.isLocked()).toBe(true);
+    expect(() => stream.iter()).toThrowError(TypeError);
+    stream.triggerClose();
+  });
+
+  it('should synchronously lock the stream when asArray() is called', () => {
+    const stream = new ReadStreamImpl<number>(noopCb);
+    void stream.asArray();
+    expect(stream.isLocked()).toBe(true);
+    expect(() => stream.iter()).toThrowError(TypeError);
+    stream.triggerClose();
+  });
+
+  it('should synchronously lock the stream when drain() is called', () => {
+    const stream = new ReadStreamImpl<number>(noopCb);
+    stream.drain();
+    expect(stream.isLocked()).toBe(true);
+    expect(() => stream.iter()).toThrowError(TypeError);
+    stream.triggerClose();
+  });
+
+  it.fails('should synchronously lock the stream when tee() is called', () => {
+    const stream = new ReadStreamImpl<number>(noopCb);
+    stream.tee();
+    expect(stream.isLocked()).toBe(true);
+    expect(() => stream.iter()).toThrowError(TypeError);
+    stream.triggerClose();
+  });
+
+  it('should iterate over the values pushed to the stream', async () => {
+    const stream = new ReadStreamImpl<number>(noopCb);
+    const iterator = stream.iter()[Symbol.asyncIterator]();
+
+    stream.pushValue(1);
+    expect((await iterator.next()).value).toBe(1);
+    stream.pushValue(2);
+    expect((await iterator.next()).value).toBe(2);
+    stream.pushValue(3);
+    expect((await iterator.next()).value).toBe(3);
+    stream.triggerClose();
+    expect((await iterator.next()).done).toBe(true);
+  });
+
+  it('should iterate over the values push to the stream after close', async () => {
+    const stream = new ReadStreamImpl<number>(noopCb);
+    const iterator = stream.iter()[Symbol.asyncIterator]();
+
+    stream.pushValue(1);
+    stream.pushValue(2);
+    stream.pushValue(3);
+    stream.triggerClose();
+    expect((await iterator.next()).value).toBe(1);
+    expect((await iterator.next()).value).toBe(2);
+    expect((await iterator.next()).value).toBe(3);
+    expect((await iterator.next()).done).toBe(true);
+  });
+
+  it('should handle eager iterations gracefully', async () => {
+    const stream = new ReadStreamImpl<number>(noopCb);
+    const iterator = stream.iter()[Symbol.asyncIterator]();
+
+    const next1 = iterator.next();
+    const next2 = iterator.next();
+    stream.pushValue(1);
+    stream.pushValue(2);
+    expect((await next1).value).toEqual(1);
+    expect((await next2).value).toEqual(2);
+    const next3 = iterator.next();
+    const nextDone = iterator.next();
+    stream.pushValue(3);
+    stream.triggerClose();
+    expect((await next3).value).toEqual(3);
+    expect((await nextDone).done).toEqual(true);
+  });
+
+  it('should not resolve iterator until value is pushed or stream is closed', async () => {
+    const stream = new ReadStreamImpl<number>(noopCb);
+
+    const iterator = stream.iter()[Symbol.asyncIterator]();
+
+    const nextValueP = iterator.next();
+    expect(
+      await Promise.race([
+        new Promise((resolve) => setTimeout(() => resolve('timeout'), 10)),
+        nextValueP,
+      ]),
+    ).toEqual('timeout');
+
+    stream.pushValue(1);
+    expect(
+      await Promise.race([
+        new Promise((resolve) => setTimeout(() => resolve('timeout'), 10)),
+        nextValueP,
+      ]),
+    ).toEqual({ value: 1, done: false });
+
+    const nextDoneP = iterator.next();
+    expect(
+      await Promise.race([
+        new Promise((resolve) => setTimeout(() => resolve('timeout'), 10)),
+        nextDoneP,
+      ]),
+    ).toEqual('timeout');
+
+    stream.triggerClose();
+    expect(
+      await Promise.race([
+        new Promise((resolve) => setTimeout(() => resolve('timeout'), 10)),
+        nextDoneP,
+      ]),
+    ).toEqual({ value: undefined, done: true });
+  });
+
+  it('should return an array of the stream values when asArray is called after close', async () => {
+    const stream = new ReadStreamImpl<number>(noopCb);
+    stream.pushValue(1);
+    stream.pushValue(2);
+    stream.pushValue(3);
+    stream.triggerClose();
+
+    const array = await stream.asArray();
+    expect(array).toEqual([1, 2, 3]);
+  });
+
+  it('should not resolve asArray until the stream is closed', async () => {
+    const stream = new ReadStreamImpl<number>(noopCb);
+    stream.pushValue(1);
+
+    const arrayP = stream.asArray();
+
+    stream.pushValue(2);
+    stream.pushValue(3);
+
+    expect(
+      await Promise.race([
+        new Promise((resolve) => setTimeout(() => resolve('timeout'), 10)),
+        arrayP,
+      ]),
+    ).toEqual('timeout');
+
+    stream.pushValue(4);
+    stream.triggerClose();
+    expect(
+      await Promise.race([
+        new Promise((resolve) => setTimeout(() => resolve('timeout'), 10)),
+        arrayP,
+      ]),
+    ).toEqual([1, 2, 3, 4]);
+  });
+
+  it('should request to close the stream when requestClose is called', () => {
+    const requestCloseCb = vi.fn();
+    const stream = new ReadStreamImpl<number>(requestCloseCb);
+    void stream.requestClose();
+    expect(requestCloseCb).toHaveBeenCalled();
+    expect(stream.isCloseRequested()).toBe(true);
+    stream.triggerClose();
+  });
+
+  it('should request to close once the stream when requestClose is called', () => {
+    const requestCloseCb = vi.fn();
+    const stream = new ReadStreamImpl<number>(requestCloseCb);
+    void stream.requestClose();
+    void stream.requestClose();
+    expect(requestCloseCb).toHaveBeenCalledTimes(1);
+    stream.triggerClose();
+  });
+
+  it('should resolve waitForClose until after close', async () => {
+    const stream = new ReadStreamImpl<number>(noopCb);
+
+    const waitP = stream.waitForClose();
+
+    expect(
+      await Promise.race([
+        new Promise((resolve) => setTimeout(() => resolve('timeout'), 10)),
+        waitP,
+      ]),
+    ).toEqual('timeout');
+
+    stream.triggerClose();
+    expect(
+      await Promise.race([
+        new Promise((resolve) => setTimeout(() => resolve('timeout'), 10)),
+        waitP,
+      ]),
+    ).toEqual(undefined);
+    expect(
+      await Promise.race([
+        new Promise((resolve) => setTimeout(() => resolve('timeout'), 10)),
+        stream.waitForClose(),
+      ]),
+    ).toEqual(undefined);
+  });
+
+  it('should resolve waitForClose when called after closing', async () => {
+    const stream = new ReadStreamImpl<number>(noopCb);
+    stream.triggerClose();
+    expect(
+      await Promise.race([
+        new Promise((resolve) => setTimeout(() => resolve('timeout'), 10)),
+        stream.waitForClose(),
+      ]),
+    ).toEqual(undefined);
+    expect(
+      await Promise.race([
+        new Promise((resolve) => setTimeout(() => resolve('timeout'), 10)),
+        stream.waitForClose(),
+      ]),
+    ).toEqual(undefined);
+  });
+
+  it('should throw when pushing to a closed stream', async () => {
+    const stream = new ReadStreamImpl<number>(noopCb);
+    stream.triggerClose();
+    expect(() => stream.pushValue(1)).toThrowError(Error);
+  });
+
+  it('shouild throw when closing multiple times', async () => {
+    const stream = new ReadStreamImpl<number>(noopCb);
+    stream.triggerClose();
+    expect(() => stream.triggerClose()).toThrowError(Error);
+  });
+
+  it('should support for-await-of with iter', async () => {
+    const stream = new ReadStreamImpl<number>(noopCb);
+
+    const iterable = stream.iter();
+
+    stream.pushValue(1);
+    for await (const value of iterable) {
+      expect(value).toBe(1);
+      break;
+    }
+
+    stream.pushValue(2);
+    for await (const value of iterable) {
+      expect(value).toBe(2);
+      break;
+    }
+
+    stream.triggerClose();
+    for await (const value of iterable) {
+      expect.fail('did not expect value, got: ' + value);
+    }
+  });
+
+  describe('drain', () => {
+    it('should reject the next stream iteration', async () => {
+      const stream = new ReadStreamImpl<number>(noopCb);
+      const iterator = stream.iter()[Symbol.asyncIterator]();
+      stream.drain();
+      await expect(async () => iterator.next()).rejects.toThrow(
+        InterruptedStreamError,
+      );
+      stream.triggerClose();
+    });
+
+    it('should reject the pending stream iteration', async () => {
+      const stream = new ReadStreamImpl<number>(noopCb);
+      const iterator = stream.iter()[Symbol.asyncIterator]();
+      const pending = iterator.next();
+      stream.drain();
+      await expect(async () => pending).rejects.toThrow(InterruptedStreamError);
+      stream.triggerClose();
+    });
+
+    it('should reject the next stream iteration wtih a queued up value', async () => {
+      const stream = new ReadStreamImpl<number>(noopCb);
+      const iterator = stream.iter()[Symbol.asyncIterator]();
+      stream.pushValue(1);
+      stream.drain();
+      await expect(async () => iterator.next()).rejects.toThrow(
+        InterruptedStreamError,
+      );
+      stream.triggerClose();
+    });
+
+    it('should reject the next stream iteration with a queued up value after stream is closed', async () => {
+      const stream = new ReadStreamImpl<number>(noopCb);
+      const iterator = stream.iter()[Symbol.asyncIterator]();
+      stream.pushValue(1);
+      stream.triggerClose();
+      stream.drain();
+      await expect(async () => iterator.next()).rejects.toThrow(
+        InterruptedStreamError,
+      );
+    });
+
+    it('should not reject the next stream iteration with an empty queue after stream is closed', async () => {
+      const stream = new ReadStreamImpl<number>(noopCb);
+      const iterator = stream.iter()[Symbol.asyncIterator]();
+      stream.triggerClose();
+      stream.drain();
+      expect((await iterator.next()).done).toEqual(true);
+    });
+
+    it('should reject the next stream iteration wtih a queued up value', async () => {
+      const stream = new ReadStreamImpl<number>(noopCb);
+      const iterator = stream.iter()[Symbol.asyncIterator]();
+      stream.pushValue(1);
+      stream.drain();
+      await expect(async () => iterator.next()).rejects.toThrow(
+        InterruptedStreamError,
+      );
+      stream.triggerClose();
+    });
+  });
+});

--- a/router/streams.ts
+++ b/router/streams.ts
@@ -51,13 +51,6 @@ export interface ReadStream<T> {
    */
   isLocked(): boolean;
   /**
-   * `tee` splits the stream into two {@link ReadStream} instances that
-   * can be consumed independently. The original stream will be locked forever.
-   *
-   * Consuming a locked stream will throw an error.
-   */
-  tee(): [ReadStream<T>, ReadStream<T>];
-  /**
    * `waitForClose` returns a promise that resolves when the stream is closed,
    * does not send a close request.
    */
@@ -280,10 +273,6 @@ export class ReadStreamImpl<T> implements ReadStream<T> {
     this.queue.length = 0;
 
     this.resolveNext?.();
-  }
-
-  public tee(): [ReadStream<T>, ReadStream<T>] {
-    throw new Error('Method not implemented.');
   }
 
   public isClosed(): boolean {

--- a/router/streams.ts
+++ b/router/streams.ts
@@ -34,8 +34,8 @@ export interface ReadStream<T> {
   /**
    * `drain` locks the stream and discards any existing or future data.
    *
-   * If there is an existing lock (e.g. using `iter`), `drain` causes
-   * it to throw an {@link InterruptedStreamError}.
+   * If there is an existing Promise waiting for the next value,
+   * `drain` causes it to throw an {@link InterruptedStreamError}.
    */
   drain(): undefined;
   /**


### PR DESCRIPTION
## Why

Implementation for read stream from #111

and #118 

## What changed

Reduced the API surface area since the RFC removing "break" stuff, `drain` is now how you can interrupt iteration. Otherwise, just implementation and tests for ReadStream.

I decided to leave `tee` out of the implementation for now, we can consider whether we want to make it part of the API or not later, throws an error for now.