### PR TITLE
simplify api surface for defining a custom handshake

### DIFF
--- a/__tests__/fixtures/cleanup.ts
+++ b/__tests__/fixtures/cleanup.ts
@@ -1,5 +1,11 @@
 import { expect, vi } from 'vitest';
-import { Connection, OpaqueTransportMessage, Transport } from '../../transport';
+import {
+  ClientTransport,
+  Connection,
+  OpaqueTransportMessage,
+  ServerTransport,
+  Transport,
+} from '../../transport';
 import { Server } from '../../router';
 import { log } from '../../logging/log';
 import { AnyServiceSchemaMap } from '../../router/services';
@@ -107,14 +113,18 @@ export async function testFinishesCleanly({
   serverTransport,
   server,
 }: Partial<{
-  clientTransports: Array<Transport<Connection>>;
-  serverTransport: Transport<Connection>;
+  clientTransports: Array<ClientTransport<Connection>>;
+  serverTransport: ServerTransport<Connection>;
   server: Server<AnyServiceSchemaMap>;
 }>) {
   log?.info('*** end of test cleanup ***');
   vi.useFakeTimers({ shouldAdvanceTime: true });
 
   if (clientTransports) {
+    for (const t of clientTransports) {
+      t.reconnectOnConnectionDrop = false;
+    }
+
     await Promise.all(clientTransports.map(waitForTransportToFinish));
     await advanceFakeTimersBySessionGrace();
     await Promise.all(clientTransports.map(ensureTransportIsClean));

--- a/__tests__/fixtures/matrix.ts
+++ b/__tests__/fixtures/matrix.ts
@@ -1,30 +1,13 @@
 import { Codec } from '../../codec';
-import {
-  ClientTransport,
-  Connection,
-  ServerTransport,
-  TransportClientId,
-} from '../../transport';
 import { ValidCodecs, codecs } from './codec';
 import {
-  TestTransportOptions,
+  TransportMatrixEntry,
   ValidTransports,
   transports,
 } from './transports';
 
 interface TestMatrixEntry {
-  transport: {
-    name: string;
-    setup: (opts?: TestTransportOptions) => Promise<{
-      simulatePhantomDisconnect: () => void;
-      getClientTransport: (
-        id: TransportClientId,
-      ) => ClientTransport<Connection>;
-      getServerTransport: () => ServerTransport<Connection>;
-      restartServer: () => Promise<void>;
-      cleanup: () => Promise<void> | void;
-    }>;
-  };
+  transport: TransportMatrixEntry;
   codec: {
     name: string;
     codec: Codec;

--- a/__tests__/fixtures/transports.ts
+++ b/__tests__/fixtures/transports.ts
@@ -1,6 +1,8 @@
 import {
+  ClientHandshakeOptions,
   ClientTransport,
   Connection,
+  ServerHandshakeOptions,
   ServerTransport,
   TransportClientId,
 } from '../../transport';
@@ -22,12 +24,17 @@ import {
 import { WebSocketClientTransport } from '../../transport/impls/ws/client';
 import { WebSocketServerTransport } from '../../transport/impls/ws/server';
 import NodeWs from 'ws';
+import { TSchema } from '@sinclair/typebox';
 
 export type ValidTransports = 'ws' | 'unix sockets';
 
 export interface TestTransportOptions {
   client?: ProvidedClientTransportOptions;
   server?: ProvidedServerTransportOptions;
+  customHandshake?: {
+    client: ClientHandshakeOptions<TSchema>;
+    server: ServerHandshakeOptions<TSchema>;
+  };
 }
 
 export const transports: Array<{
@@ -64,6 +71,11 @@ export const transports: Array<{
             id,
             opts?.client,
           );
+
+          if (opts?.customHandshake) {
+            clientTransport.extendHandshake(opts.customHandshake.client);
+          }
+
           void clientTransport.connect('SERVER');
           transports.push(clientTransport);
           return clientTransport;
@@ -74,6 +86,11 @@ export const transports: Array<{
             'SERVER',
             opts?.server,
           );
+
+          if (opts?.customHandshake) {
+            serverTransport.extendHandshake(opts.customHandshake.server);
+          }
+
           transports.push(serverTransport);
           return serverTransport;
         },
@@ -125,6 +142,11 @@ export const transports: Array<{
             id,
             opts?.client,
           );
+
+          if (opts?.customHandshake) {
+            clientTransport.extendHandshake(opts.customHandshake.client);
+          }
+
           void clientTransport.connect('SERVER');
           transports.push(clientTransport);
           return clientTransport;
@@ -135,6 +157,11 @@ export const transports: Array<{
             'SERVER',
             opts?.server,
           );
+
+          if (opts?.customHandshake) {
+            serverTransport.extendHandshake(opts.customHandshake.server);
+          }
+
           transports.push(serverTransport);
           return serverTransport;
         },

--- a/__tests__/serialize.test.ts
+++ b/__tests__/serialize.test.ts
@@ -5,152 +5,166 @@ import {
   TestServiceSchema,
 } from './fixtures/services';
 import { serializeSchema } from '../router';
+import { Type } from '@sinclair/typebox';
 
 describe('serialize server to jsonschema', () => {
   test('serialize entire service schema', () => {
     const schema = { test: TestServiceSchema };
-    expect(serializeSchema(schema)).toStrictEqual({
-      test: {
-        procedures: {
-          add: {
-            input: {
-              properties: {
-                n: { type: 'number' },
-              },
-              required: ['n'],
-              type: 'object',
-            },
-            output: {
-              properties: {
-                result: { type: 'number' },
-              },
-              required: ['result'],
-              type: 'object',
-            },
-            errors: {
-              not: {},
-            },
-            type: 'rpc',
-          },
-          echo: {
-            input: {
-              properties: {
-                msg: { type: 'string' },
-                ignore: { type: 'boolean' },
-                end: { type: 'boolean' },
-              },
-              required: ['msg', 'ignore'],
-              type: 'object',
-            },
-            output: {
-              properties: {
-                response: { type: 'string' },
-              },
-              required: ['response'],
-              type: 'object',
-            },
-            errors: {
-              not: {},
-            },
-            type: 'stream',
-          },
-          echoWithPrefix: {
-            errors: {
-              not: {},
-            },
-            init: {
-              properties: {
-                prefix: {
-                  type: 'string',
+    const handshakeSchema = Type.Object({
+      token: Type.String(),
+    });
+
+    expect(serializeSchema(schema, handshakeSchema)).toStrictEqual({
+      handshakeSchema: {
+        properties: {
+          token: { type: 'string' },
+        },
+        required: ['token'],
+        type: 'object',
+      },
+      services: {
+        test: {
+          procedures: {
+            add: {
+              input: {
+                properties: {
+                  n: { type: 'number' },
                 },
+                required: ['n'],
+                type: 'object',
               },
-              required: ['prefix'],
-              type: 'object',
-            },
-            input: {
-              properties: {
-                end: {
-                  type: 'boolean',
+              output: {
+                properties: {
+                  result: { type: 'number' },
                 },
-                ignore: {
-                  type: 'boolean',
-                },
-                msg: {
-                  type: 'string',
-                },
+                required: ['result'],
+                type: 'object',
               },
-              required: ['msg', 'ignore'],
-              type: 'object',
-            },
-            output: {
-              properties: {
-                response: {
-                  type: 'string',
-                },
+              errors: {
+                not: {},
               },
-              required: ['response'],
-              type: 'object',
+              type: 'rpc',
             },
-            type: 'stream',
-          },
-          echoUnion: {
-            description: 'Echos back whatever we sent',
-            errors: {
-              not: {},
+            echo: {
+              input: {
+                properties: {
+                  msg: { type: 'string' },
+                  ignore: { type: 'boolean' },
+                  end: { type: 'boolean' },
+                },
+                required: ['msg', 'ignore'],
+                type: 'object',
+              },
+              output: {
+                properties: {
+                  response: { type: 'string' },
+                },
+                required: ['response'],
+                type: 'object',
+              },
+              errors: {
+                not: {},
+              },
+              type: 'stream',
             },
-            input: {
-              anyOf: [
-                {
-                  description: 'A',
-                  properties: {
-                    a: {
-                      description: 'A number',
-                      type: 'number',
-                    },
+            echoWithPrefix: {
+              errors: {
+                not: {},
+              },
+              init: {
+                properties: {
+                  prefix: {
+                    type: 'string',
                   },
-                  required: ['a'],
-                  type: 'object',
                 },
-                {
-                  description: 'B',
-                  properties: {
-                    b: {
-                      description: 'A string',
-                      type: 'string',
-                    },
+                required: ['prefix'],
+                type: 'object',
+              },
+              input: {
+                properties: {
+                  end: {
+                    type: 'boolean',
                   },
-                  required: ['b'],
-                  type: 'object',
+                  ignore: {
+                    type: 'boolean',
+                  },
+                  msg: {
+                    type: 'string',
+                  },
                 },
-              ],
+                required: ['msg', 'ignore'],
+                type: 'object',
+              },
+              output: {
+                properties: {
+                  response: {
+                    type: 'string',
+                  },
+                },
+                required: ['response'],
+                type: 'object',
+              },
+              type: 'stream',
             },
-            output: {
-              anyOf: [
-                {
-                  description: 'A',
-                  properties: {
-                    a: {
-                      description: 'A number',
-                      type: 'number',
+            echoUnion: {
+              description: 'Echos back whatever we sent',
+              errors: {
+                not: {},
+              },
+              input: {
+                anyOf: [
+                  {
+                    description: 'A',
+                    properties: {
+                      a: {
+                        description: 'A number',
+                        type: 'number',
+                      },
                     },
+                    required: ['a'],
+                    type: 'object',
                   },
-                  required: ['a'],
-                  type: 'object',
-                },
-                {
-                  description: 'B',
-                  properties: {
-                    b: {
-                      description: 'A string',
-                      type: 'string',
+                  {
+                    description: 'B',
+                    properties: {
+                      b: {
+                        description: 'A string',
+                        type: 'string',
+                      },
                     },
+                    required: ['b'],
+                    type: 'object',
                   },
-                  required: ['b'],
-                  type: 'object',
-                },
-              ],
+                ],
+              },
+              output: {
+                anyOf: [
+                  {
+                    description: 'A',
+                    properties: {
+                      a: {
+                        description: 'A number',
+                        type: 'number',
+                      },
+                    },
+                    required: ['a'],
+                    type: 'object',
+                  },
+                  {
+                    description: 'B',
+                    properties: {
+                      b: {
+                        description: 'A string',
+                        type: 'string',
+                      },
+                    },
+                    required: ['b'],
+                    type: 'object',
+                  },
+                ],
+              },
+              type: 'rpc',
             },
-            type: 'rpc',
           },
         },
       },

--- a/router/context.ts
+++ b/router/context.ts
@@ -1,7 +1,4 @@
-import {
-  ParsedHandshakeMetadata,
-  TransportClientId,
-} from '../transport/message';
+import { TransportClientId } from '../transport/message';
 import { Connection, Session } from '../transport/session';
 
 /**
@@ -28,6 +25,17 @@ import { Connection, Session } from '../transport/session';
 export interface ServiceContext {}
 
 /**
+ * The parsed metadata schema for a service. This is the
+ * return value of the {@link ServerHandshakeOptions.validate}
+ * if the handshake extension is used.
+
+ * You should use declaration merging to extend this interface
+ * with the sanitized metadata.
+ */
+/* eslint-disable-next-line @typescript-eslint/no-empty-interface */
+export interface ParsedMetadata {}
+
+/**
  * The {@link ServiceContext} with state. This is what is passed to procedures.
  */
 export type ServiceContextWithState<State> = ServiceContext & { state: State };
@@ -37,5 +45,6 @@ export type ServiceContextWithTransportInfo<State> = ServiceContext & {
   to: TransportClientId;
   from: TransportClientId;
   streamId: string;
-  session: Session<Connection> & { metadata: ParsedHandshakeMetadata };
+  session: Session<Connection>;
+  metadata: ParsedMetadata;
 };

--- a/router/index.ts
+++ b/router/index.ts
@@ -18,7 +18,7 @@ export type {
   PayloadType,
   ProcedureMap,
   ProcedureResult,
-  RPCProcedure,
+  RpcProcedure as RPCProcedure,
   UploadProcedure,
   SubscriptionProcedure,
   StreamProcedure,

--- a/router/procedures.ts
+++ b/router/procedures.ts
@@ -50,7 +50,7 @@ export type ProcedureResult<
  * @template O - The TypeBox schema of the output object.
  * @template E - The TypeBox schema of the error object.
  */
-export interface RPCProcedure<
+export interface RpcProcedure<
   State,
   I extends PayloadType,
   O extends PayloadType,
@@ -181,7 +181,7 @@ export type StreamProcedure<
 
 /**
  * Defines a Procedure type that can be a:
- * - {@link RPCProcedure} for a single message in both directions (1:1)
+ * - {@link RpcProcedure} for a single message in both directions (1:1)
  * - {@link UploadProcedure} for a client-stream (potentially preceded by an
  *   initialization message)
  * - {@link SubscriptionProcedure} for a single message from client, stream from server (1:n)
@@ -207,7 +207,7 @@ export type Procedure<
   ? Ty extends 'upload' ? UploadProcedure<State, I, O, E, Init>
   : Ty extends 'stream' ? StreamProcedure<State, I, O, E, Init>
   : never
-  : Ty extends 'rpc' ? RPCProcedure<State, I, O, E>
+  : Ty extends 'rpc' ? RpcProcedure<State, I, O, E>
   : Ty extends 'upload' ? UploadProcedure<State, I, O, E>
   : Ty extends 'subscription' ? SubscriptionProcedure<State, I, O, E>
   : Ty extends 'stream' ? StreamProcedure<State, I, O, E>
@@ -242,7 +242,7 @@ export type ProcedureMap<State = object> = Record<string, AnyProcedure<State>>;
 // is not recognized as optional, for some reason
 
 /**
- * Creates an {@link RPCProcedure}.
+ * Creates an {@link RpcProcedure}.
  */
 // signature: default errors
 function rpc<State, I extends PayloadType, O extends PayloadType>(def: {
@@ -250,8 +250,8 @@ function rpc<State, I extends PayloadType, O extends PayloadType>(def: {
   output: O;
   errors?: never;
   description?: string;
-  handler: RPCProcedure<State, I, O, TNever>['handler'];
-}): Branded<RPCProcedure<State, I, O, TNever>>;
+  handler: RpcProcedure<State, I, O, TNever>['handler'];
+}): Branded<RpcProcedure<State, I, O, TNever>>;
 
 // signature: explicit errors
 function rpc<
@@ -264,8 +264,8 @@ function rpc<
   output: O;
   errors: E;
   description?: string;
-  handler: RPCProcedure<State, I, O, E>['handler'];
-}): Branded<RPCProcedure<State, I, O, E>>;
+  handler: RpcProcedure<State, I, O, E>['handler'];
+}): Branded<RpcProcedure<State, I, O, E>>;
 
 // implementation
 function rpc({
@@ -279,7 +279,7 @@ function rpc({
   output: PayloadType;
   errors?: RiverError;
   description?: string;
-  handler: RPCProcedure<
+  handler: RpcProcedure<
     object,
     PayloadType,
     PayloadType,

--- a/transport/events.ts
+++ b/transport/events.ts
@@ -8,6 +8,7 @@ export const ProtocolError = {
   UseAfterDestroy: 'use_after_destroy',
   MessageOrderingViolated: 'message_ordering_violated',
 } as const;
+
 export type ProtocolErrorType =
   (typeof ProtocolError)[keyof typeof ProtocolError];
 

--- a/transport/index.ts
+++ b/transport/index.ts
@@ -14,10 +14,8 @@ export type {
   TransportMessage,
   OpaqueTransportMessage,
   TransportClientId,
-  HandshakeRequestMetadata,
-  ParsedHandshakeMetadata,
-  ClientHandshakeOptions,
-  ServerHandshakeOptions,
+  ClientHandshakeOptions as ClientHandshakeOptions,
+  ServerHandshakeOptions as ServerHandshakeOptions,
   isStreamOpen,
   isStreamClose,
 } from './message';

--- a/transport/message.ts
+++ b/transport/message.ts
@@ -50,8 +50,7 @@ export interface ServerHandshakeOptions<MetadataSchema extends TSchema> {
    */
   validate: (
     metadata: Static<MetadataSchema>,
-    session: Session<Connection>,
-    isReconnect: boolean,
+    session?: Session<Connection>,
   ) => false | ParsedMetadata | Promise<false | ParsedMetadata>;
 }
 

--- a/transport/session.ts
+++ b/transport/session.ts
@@ -3,7 +3,6 @@ import {
   ControlFlags,
   ControlMessageAckSchema,
   OpaqueTransportMessage,
-  ParsedHandshakeMetadata,
   PartialTransportMessage,
   TransportClientId,
   TransportMessage,
@@ -130,13 +129,6 @@ export class Session<ConnType extends Connection> {
    * for this session.
    */
   advertisedSessionId?: string;
-
-  /**
-   * The metadata for this session, as parsed from the handshake.
-   *
-   * Will only ever be populated on the server side.
-   */
-  metadata?: ParsedHandshakeMetadata;
 
   /**
    * Number of messages we've sent along this session (excluding handshake and acks)

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -922,7 +922,7 @@ describe.each(testMatrix())(
         construct: get,
       });
 
-      const clientHandshakeFailed = vi.fn(console.log);
+      const clientHandshakeFailed = vi.fn();
       clientTransport.addEventListener('protocolError', clientHandshakeFailed);
       const serverRejectedConnection = vi.fn();
       serverTransport.addEventListener(

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -22,7 +22,6 @@ import {
 import { testMatrix } from '../__tests__/fixtures/matrix';
 import { PartialTransportMessage } from './message';
 import { Type } from '@sinclair/typebox';
-import { bindLogger, coloredStringLogger } from '../logging';
 
 describe.each(testMatrix())(
   'transport connection behaviour tests ($transport.name transport, $codec.name codec)',

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -995,7 +995,6 @@ export abstract class ServerTransport<
     let parsedMetadata: ParsedMetadata = {};
     if (this.handshakeExtensions) {
       // check that the metadata that was sent is the correct shape
-      console.log(rawMetadata)
       if (!Value.Check(this.handshakeExtensions.schema, rawMetadata)) {
         conn.telemetry?.span.setStatus({
           code: SpanStatusCode.ERROR,

--- a/util/testHelpers.ts
+++ b/util/testHelpers.ts
@@ -159,7 +159,8 @@ function dummyCtx<State>(
     to: session.to,
     from: session.from,
     streamId: nanoid(),
-    session: session as ServiceContextWithTransportInfo<State>['session'],
+    session,
+    metadata: {},
   };
 }
 


### PR DESCRIPTION
## Why

<!-- Describe what you are trying to accomplish with this pull request -->

- shouldn't need to define handshake types once in typescript and another in typebox

## What changed

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

- lift out handshake definition to client/server instead of at the transport level
- split out validateHandshakeMetadata into its own function
- changes schema validation to only happen at construction time + receive time
  - i believe that we dont actually need a typebox schema within river for parsed handshake type
  - turns out that this is enough to not need to drill types everywhere
- simplify tests

## Versioning

- [ ] Breaking protocol change
- [x] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
