### PR TITLE
pass previous metadata to validate

### DIFF
--- a/transport/message.ts
+++ b/transport/message.ts
@@ -1,6 +1,5 @@
 import { Type, TSchema, Static } from '@sinclair/typebox';
 import { nanoid } from 'nanoid';
-import { Connection, Session } from './session';
 import { PropagationContext } from '../tracing';
 import { ParsedMetadata } from '../router/context';
 
@@ -50,7 +49,7 @@ export interface ServerHandshakeOptions<MetadataSchema extends TSchema> {
    */
   validate: (
     metadata: Static<MetadataSchema>,
-    session?: Session<Connection>,
+    previousParsedMetadata?: ParsedMetadata,
   ) => false | ParsedMetadata | Promise<false | ParsedMetadata>;
 }
 

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -1017,9 +1017,13 @@ export abstract class ServerTransport<
         return false;
       }
 
+      const previousParsedMetadata = session
+        ? this.sessionHandshakeMetadata.get(session)
+        : undefined;
+
       parsedMetadata = await this.handshakeExtensions.validate(
         rawMetadata,
-        session,
+        previousParsedMetadata,
       );
 
       // handler rejected the connection


### PR DESCRIPTION
## Why + What changed

<!-- Describe what you are trying to accomplish with this pull request -->

- session no longer contains previous metadata info so passing it to validate doesn't make sense
- let's just pass the metadata directly (this is the only thing in session we check in web anyways)
- added a test for this

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [x] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
