### PR TITLE
remove unnecessary generic `MetadataSchema`

### DIFF
--- a/__tests__/fixtures/transports.ts
+++ b/__tests__/fixtures/transports.ts
@@ -24,7 +24,6 @@ import {
 import { WebSocketClientTransport } from '../../transport/impls/ws/client';
 import { WebSocketServerTransport } from '../../transport/impls/ws/server';
 import NodeWs from 'ws';
-import { TSchema } from '@sinclair/typebox';
 
 export type ValidTransports = 'ws' | 'unix sockets';
 
@@ -38,10 +37,10 @@ export interface TransportMatrixEntry {
   setup: (opts?: TestTransportOptions) => Promise<{
     getClientTransport: (
       id: TransportClientId,
-      handshakeOptions?: ClientHandshakeOptions<TSchema>,
+      handshakeOptions?: ClientHandshakeOptions,
     ) => ClientTransport<Connection>;
     getServerTransport: (
-      handshakeOptions?: ServerHandshakeOptions<TSchema>,
+      handshakeOptions?: ServerHandshakeOptions,
     ) => ServerTransport<Connection>;
     simulatePhantomDisconnect: () => void;
     restartServer: () => Promise<void>;

--- a/router/client.ts
+++ b/router/client.ts
@@ -20,7 +20,7 @@ import {
   PartialTransportMessage,
   ClientHandshakeOptions,
 } from '../transport/message';
-import { Static, TSchema } from '@sinclair/typebox';
+import { Static } from '@sinclair/typebox';
 import { nanoid } from 'nanoid';
 import { Err, Result, UNEXPECTED_DISCONNECT } from './result';
 import { EventMap } from '../transport/events';
@@ -194,14 +194,11 @@ const defaultClientOptions: ClientOptions = {
  * @param {Partial<ClientOptions>} providedClientOptions - The options for the client.
  * @returns The client for the server.
  */
-export function createClient<
-  ServiceSchemaMap extends AnyServiceSchemaMap,
-  MetadataSchema extends TSchema = TSchema,
->(
-  transport: ClientTransport<Connection, MetadataSchema>,
+export function createClient<ServiceSchemaMap extends AnyServiceSchemaMap>(
+  transport: ClientTransport<Connection>,
   serverId: TransportClientId,
   providedClientOptions: Partial<
-    ClientOptions & { handshakeOptions: ClientHandshakeOptions<MetadataSchema> }
+    ClientOptions & { handshakeOptions: ClientHandshakeOptions }
   > = {},
 ): Client<ServiceSchemaMap> {
   if (providedClientOptions.handshakeOptions) {

--- a/router/context.ts
+++ b/router/context.ts
@@ -31,6 +31,14 @@ export interface ServiceContext {}
 
  * You should use declaration merging to extend this interface
  * with the sanitized metadata.
+ *
+ * ```ts
+ * declare module '@replit/river' {
+ *   interface ParsedMetadata {
+ *     userId: number;
+ *   }
+ * }
+ * ```
  */
 /* eslint-disable-next-line @typescript-eslint/no-empty-interface */
 export interface ParsedMetadata {}

--- a/router/index.ts
+++ b/router/index.ts
@@ -29,6 +29,7 @@ export type { Client } from './client';
 export { createServer } from './server';
 export type { Server } from './server';
 export type {
+  ParsedMetadata,
   ServiceContext,
   ServiceContextWithState,
   ServiceContextWithTransportInfo,

--- a/router/server.ts
+++ b/router/server.ts
@@ -1,4 +1,4 @@
-import { Static, TSchema } from '@sinclair/typebox';
+import { Static } from '@sinclair/typebox';
 import { ServerTransport } from '../transport/transport';
 import { AnyProcedure, PayloadType } from './procedures';
 import {
@@ -59,11 +59,8 @@ interface ProcStream {
   };
 }
 
-class RiverServer<
-  Services extends AnyServiceSchemaMap,
-  MetadataSchema extends TSchema,
-> {
-  transport: ServerTransport<Connection, MetadataSchema>;
+class RiverServer<Services extends AnyServiceSchemaMap> {
+  transport: ServerTransport<Connection>;
   services: InstantiatedServiceSchemaMap<Services>;
   contextMap: Map<AnyService, ServiceContextWithState<object>>;
   // map of streamId to ProcStream
@@ -73,9 +70,9 @@ class RiverServer<
   disconnectedSessions: Set<TransportClientId>;
 
   constructor(
-    transport: ServerTransport<Connection, MetadataSchema>,
+    transport: ServerTransport<Connection>,
     services: Services,
-    handshakeOptions?: ServerHandshakeOptions<MetadataSchema>,
+    handshakeOptions?: ServerHandshakeOptions,
     extendedContext?: Omit<ServiceContext, 'state'>,
   ) {
     const instances: Record<string, AnyService> = {};
@@ -578,14 +575,11 @@ class RiverServer<
  * @param extendedContext - An optional object containing additional context to be passed to all services.
  * @returns A promise that resolves to a server instance with the registered services.
  */
-export function createServer<
-  Services extends AnyServiceSchemaMap,
-  MetadataSchema extends TSchema = TSchema,
->(
-  transport: ServerTransport<Connection, MetadataSchema>,
+export function createServer<Services extends AnyServiceSchemaMap>(
+  transport: ServerTransport<Connection>,
   services: Services,
   providedServerOptions?: Partial<{
-    handshakeOptions?: ServerHandshakeOptions<MetadataSchema>;
+    handshakeOptions?: ServerHandshakeOptions;
     extendedContext?: Omit<ServiceContext, 'state'>;
   }>,
 ): Server<Services> {

--- a/transport/message.ts
+++ b/transport/message.ts
@@ -16,7 +16,9 @@ export const enum ControlFlags {
   StreamClosedBit = 0b0100,
 }
 
-export interface ClientHandshakeOptions<MetadataSchema extends TSchema> {
+export interface ClientHandshakeOptions<
+  MetadataSchema extends TSchema = TSchema,
+> {
   /**
    * Schema for the metadata that the client sends to the server
    * during the handshake.
@@ -29,7 +31,9 @@ export interface ClientHandshakeOptions<MetadataSchema extends TSchema> {
   construct: () => Static<MetadataSchema> | Promise<Static<MetadataSchema>>;
 }
 
-export interface ServerHandshakeOptions<MetadataSchema extends TSchema> {
+export interface ServerHandshakeOptions<
+  MetadataSchema extends TSchema = TSchema,
+> {
   /**
    * Schema for the metadata that the server receives from the client
    * during the handshake.

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -25,7 +25,7 @@ import {
   ProtocolErrorType,
 } from './events';
 import { Connection, Session, SessionOptions } from './session';
-import { Static, TSchema } from '@sinclair/typebox';
+import { Static } from '@sinclair/typebox';
 import { coerceErrorString } from '../util/stringify';
 import { ConnectionRetryOptions, LeakyBucketRateLimit } from './rateLimit';
 import { NaiveJsonCodec } from '../codec';
@@ -493,7 +493,6 @@ export abstract class Transport<ConnType extends Connection> {
 
 export abstract class ClientTransport<
   ConnType extends Connection,
-  HandshakeMetadata extends TSchema = TSchema,
 > extends Transport<ConnType> {
   /**
    * The options for this transport.
@@ -517,7 +516,7 @@ export abstract class ClientTransport<
   /**
    * Optional handshake options for this client.
    */
-  handshakeExtensions?: ClientHandshakeOptions<HandshakeMetadata>;
+  handshakeExtensions?: ClientHandshakeOptions;
 
   constructor(
     clientId: TransportClientId,
@@ -532,7 +531,7 @@ export abstract class ClientTransport<
     this.retryBudget = new LeakyBucketRateLimit(this.options);
   }
 
-  extendHandshake(options: ClientHandshakeOptions<HandshakeMetadata>) {
+  extendHandshake(options: ClientHandshakeOptions) {
     this.handshakeExtensions = options;
   }
 
@@ -811,7 +810,7 @@ export abstract class ClientTransport<
   }
 
   protected async sendHandshake(to: TransportClientId, conn: ConnType) {
-    let metadata: Static<HandshakeMetadata> | undefined;
+    let metadata: unknown = undefined;
 
     if (this.handshakeExtensions) {
       metadata = await this.handshakeExtensions.construct();
@@ -862,7 +861,6 @@ export abstract class ClientTransport<
 
 export abstract class ServerTransport<
   ConnType extends Connection,
-  CustomMetadataSchema extends TSchema = TSchema,
 > extends Transport<ConnType> {
   /**
    * The options for this transport.
@@ -872,7 +870,7 @@ export abstract class ServerTransport<
   /**
    * Optional handshake options for the server.
    */
-  handshakeExtensions?: ServerHandshakeOptions<CustomMetadataSchema>;
+  handshakeExtensions?: ServerHandshakeOptions;
 
   /**
    * A map of session handshake data for each session.
@@ -895,7 +893,7 @@ export abstract class ServerTransport<
     });
   }
 
-  extendHandshake(options: ServerHandshakeOptions<CustomMetadataSchema>) {
+  extendHandshake(options: ServerHandshakeOptions) {
     this.handshakeExtensions = options;
   }
 


### PR DESCRIPTION
## Why

- transports dont need the type of the schema `MetadataSchema` drilled throughout
- construction of extra handshake data is internal
- everything else is just `ParsedMetadata` which is exposed as an interface that can be overridden

<!-- Describe what you are trying to accomplish with this pull request -->

## What changed

- remove unnecessary generic `MetadataSchema`
- export `ParsedMetadata` so we can properly override it

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [x] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
