### PR TITLE
[codec] handle undefined properly

### DIFF
--- a/__tests__/cleanup.test.ts
+++ b/__tests__/cleanup.test.ts
@@ -183,7 +183,7 @@ describe.each(testMatrix())(
 
       // start procedure
       const [input, output, close] = await client.test.echo.stream();
-      input.push({ msg: '1', ignore: false });
+      input.push({ msg: '1', ignore: false, end: undefined });
       input.push({ msg: '2', ignore: false, end: true });
 
       const result1 = await iterNext(output);

--- a/codec/binary.ts
+++ b/codec/binary.ts
@@ -6,7 +6,9 @@ import { Codec } from './types';
  * @type {Codec}
  */
 export const BinaryCodec: Codec = {
-  toBuffer: encode,
+  toBuffer(obj) {
+    return encode(obj, { ignoreUndefined: true });
+  },
   fromBuffer: (buff: Uint8Array) => {
     try {
       const res = decode(buff);

--- a/codec/codec.test.ts
+++ b/codec/codec.test.ts
@@ -13,8 +13,13 @@ describe.each(codecs)('codec -- $name', ({ codec }) => {
   });
 
   test('encodes null properly', () => {
-    const msg = { null: null };
+    const msg = { test: null };
     expect(codec.fromBuffer(codec.toBuffer(msg))).toStrictEqual(msg);
+  });
+
+  test('skips optional fields', () => {
+    const msg = { test: undefined };
+    expect(codec.fromBuffer(codec.toBuffer(msg))).toStrictEqual({});
   });
 
   test('deeply nested test', () => {


### PR DESCRIPTION
## Why

- if you pass `undefined` explicitly to a `Type.Optional` it would get serialized to `null` on the other side and then it would fail the schema validation because `Type.Optional(T) -> T | undefined` and `null` doesn't validate

<!-- Describe what you are trying to accomplish with this pull request -->

## What changed

- drop undefined values

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
