### PR TITLE
don't log the full transport message in logs, add validation info

### DIFF
--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -31,7 +31,9 @@ import {
 import { testMatrix } from './fixtures/matrix';
 import { Type } from '@sinclair/typebox';
 import { Procedure, ServiceSchema } from '../router';
+import { bindLogger, jsonLogger } from '../logging';
 
+bindLogger(jsonLogger);
 describe.each(testMatrix())(
   'client <-> server integration test ($transport.name transport, $codec.name codec)',
   async ({ transport, codec }) => {

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -31,9 +31,7 @@ import {
 import { testMatrix } from './fixtures/matrix';
 import { Type } from '@sinclair/typebox';
 import { Procedure, ServiceSchema } from '../router';
-import { bindLogger, jsonLogger } from '../logging';
 
-bindLogger(jsonLogger);
 describe.each(testMatrix())(
   'client <-> server integration test ($transport.name transport, $codec.name codec)',
   async ({ transport, codec }) => {

--- a/logging/log.ts
+++ b/logging/log.ts
@@ -105,7 +105,7 @@ const createLogProxy = (log: Logger) =>
     {
       get(_target, prop: LoggingLevel) {
         return (msg: string, metadata?: MessageMetadata) => {
-          // skip cloning object if metadat has no transportMessage
+          // skip cloning object if metadata has no transportMessage
           if (!metadata?.transportMessage) {
             log[prop](msg, metadata);
             return;

--- a/router/client.ts
+++ b/router/client.ts
@@ -224,10 +224,9 @@ export function createClient<
     const [input] = opts.args;
     log?.info(`invoked ${procType} ${serviceName}.${procName}`, {
       clientId: transport.clientId,
-      partialTransportMessage: {
+      transportMessage: {
         procedureName: procName,
         serviceName,
-        payload: input,
       },
     });
 

--- a/router/server.ts
+++ b/router/server.ts
@@ -113,7 +113,7 @@ class RiverServer<
     if (message.to !== this.transport.clientId) {
       log?.info(`got msg with destination that isn't this server, ignoring`, {
         clientId: this.transport.clientId,
-        fullTransportMessage: message,
+        transportMessage: message,
       });
       return;
     }
@@ -173,7 +173,7 @@ class RiverServer<
         `can't create a new procedure stream from a message that doesn't have the stream open bit set`,
         {
           clientId: this.transport.clientId,
-          fullTransportMessage: message,
+          transportMessage: message,
           tags: ['invariant-violation'],
         },
       );
@@ -183,7 +183,7 @@ class RiverServer<
     if (!message.procedureName || !message.serviceName) {
       log?.warn(`missing procedure or service name in stream open message`, {
         clientId: this.transport.clientId,
-        fullTransportMessage: message,
+        transportMessage: message,
       });
       return;
     }
@@ -191,7 +191,7 @@ class RiverServer<
     if (!(message.serviceName in this.services)) {
       log?.warn(`couldn't find service ${message.serviceName}`, {
         clientId: this.transport.clientId,
-        fullTransportMessage: message,
+        transportMessage: message,
       });
       return;
     }
@@ -203,7 +203,7 @@ class RiverServer<
         `couldn't find a matching procedure for ${message.serviceName}.${message.procedureName}`,
         {
           clientId: this.transport.clientId,
-          fullTransportMessage: message,
+          transportMessage: message,
         },
       );
       return;
@@ -213,7 +213,7 @@ class RiverServer<
     if (!session) {
       log?.warn(`couldn't find session for ${message.from}`, {
         clientId: this.transport.clientId,
-        fullTransportMessage: message,
+        transportMessage: message,
       });
       return;
     }
@@ -463,7 +463,7 @@ class RiverServer<
           `got request for invalid procedure type ${
             (procedure as AnyProcedure).type
           } at ${message.serviceName}.${message.procedureName}`,
-          { ...session.loggingMetadata, fullTransportMessage: message },
+          { ...session.loggingMetadata, transportMessage: message },
         );
         return;
     }
@@ -508,7 +508,7 @@ class RiverServer<
     } else if (!Value.Check(ControlMessagePayloadSchema, message.payload)) {
       log?.error(
         `procedure ${serviceName}.${procedureName} received invalid payload`,
-        { clientId: this.transport.clientId, fullTransportMessage: message },
+        { clientId: this.transport.clientId, transportMessage: message },
       );
     }
 

--- a/transport/session.ts
+++ b/transport/session.ts
@@ -200,7 +200,7 @@ export class Session<ConnType extends Connection> {
     const fullMsg: TransportMessage = this.constructMsg(msg);
     log?.debug(`sending msg`, {
       ...this.loggingMetadata,
-      fullTransportMessage: fullMsg,
+      transportMessage: fullMsg,
     });
 
     if (this.connection) {
@@ -210,13 +210,13 @@ export class Session<ConnType extends Connection> {
         `failed to send msg to ${fullMsg.to}, connection is probably dead`,
         {
           ...this.loggingMetadata,
-          fullTransportMessage: fullMsg,
+          transportMessage: fullMsg,
         },
       );
     } else {
       log?.info(
         `failed to send msg to ${fullMsg.to}, connection not ready yet`,
-        { ...this.loggingMetadata, fullTransportMessage: fullMsg },
+        { ...this.loggingMetadata, transportMessage: fullMsg },
       );
     }
 
@@ -262,7 +262,7 @@ export class Session<ConnType extends Connection> {
     for (const msg of this.sendBuffer) {
       log?.debug(`resending msg`, {
         ...this.loggingMetadata,
-        fullTransportMessage: msg,
+        transportMessage: msg,
         connId: conn.id,
       });
       const ok = conn.send(this.codec.toBuffer(msg));
@@ -277,7 +277,7 @@ export class Session<ConnType extends Connection> {
 
         log?.error(errMsg, {
           ...this.loggingMetadata,
-          fullTransportMessage: msg,
+          transportMessage: msg,
           connId: conn.id,
           tags: ['invariant-violation'],
         });

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -322,6 +322,9 @@ export abstract class Transport<ConnType extends Connection> {
     if (!Value.Check(OpaqueTransportMessageSchema, parsedMsg)) {
       log?.error(`received invalid msg: ${JSON.stringify(parsedMsg)}`, {
         clientId: this.clientId,
+        validationErrors: [
+          ...Value.Errors(OpaqueTransportMessageSchema, parsedMsg),
+        ],
       });
       return null;
     }
@@ -630,6 +633,12 @@ export abstract class ClientTransport<
         clientId: this.clientId,
         connectedTo: parsed.from,
         transportMessage: parsed,
+        validationErrors: [
+          ...Value.Errors(
+            ControlMessageHandshakeResponseSchema,
+            parsed.payload,
+          ),
+        ],
       });
       this.protocolError(
         ProtocolError.HandshakeFailed,
@@ -810,6 +819,9 @@ export abstract class ClientTransport<
         log?.error(`constructed handshake metadata did not match schema`, {
           clientId: this.clientId,
           connectedTo: to,
+          validationErrors: [
+            ...Value.Errors(this.handshakeExtensions.schema, metadata),
+          ],
           tags: ['invariant-violation'],
         });
         this.protocolError(
@@ -1012,6 +1024,9 @@ export abstract class ServerTransport<
         log?.warn(`received malformed handshake metadata from ${from}`, {
           clientId: this.clientId,
           connId: conn.id,
+          validationErrors: [
+            ...Value.Errors(this.handshakeExtensions.schema, rawMetadata),
+          ],
         });
         this.protocolError(ProtocolError.HandshakeFailed, reason);
         return false;
@@ -1080,6 +1095,9 @@ export abstract class ServerTransport<
         // safe to log metadata here as we remove the payload
         // before passing it to user-land
         transportMessage: parsed,
+        validationErrors: [
+          ...Value.Errors(ControlMessageHandshakeRequestSchema, parsed.payload),
+        ],
       });
       this.protocolError(
         ProtocolError.HandshakeFailed,


### PR DESCRIPTION
## Why

<!-- Describe what you are trying to accomplish with this pull request -->

this caused issues in production with large payload responses (e.g. buffers containing long files)

## What changed

- strip payload and tracing info from logs
- log parsing errors where appropriate

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
