### PR TITLE
make sure we dont assign conn until handshake is complete

### DIFF
--- a/transport/session.ts
+++ b/transport/session.ts
@@ -313,8 +313,8 @@ export class Session<ConnType extends Connection> {
   replaceWithNewConnection(newConn: ConnType) {
     this.closeStaleConnection(newConn);
     this.cancelGrace();
-    this.connection = newConn;
     this.sendBufferedMessages(newConn);
+    this.connection = newConn;
   }
 
   beginGrace(cb: () => void) {

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -824,7 +824,9 @@ export abstract class ClientTransport<
       }
     }
 
-    const { session } = this.getOrCreateSession(to, conn);
+    // dont pass conn here as we dont want the session to start using the conn
+    // until we have finished the handshake
+    const { session } = this.getOrCreateSession(to);
     const requestMsg = handshakeRequestMessage(
       this.clientId,
       to,


### PR DESCRIPTION
## Why

<!-- Describe what you are trying to accomplish with this pull request -->

`getOrCreateSession` assigns the connection to the session if the connection is passed in. The way we used it before meant that we could pass the connection to the session _before_ the handshake completed which mean that you could have

1. start connection
2. session is created and handshake is initiated
3. client gets session notif and synchronously tries to send a message
4. handshake is finished

to the server, it would get the client message before the handshake message which violates a protocol assumption

## What changed

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

literally just dont assign the connection to the session until the handshake is complete

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
