### PR TITLE
[nix] Add flake.nix with dev shell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+use flake
+dotenv_if_exists
+PATH_add ./node_modules/.bin

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 dist
 node_modules
 example
+
+# Nix
+/.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1716479278,
+        "narHash": "sha256-2eh7rYxQOntkUjFXtlPH7lBuUDd4isu/YHRjNJW7u1Q=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "2ee89d5a0167a8aa0f2a5615d2b8aefb1f299cd4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,25 @@
+{
+  description = "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!";
+
+  inputs.nixpkgs.url = "github:nixos/nixpkgs";
+
+  outputs = { self, nixpkgs }:
+  let
+    mkDevShell = system:
+    let
+      pkgs = nixpkgs.legacyPackages.${system};
+    in
+    pkgs.mkShell {
+      nativeBuildInputs = with pkgs; [
+        nodejs
+        nodePackages.typescript-language-server
+      ];
+    };
+  in
+  {
+    devShells.aarch64-linux.default = mkDevShell "aarch64-linux";
+    devShells.aarch64-darwin.default = mkDevShell "aarch64-darwin";
+    devShells.x86_64-linux.default = mkDevShell "x86_64-linux";
+    devShells.x86_64-darwin.default = mkDevShell "x86_64-darwin";
+  };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import { configDefaults, coverageConfigDefaults } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    exclude: [...configDefaults.exclude, '**/.direnv/**'],
+    coverage: {
+      exclude: [...coverageConfigDefaults.exclude, '**/.direnv/**'],
+    },
+  },
+});


### PR DESCRIPTION
## Why

This makes it easy for developers who use Nix/NixOS to develop river.

## What changed

- Add `flake.nix` with dev shell including node & typescript-language-server
- Add `.envrc` for `direnv` support, which also adds node binaries to the `PATH` for convenience

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
