### PR TITLE
[protocolv2] Init always exists

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -95,9 +95,9 @@ interface BaseError {
 The `Result` type MUST conform to:
 
 ```ts
-type Result<T, E extends BaseError> =
-  | { ok: true; payload: T }
-  | { ok: false; payload: E };
+type Result<SuccessPayload, ErrorPayload extends BaseError> =
+  | { ok: true; payload: SuccessPayload }
+  | { ok: false; payload: ErrorPayload };
 ```
 
 The messages in either direction must also contain additional information so that the receiving party knows where to route the message payload. This wrapper message is referred to as a `TransportMessage` and its payload can be a `Control`, a `Result`, an `Init`, an `Input`, or an `Output`. The schema for the transport message is as follows:

--- a/__tests__/bandwidth.bench.ts
+++ b/__tests__/bandwidth.bench.ts
@@ -52,7 +52,7 @@ describe('bandwidth', async () => {
       { time: BENCH_DURATION },
     );
 
-    const [inputWriter, outputReader] = await client.test.echo.stream();
+    const [inputWriter, outputReader] = await client.test.echo.stream({});
     bench(
       `${name} -- stream`,
       async () => {

--- a/__tests__/cleanup.test.ts
+++ b/__tests__/cleanup.test.ts
@@ -182,8 +182,9 @@ describe.each(testMatrix())(
         clientTransport.eventDispatcher.numberOfListeners('message');
 
       // start procedure
-      const [inputWriter, outputReader, close] =
-        await client.test.echo.stream();
+      const [inputWriter, outputReader, close] = await client.test.echo.stream(
+        {},
+      );
       inputWriter.write({ msg: '1', ignore: false, end: undefined });
       inputWriter.write({ msg: '2', ignore: false, end: true });
 
@@ -318,7 +319,7 @@ describe.each(testMatrix())(
 
       // start procedure
       const [inputWriter, addResult] =
-        await client.uploadable.addMultiple.upload();
+        await client.uploadable.addMultiple.upload({});
       inputWriter.write({ n: 1 });
       inputWriter.write({ n: 2 });
       inputWriter.close();
@@ -368,7 +369,7 @@ describe.each(testMatrix())(
       });
 
       // start a stream
-      const [inputWriter, outputReader] = await client.test.echo.stream();
+      const [inputWriter, outputReader] = await client.test.echo.stream({});
       inputWriter.write({ msg: '1', ignore: false });
 
       const outputIterator = getIteratorFromStream(outputReader);

--- a/__tests__/disconnects.test.ts
+++ b/__tests__/disconnects.test.ts
@@ -91,7 +91,7 @@ describe.each(testMatrix())(
       });
 
       // start procedure
-      const [inputWriter, outputReader] = await client.test.echo.stream();
+      const [inputWriter, outputReader] = await client.test.echo.stream({});
       const outputIterator = getIteratorFromStream(outputReader);
 
       inputWriter.write({ msg: 'abc', ignore: false });
@@ -236,7 +236,7 @@ describe.each(testMatrix())(
 
       // start procedure
       const [inputWriter, addResult] =
-        await client.uploadable.addMultiple.upload();
+        await client.uploadable.addMultiple.upload({});
       inputWriter.write({ n: 1 });
       inputWriter.write({ n: 2 });
       // end procedure

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -147,8 +147,9 @@ describe.each(testMatrix())(
       });
 
       // test
-      const [inputWriter, outputReader, close] =
-        await client.test.echo.stream();
+      const [inputWriter, outputReader, close] = await client.test.echo.stream(
+        {},
+      );
       const outputIterator = getIteratorFromStream(outputReader);
 
       inputWriter.write({ msg: 'abc', ignore: false });
@@ -237,7 +238,7 @@ describe.each(testMatrix())(
 
       // test
       const [inputWriter, outputReader, close] =
-        await client.fallible.echo.stream();
+        await client.fallible.echo.stream({});
       const outputIterator = getIteratorFromStream(outputReader);
       inputWriter.write({ msg: 'abc', throwResult: false, throwError: false });
       const result1 = await iterNext(outputIterator);
@@ -328,7 +329,7 @@ describe.each(testMatrix())(
 
       // test
       const [inputWriter, addResult] =
-        await client.uploadable.addMultiple.upload();
+        await client.uploadable.addMultiple.upload({});
       inputWriter.write({ n: 1 });
       inputWriter.write({ n: 2 });
       inputWriter.close();
@@ -474,7 +475,7 @@ describe.each(testMatrix())(
       // test
       const openStreams = [];
       for (let i = 0; i < CONCURRENCY; i++) {
-        const streamHandle = await client.test.echo.stream();
+        const streamHandle = await client.test.echo.stream({});
         const inputWriter = streamHandle[0];
         inputWriter.write({ msg: `${i}-1`, ignore: false });
         inputWriter.write({ msg: `${i}-2`, ignore: false });
@@ -689,7 +690,7 @@ describe.each(testMatrix())(
       const services = {
         test: ServiceSchema.define({
           getData: Procedure.rpc({
-            input: Type.Object({}),
+            init: Type.Object({}),
             output: Type.Object({
               data: Type.String(),
               extra: Type.Number(),

--- a/__tests__/handler.test.ts
+++ b/__tests__/handler.test.ts
@@ -18,7 +18,7 @@ import {
 import { UNCAUGHT_ERROR } from '../router/result';
 import { Observable } from './fixtures/observable';
 
-describe.skip('server-side test', () => {
+describe('server-side test', () => {
   const service = TestServiceSchema.instantiate();
 
   test('rpc basic', async () => {
@@ -73,7 +73,12 @@ describe.skip('server-side test', () => {
     assert(result2.ok);
     expect(result2.payload).toStrictEqual({ response: 'ghi' });
 
-    expect(outputIterator.next()).toEqual({ done: true, value: undefined });
+    await outputReader.requestClose();
+
+    expect(await outputIterator.next()).toEqual({
+      done: true,
+      value: undefined,
+    });
   });
 
   test('stream with initialization', async () => {
@@ -96,8 +101,12 @@ describe.skip('server-side test', () => {
     const result2 = await iterNext(outputIterator);
     assert(result2.ok);
     expect(result2.payload).toStrictEqual({ response: 'test ghi' });
+    await outputReader.requestClose();
 
-    expect(outputIterator.next()).toEqual({ done: true, value: undefined });
+    expect(await outputIterator.next()).toEqual({
+      done: true,
+      value: undefined,
+    });
   });
 
   test('fallible stream', async () => {

--- a/__tests__/serialize.test.ts
+++ b/__tests__/serialize.test.ts
@@ -26,7 +26,7 @@ describe('serialize server to jsonschema', () => {
         test: {
           procedures: {
             add: {
-              input: {
+              init: {
                 properties: {
                   n: { type: 'number' },
                 },
@@ -49,7 +49,7 @@ describe('serialize server to jsonschema', () => {
               errors: {
                 not: {},
               },
-              input: {
+              init: {
                 properties: {
                   n: {
                     type: 'number',
@@ -70,6 +70,10 @@ describe('serialize server to jsonschema', () => {
               errors: {
                 not: {},
               },
+              init: {
+                properties: {},
+                type: 'object',
+              },
               input: {
                 properties: {
                   n: {
@@ -88,6 +92,10 @@ describe('serialize server to jsonschema', () => {
               type: 'stream',
             },
             echo: {
+              init: {
+                properties: {},
+                type: 'object',
+              },
               input: {
                 properties: {
                   msg: { type: 'string' },
@@ -153,7 +161,7 @@ describe('serialize server to jsonschema', () => {
               errors: {
                 not: {},
               },
-              input: {
+              init: {
                 anyOf: [
                   {
                     description: 'A',
@@ -207,6 +215,38 @@ describe('serialize server to jsonschema', () => {
               },
               type: 'rpc',
             },
+            unimplementedSubscription: {
+              errors: {
+                not: {},
+              },
+              init: {
+                properties: {},
+                type: 'object',
+              },
+              output: {
+                properties: {},
+                type: 'object',
+              },
+              type: 'subscription',
+            },
+            unimplementedUpload: {
+              errors: {
+                not: {},
+              },
+              init: {
+                properties: {},
+                type: 'object',
+              },
+              input: {
+                properties: {},
+                type: 'object',
+              },
+              output: {
+                properties: {},
+                type: 'object',
+              },
+              type: 'upload',
+            },
           },
         },
       },
@@ -219,7 +259,7 @@ describe('serialize service to jsonschema', () => {
     expect(TestServiceSchema.serialize()).toStrictEqual({
       procedures: {
         add: {
-          input: {
+          init: {
             properties: {
               n: { type: 'number' },
             },
@@ -242,7 +282,7 @@ describe('serialize service to jsonschema', () => {
           errors: {
             not: {},
           },
-          input: {
+          init: {
             properties: {
               n: {
                 type: 'number',
@@ -263,6 +303,10 @@ describe('serialize service to jsonschema', () => {
           errors: {
             not: {},
           },
+          init: {
+            properties: {},
+            type: 'object',
+          },
           input: {
             properties: {
               n: {
@@ -281,6 +325,10 @@ describe('serialize service to jsonschema', () => {
           type: 'stream',
         },
         echo: {
+          init: {
+            properties: {},
+            type: 'object',
+          },
           input: {
             properties: {
               msg: { type: 'string' },
@@ -346,7 +394,7 @@ describe('serialize service to jsonschema', () => {
           errors: {
             not: {},
           },
-          input: {
+          init: {
             anyOf: [
               {
                 description: 'A',
@@ -400,6 +448,38 @@ describe('serialize service to jsonschema', () => {
           },
           type: 'rpc',
         },
+        unimplementedSubscription: {
+          errors: {
+            not: {},
+          },
+          init: {
+            properties: {},
+            type: 'object',
+          },
+          output: {
+            properties: {},
+            type: 'object',
+          },
+          type: 'subscription',
+        },
+        unimplementedUpload: {
+          errors: {
+            not: {},
+          },
+          init: {
+            properties: {},
+            type: 'object',
+          },
+          input: {
+            properties: {},
+            type: 'object',
+          },
+          output: {
+            properties: {},
+            type: 'object',
+          },
+          type: 'upload',
+        },
       },
     });
   });
@@ -411,7 +491,7 @@ describe('serialize service to jsonschema', () => {
           errors: {
             not: {},
           },
-          input: {
+          init: {
             properties: {
               file: {
                 type: 'string',
@@ -439,7 +519,7 @@ describe('serialize service to jsonschema', () => {
     expect(FallibleServiceSchema.serialize()).toStrictEqual({
       procedures: {
         divide: {
-          input: {
+          init: {
             properties: {
               a: { type: 'number' },
               b: { type: 'number' },
@@ -485,6 +565,10 @@ describe('serialize service to jsonschema', () => {
               },
             },
             required: ['code', 'message'],
+            type: 'object',
+          },
+          init: {
+            properties: {},
             type: 'object',
           },
           input: {

--- a/__tests__/typescript-stress.test.ts
+++ b/__tests__/typescript-stress.test.ts
@@ -37,7 +37,7 @@ const fnBody = Procedure.rpc<
   typeof output,
   typeof errors
 >({
-  input,
+  init: input,
   output,
   errors,
   async handler(_state, msg) {
@@ -207,30 +207,32 @@ describe('Output<> type', () => {
   const services = {
     test: ServiceSchema.define({
       rpc: Procedure.rpc({
-        input: Type.Object({ n: Type.Number() }),
+        init: Type.Object({ n: Type.Number() }),
         output: Type.Object({ n: Type.Number() }),
         async handler(_, { n }) {
           return Ok({ n });
         },
       }),
       stream: Procedure.stream({
+        init: Type.Object({}),
         input: Type.Object({ n: Type.Number() }),
         output: Type.Object({ n: Type.Number() }),
-        async handler(_c, _in, output) {
+        async handler(_c, _init, _input, output) {
           output.write(Ok({ n: 1 }));
         },
       }),
       subscription: Procedure.subscription({
-        input: Type.Object({ n: Type.Number() }),
+        init: Type.Object({ n: Type.Number() }),
         output: Type.Object({ n: Type.Number() }),
-        async handler(_c, _in, output) {
+        async handler(_c, _init, output) {
           output.write(Ok({ n: 1 }));
         },
       }),
       upload: Procedure.upload({
+        init: Type.Object({}),
         input: Type.Object({ n: Type.Number() }),
         output: Type.Object({ n: Type.Number() }),
-        async handler(_c, _in) {
+        async handler(_c, _init, _input) {
           return Ok({ n: 1 });
         },
       }),
@@ -262,7 +264,7 @@ describe('Output<> type', () => {
 
     // Then
     void client.test.stream
-      .stream()
+      .stream({})
       .then(([_in, outputReader, _close]) =>
         iterNext(getIteratorFromStream(outputReader)),
       )
@@ -296,7 +298,7 @@ describe('Output<> type', () => {
 
     // Then
     void client.test.upload
-      .upload()
+      .upload({})
       .then(([_input, result]) => result)
       .then(acceptOutput);
     expect(client).toBeTruthy();

--- a/router/client.ts
+++ b/router/client.ts
@@ -300,9 +300,7 @@ function handleStream(
     procedureName,
     streamId,
   );
-  let firstMessage = true;
   let healthyClose = true;
-
   const inputWriter = new WriteStreamImpl(
     (rawIn: unknown) => {
       const m: PartialTransportMessage = {
@@ -310,14 +308,6 @@ function handleStream(
         payload: rawIn,
         controlFlags: 0,
       };
-
-      if (firstMessage) {
-        m.serviceName = serviceName;
-        m.procedureName = procedureName;
-        m.tracing = getPropagationContext(ctx);
-        m.controlFlags |= ControlFlags.StreamOpenBit;
-        firstMessage = false;
-      }
 
       transport.send(serverId, m);
     },
@@ -330,18 +320,14 @@ function handleStream(
   const readStreamRequestCloseNotImplemented = () => undefined;
   const outputReader = new ReadStreamImpl(readStreamRequestCloseNotImplemented);
 
-  if (init) {
-    transport.send(serverId, {
-      streamId,
-      serviceName,
-      procedureName,
-      tracing: getPropagationContext(ctx),
-      payload: init,
-      controlFlags: ControlFlags.StreamOpenBit,
-    });
-
-    firstMessage = false;
-  }
+  transport.send(serverId, {
+    streamId,
+    serviceName,
+    procedureName,
+    tracing: getPropagationContext(ctx),
+    payload: init,
+    controlFlags: ControlFlags.StreamOpenBit,
+  });
 
   // transport -> output
   function onMessage(msg: OpaqueTransportMessage) {
@@ -480,7 +466,6 @@ function handleUpload(
     streamId,
   );
 
-  let firstMessage = true;
   let healthyClose = true;
 
   const inputWriter = new WriteStreamImpl(
@@ -491,14 +476,6 @@ function handleUpload(
         controlFlags: 0,
       };
 
-      if (firstMessage) {
-        m.serviceName = serviceName;
-        m.procedureName = procedureName;
-        m.tracing = getPropagationContext(ctx);
-        m.controlFlags |= ControlFlags.StreamOpenBit;
-        firstMessage = false;
-      }
-
       transport.send(serverId, m);
     },
     () => {
@@ -508,18 +485,14 @@ function handleUpload(
     },
   );
 
-  if (init) {
-    transport.send(serverId, {
-      streamId,
-      serviceName,
-      procedureName,
-      tracing: getPropagationContext(ctx),
-      payload: init,
-      controlFlags: ControlFlags.StreamOpenBit,
-    });
-
-    firstMessage = false;
-  }
+  transport.send(serverId, {
+    streamId,
+    serviceName,
+    procedureName,
+    tracing: getPropagationContext(ctx),
+    payload: init,
+    controlFlags: ControlFlags.StreamOpenBit,
+  });
 
   const responsePromise = new Promise((resolve) => {
     // on disconnect, set a timer to return an error

--- a/router/client.ts
+++ b/router/client.ts
@@ -2,7 +2,6 @@ import { ClientTransport } from '../transport/transport';
 import {
   AnyService,
   ProcErrors,
-  ProcHasInit,
   ProcInit,
   ProcInput,
   ProcOutput,
@@ -46,7 +45,7 @@ type ServiceClient<Router extends AnyService> = {
   > extends 'rpc'
     ? {
         rpc: (
-          input: Static<ProcInput<Router, ProcName>>,
+          init: Static<ProcInit<Router, ProcName>>,
         ) => Promise<
           Result<
             Static<ProcOutput<Router, ProcName>>,
@@ -55,66 +54,37 @@ type ServiceClient<Router extends AnyService> = {
         >;
       }
     : ProcType<Router, ProcName> extends 'upload'
-    ? ProcHasInit<Router, ProcName> extends true
-      ? {
-          upload: (init: Static<ProcInit<Router, ProcName>>) => Promise<
-            [
-              WriteStream<Static<ProcInput<Router, ProcName>>>, // input
-              Promise<
-                Result<
-                  Static<ProcOutput<Router, ProcName>>,
-                  Static<ProcErrors<Router, ProcName>>
-                >
-              >, // output
-            ]
-          >;
-        }
-      : {
-          upload: () => Promise<
-            [
-              WriteStream<Static<ProcInput<Router, ProcName>>>, // input
-              Promise<
-                Result<
-                  Static<ProcOutput<Router, ProcName>>,
-                  Static<ProcErrors<Router, ProcName>>
-                >
-              >, // output
-            ]
-          >;
-        }
+    ? {
+        upload: (init: Static<ProcInit<Router, ProcName>>) => Promise<
+          [
+            WriteStream<Static<ProcInput<Router, ProcName>>>, // input
+            Promise<
+              Result<
+                Static<ProcOutput<Router, ProcName>>,
+                Static<ProcErrors<Router, ProcName>>
+              >
+            >, // output
+          ]
+        >;
+      }
     : ProcType<Router, ProcName> extends 'stream'
-    ? ProcHasInit<Router, ProcName> extends true
-      ? {
-          stream: (init: Static<ProcInit<Router, ProcName>>) => Promise<
-            [
-              WriteStream<Static<ProcInput<Router, ProcName>>>, // input
-              ReadStream<
-                Result<
-                  Static<ProcOutput<Router, ProcName>>,
-                  Static<ProcErrors<Router, ProcName>>
-                >
-              >, // output
-              () => void, // close handle
-            ]
-          >;
-        }
-      : {
-          stream: () => Promise<
-            [
-              WriteStream<Static<ProcInput<Router, ProcName>>>, // input
-              ReadStream<
-                Result<
-                  Static<ProcOutput<Router, ProcName>>,
-                  Static<ProcErrors<Router, ProcName>>
-                >
-              >, // output
-              () => void, // close handle
-            ]
-          >;
-        }
+    ? {
+        stream: (init: Static<ProcInit<Router, ProcName>>) => Promise<
+          [
+            WriteStream<Static<ProcInput<Router, ProcName>>>, // input
+            ReadStream<
+              Result<
+                Static<ProcOutput<Router, ProcName>>,
+                Static<ProcErrors<Router, ProcName>>
+              >
+            >, // output
+            () => void, // close handle
+          ]
+        >;
+      }
     : ProcType<Router, ProcName> extends 'subscription'
     ? {
-        subscribe: (input: Static<ProcInput<Router, ProcName>>) => Promise<
+        subscribe: (init: Static<ProcInit<Router, ProcName>>) => Promise<
           [
             ReadStream<
               Result<

--- a/router/procedures.ts
+++ b/router/procedures.ts
@@ -38,33 +38,33 @@ export type PayloadType = TSchema;
  * from a single message.
  */
 export type ProcedureResult<
-  O extends PayloadType,
-  E extends RiverError,
-> = Result<Static<O>, Static<E> | Static<typeof RiverUncaughtSchema>>;
+  Output extends PayloadType,
+  Err extends RiverError,
+> = Result<Static<Output>, Static<Err> | Static<typeof RiverUncaughtSchema>>;
 
 /**
  * Procedure for a single message in both directions (1:1).
  *
  * @template State - The context state object.
- * @template I - The TypeBox schema of the input object.
- * @template O - The TypeBox schema of the output object.
- * @template E - The TypeBox schema of the error object.
+ * @template Input - The TypeBox schema of the input object.
+ * @template Output - The TypeBox schema of the output object.
+ * @template Err - The TypeBox schema of the error object.
  */
 export interface RpcProcedure<
   State,
-  I extends PayloadType,
-  O extends PayloadType,
-  E extends RiverError,
+  Input extends PayloadType,
+  Output extends PayloadType,
+  Err extends RiverError,
 > {
   type: 'rpc';
-  input: I;
-  output: O;
-  errors: E;
+  input: Input;
+  output: Output;
+  errors: Err;
   description?: string;
   handler(
     context: ServiceContextWithTransportInfo<State>,
-    input: Static<I>,
-  ): Promise<ProcedureResult<O, E>>;
+    input: Static<Input>,
+  ): Promise<ProcedureResult<Output, Err>>;
 }
 
 /**
@@ -72,66 +72,66 @@ export interface RpcProcedure<
  * single message from server (n:1).
  *
  * @template State - The context state object.
- * @template I - The TypeBox schema of the input object.
- * @template O - The TypeBox schema of the output object.
- * @template E - The TypeBox schema of the error object.
+ * @template Input - The TypeBox schema of the input object.
+ * @template Output - The TypeBox schema of the output object.
+ * @template Err - The TypeBox schema of the error object.
  * @template Init - The TypeBox schema of the input initialization object, if any.
  */
 export type UploadProcedure<
   State,
-  I extends PayloadType,
-  O extends PayloadType,
-  E extends RiverError,
+  Input extends PayloadType,
+  Output extends PayloadType,
+  Err extends RiverError,
   Init extends PayloadType | null = null,
 > = Init extends PayloadType
   ? {
       type: 'upload';
       init: Init;
-      input: I;
-      output: O;
-      errors: E;
+      input: Input;
+      output: Output;
+      errors: Err;
       description?: string;
       handler(
         context: ServiceContextWithTransportInfo<State>,
         init: Static<Init>,
-        input: ReadStream<Static<I>>,
-      ): Promise<ProcedureResult<O, E>>;
+        input: ReadStream<Static<Input>>,
+      ): Promise<ProcedureResult<Output, Err>>;
     }
   : {
       type: 'upload';
-      input: I;
-      output: O;
-      errors: E;
+      input: Input;
+      output: Output;
+      errors: Err;
       description?: string;
       handler(
         context: ServiceContextWithTransportInfo<State>,
-        input: ReadStream<Static<I>>,
-      ): Promise<ProcedureResult<O, E>>;
+        input: ReadStream<Static<Input>>,
+      ): Promise<ProcedureResult<Output, Err>>;
     };
 
 /**
  * Procedure for a single message from client, stream from server (1:n).
  *
  * @template State - The context state object.
- * @template I - The TypeBox schema of the input object.
- * @template O - The TypeBox schema of the output object.
- * @template E - The TypeBox schema of the error object.
+ * @template Input - The TypeBox schema of the input object.
+ * @template Output - The TypeBox schema of the output object.
+ * @template Err - The TypeBox schema of the error object.
  */
 export interface SubscriptionProcedure<
   State,
-  I extends PayloadType,
-  O extends PayloadType,
-  E extends RiverError,
+  Input extends PayloadType,
+  Output extends PayloadType,
+  Err extends RiverError,
 > {
   type: 'subscription';
-  input: I;
-  output: O;
-  errors: E;
+  input: Input;
+  output: Output;
+  errors: Err;
   description?: string;
   handler(
     context: ServiceContextWithTransportInfo<State>,
-    input: Static<I>,
-    output: WriteStream<ProcedureResult<O, E>>,
+    input: Static<Input>,
+    output: WriteStream<ProcedureResult<Output, Err>>,
   ): Promise<(() => void) | void>;
 }
 
@@ -140,42 +140,42 @@ export interface SubscriptionProcedure<
  * (n:n).
  *
  * @template State - The context state object.
- * @template I - The TypeBox schema of the input object.
- * @template O - The TypeBox schema of the output object.
- * @template E - The TypeBox schema of the error object.
+ * @template Input - The TypeBox schema of the input object.
+ * @template Output - The TypeBox schema of the output object.
+ * @template Err - The TypeBox schema of the error object.
  * @template Init - The TypeBox schema of the input initialization object, if any.
  */
 export type StreamProcedure<
   State,
-  I extends PayloadType,
-  O extends PayloadType,
-  E extends RiverError,
+  Input extends PayloadType,
+  Output extends PayloadType,
+  Err extends RiverError,
   Init extends PayloadType | null = null,
 > = Init extends PayloadType
   ? {
       type: 'stream';
       init: Init;
-      input: I;
-      output: O;
-      errors: E;
+      input: Input;
+      output: Output;
+      errors: Err;
       description?: string;
       handler(
         context: ServiceContextWithTransportInfo<State>,
         init: Static<Init>,
-        input: ReadStream<Static<I>>,
-        output: WriteStream<ProcedureResult<O, E>>,
+        input: ReadStream<Static<Input>>,
+        output: WriteStream<ProcedureResult<Output, Err>>,
       ): Promise<(() => void) | void>;
     }
   : {
       type: 'stream';
-      input: I;
-      output: O;
-      errors: E;
+      input: Input;
+      output: Output;
+      errors: Err;
       description?: string;
       handler(
         context: ServiceContextWithTransportInfo<State>,
-        input: ReadStream<Static<I>>,
-        output: WriteStream<ProcedureResult<O, E>>,
+        input: ReadStream<Static<Input>>,
+        output: WriteStream<ProcedureResult<Output, Err>>,
       ): Promise<(() => void) | void>;
     };
 
@@ -190,27 +190,27 @@ export type StreamProcedure<
  *
  * @template State - The TypeBox schema of the state object.
  * @template Ty - The type of the procedure.
- * @template I - The TypeBox schema of the input object.
- * @template O - The TypeBox schema of the output object.
+ * @template Input - The TypeBox schema of the input object.
+ * @template Output - The TypeBox schema of the output object.
  * @template Init - The TypeBox schema of the input initialization object, if any.
  */
 // prettier-ignore
 export type Procedure<
   State,
   Ty extends ValidProcType,
-  I extends PayloadType,
-  O extends PayloadType,
-  E extends RiverError,
+  Input extends PayloadType,
+  Output extends PayloadType,
+  Err extends RiverError,
   Init extends PayloadType | null = null,
 > = { type: Ty } & (
   Init extends PayloadType
-  ? Ty extends 'upload' ? UploadProcedure<State, I, O, E, Init>
-  : Ty extends 'stream' ? StreamProcedure<State, I, O, E, Init>
+  ? Ty extends 'upload' ? UploadProcedure<State, Input, Output, Err, Init>
+  : Ty extends 'stream' ? StreamProcedure<State, Input, Output, Err, Init>
   : never
-  : Ty extends 'rpc' ? RpcProcedure<State, I, O, E>
-  : Ty extends 'upload' ? UploadProcedure<State, I, O, E>
-  : Ty extends 'subscription' ? SubscriptionProcedure<State, I, O, E>
-  : Ty extends 'stream' ? StreamProcedure<State, I, O, E>
+  : Ty extends 'rpc' ? RpcProcedure<State, Input, Output, Err>
+  : Ty extends 'upload' ? UploadProcedure<State, Input, Output, Err>
+  : Ty extends 'subscription' ? SubscriptionProcedure<State, Input, Output, Err>
+  : Ty extends 'stream' ? StreamProcedure<State, Input, Output, Err>
   : never
 );
 
@@ -245,27 +245,31 @@ export type ProcedureMap<State = object> = Record<string, AnyProcedure<State>>;
  * Creates an {@link RpcProcedure}.
  */
 // signature: default errors
-function rpc<State, I extends PayloadType, O extends PayloadType>(def: {
-  input: I;
-  output: O;
+function rpc<
+  State,
+  Input extends PayloadType,
+  Output extends PayloadType,
+>(def: {
+  input: Input;
+  output: Output;
   errors?: never;
   description?: string;
-  handler: RpcProcedure<State, I, O, TNever>['handler'];
-}): Branded<RpcProcedure<State, I, O, TNever>>;
+  handler: RpcProcedure<State, Input, Output, TNever>['handler'];
+}): Branded<RpcProcedure<State, Input, Output, TNever>>;
 
 // signature: explicit errors
 function rpc<
   State,
-  I extends PayloadType,
-  O extends PayloadType,
-  E extends RiverError,
+  Input extends PayloadType,
+  Output extends PayloadType,
+  Err extends RiverError,
 >(def: {
-  input: I;
-  output: O;
-  errors: E;
+  input: Input;
+  output: Output;
+  errors: Err;
   description?: string;
-  handler: RpcProcedure<State, I, O, E>['handler'];
-}): Branded<RpcProcedure<State, I, O, E>>;
+  handler: RpcProcedure<State, Input, Output, Err>['handler'];
+}): Branded<RpcProcedure<State, Input, Output, Err>>;
 
 // implementation
 function rpc({
@@ -302,58 +306,62 @@ function rpc({
 // signature: init with default errors
 function upload<
   State,
-  I extends PayloadType,
-  O extends PayloadType,
+  Input extends PayloadType,
+  Output extends PayloadType,
   Init extends PayloadType,
 >(def: {
   init: Init;
-  input: I;
-  output: O;
+  input: Input;
+  output: Output;
   errors?: never;
   description?: string;
-  handler: UploadProcedure<State, I, O, TNever, Init>['handler'];
-}): Branded<UploadProcedure<State, I, O, TNever, Init>>;
+  handler: UploadProcedure<State, Input, Output, TNever, Init>['handler'];
+}): Branded<UploadProcedure<State, Input, Output, TNever, Init>>;
 
 // signature: init with explicit errors
 function upload<
   State,
-  I extends PayloadType,
-  O extends PayloadType,
-  E extends RiverError,
+  Input extends PayloadType,
+  Output extends PayloadType,
+  Err extends RiverError,
   Init extends PayloadType,
 >(def: {
   init: Init;
-  input: I;
-  output: O;
-  errors: E;
+  input: Input;
+  output: Output;
+  errors: Err;
   description?: string;
-  handler: UploadProcedure<State, I, O, E, Init>['handler'];
-}): Branded<UploadProcedure<State, I, O, E, Init>>;
+  handler: UploadProcedure<State, Input, Output, Err, Init>['handler'];
+}): Branded<UploadProcedure<State, Input, Output, Err, Init>>;
 
 // signature: no init with default errors
-function upload<State, I extends PayloadType, O extends PayloadType>(def: {
+function upload<
+  State,
+  Input extends PayloadType,
+  Output extends PayloadType,
+>(def: {
   init?: never;
-  input: I;
-  output: O;
+  input: Input;
+  output: Output;
   errors?: never;
   description?: string;
-  handler: UploadProcedure<State, I, O, TNever>['handler'];
-}): Branded<UploadProcedure<State, I, O, TNever>>;
+  handler: UploadProcedure<State, Input, Output, TNever>['handler'];
+}): Branded<UploadProcedure<State, Input, Output, TNever>>;
 
 // signature: no init with explicit errors
 function upload<
   State,
-  I extends PayloadType,
-  O extends PayloadType,
-  E extends RiverError,
+  Input extends PayloadType,
+  Output extends PayloadType,
+  Err extends RiverError,
 >(def: {
   init?: never;
-  input: I;
-  output: O;
-  errors: E;
+  input: Input;
+  output: Output;
+  errors: Err;
   description?: string;
-  handler: UploadProcedure<State, I, O, E>['handler'];
-}): Branded<UploadProcedure<State, I, O, E>>;
+  handler: UploadProcedure<State, Input, Output, Err>['handler'];
+}): Branded<UploadProcedure<State, Input, Output, Err>>;
 
 // implementation
 function upload({
@@ -403,29 +411,29 @@ function upload({
 // signature: default errors
 function subscription<
   State,
-  I extends PayloadType,
-  O extends PayloadType,
+  Input extends PayloadType,
+  Output extends PayloadType,
 >(def: {
-  input: I;
-  output: O;
+  input: Input;
+  output: Output;
   errors?: never;
   description?: string;
-  handler: SubscriptionProcedure<State, I, O, TNever>['handler'];
-}): Branded<SubscriptionProcedure<State, I, O, TNever>>;
+  handler: SubscriptionProcedure<State, Input, Output, TNever>['handler'];
+}): Branded<SubscriptionProcedure<State, Input, Output, TNever>>;
 
 // signature: explicit errors
 function subscription<
   State,
-  I extends PayloadType,
-  O extends PayloadType,
-  E extends RiverError,
+  Input extends PayloadType,
+  Output extends PayloadType,
+  Err extends RiverError,
 >(def: {
-  input: I;
-  output: O;
-  errors: E;
+  input: Input;
+  output: Output;
+  errors: Err;
   description?: string;
-  handler: SubscriptionProcedure<State, I, O, E>['handler'];
-}): Branded<SubscriptionProcedure<State, I, O, E>>;
+  handler: SubscriptionProcedure<State, Input, Output, Err>['handler'];
+}): Branded<SubscriptionProcedure<State, Input, Output, Err>>;
 
 // implementation
 function subscription({
@@ -462,58 +470,62 @@ function subscription({
 // signature: init with default errors
 function stream<
   State,
-  I extends PayloadType,
-  O extends PayloadType,
+  Input extends PayloadType,
+  Output extends PayloadType,
   Init extends PayloadType,
 >(def: {
   init: Init;
-  input: I;
-  output: O;
+  input: Input;
+  output: Output;
   errors?: never;
   description?: string;
-  handler: StreamProcedure<State, I, O, TNever, Init>['handler'];
-}): Branded<StreamProcedure<State, I, O, TNever, Init>>;
+  handler: StreamProcedure<State, Input, Output, TNever, Init>['handler'];
+}): Branded<StreamProcedure<State, Input, Output, TNever, Init>>;
 
 // signature: init with explicit errors
 function stream<
   State,
-  I extends PayloadType,
-  O extends PayloadType,
-  E extends RiverError,
+  Input extends PayloadType,
+  Output extends PayloadType,
+  Err extends RiverError,
   Init extends PayloadType,
 >(def: {
   init: Init;
-  input: I;
-  output: O;
-  errors: E;
+  input: Input;
+  output: Output;
+  errors: Err;
   description?: string;
-  handler: StreamProcedure<State, I, O, E, Init>['handler'];
-}): Branded<StreamProcedure<State, I, O, E, Init>>;
+  handler: StreamProcedure<State, Input, Output, Err, Init>['handler'];
+}): Branded<StreamProcedure<State, Input, Output, Err, Init>>;
 
 // signature: no init with default errors
-function stream<State, I extends PayloadType, O extends PayloadType>(def: {
+function stream<
+  State,
+  Input extends PayloadType,
+  Output extends PayloadType,
+>(def: {
   init?: never;
-  input: I;
-  output: O;
+  input: Input;
+  output: Output;
   errors?: never;
   description?: string;
-  handler: StreamProcedure<State, I, O, TNever>['handler'];
-}): Branded<StreamProcedure<State, I, O, TNever>>;
+  handler: StreamProcedure<State, Input, Output, TNever>['handler'];
+}): Branded<StreamProcedure<State, Input, Output, TNever>>;
 
 // signature: no init with explicit errors
 function stream<
   State,
-  I extends PayloadType,
-  O extends PayloadType,
-  E extends RiverError,
+  Input extends PayloadType,
+  Output extends PayloadType,
+  Err extends RiverError,
 >(def: {
   init?: never;
-  input: I;
-  output: O;
-  errors: E;
+  input: Input;
+  output: Output;
+  errors: Err;
   description?: string;
-  handler: StreamProcedure<State, I, O, E>['handler'];
-}): Branded<StreamProcedure<State, I, O, E>>;
+  handler: StreamProcedure<State, Input, Output, Err>['handler'];
+}): Branded<StreamProcedure<State, Input, Output, Err>>;
 
 // implementation
 function stream({

--- a/router/result.ts
+++ b/router/result.ts
@@ -50,7 +50,9 @@ export type Result<T, Err> =
       payload: Err;
     };
 
-export function Ok<const T extends Array<unknown>, const Err>(p: T): Result<T, Err>;
+export function Ok<const T extends Array<unknown>, const Err>(
+  p: T,
+): Result<T, Err>;
 export function Ok<const T extends ReadonlyArray<unknown>, const Err>(
   p: T,
 ): Result<T, Err>;

--- a/router/result.ts
+++ b/router/result.ts
@@ -40,29 +40,29 @@ export const RiverUncaughtSchema = Type.Object({
   message: Type.String(),
 });
 
-export type Result<T, E> =
+export type Result<T, Err> =
   | {
       ok: true;
       payload: T;
     }
   | {
       ok: false;
-      payload: E;
+      payload: Err;
     };
 
-export function Ok<const T extends Array<unknown>, const E>(p: T): Result<T, E>;
-export function Ok<const T extends ReadonlyArray<unknown>, const E>(
+export function Ok<const T extends Array<unknown>, const Err>(p: T): Result<T, Err>;
+export function Ok<const T extends ReadonlyArray<unknown>, const Err>(
   p: T,
-): Result<T, E>;
-export function Ok<const T, const E>(payload: T): Result<T, E>;
-export function Ok<const T, const E>(payload: T): Result<T, E> {
+): Result<T, Err>;
+export function Ok<const T, const Err>(payload: T): Result<T, Err>;
+export function Ok<const T, const Err>(payload: T): Result<T, Err> {
   return {
     ok: true,
     payload,
   };
 }
 
-export function Err<const T, const E>(error: E): Result<T, E> {
+export function Err<const T, const Err>(error: Err): Result<T, Err> {
   return {
     ok: false,
     payload: error,
@@ -79,8 +79,8 @@ export type ResultUnwrapOk<R> = R extends Result<infer T, infer __E>
 /**
  * Refine a {@link Result} type to its error payload.
  */
-export type ResultUnwrapErr<R> = R extends Result<infer __T, infer E>
-  ? E
+export type ResultUnwrapErr<R> = R extends Result<infer __T, infer Err>
+  ? Err
   : never;
 
 /**

--- a/router/server.ts
+++ b/router/server.ts
@@ -114,7 +114,7 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
     }
 
     let procStream = this.streamMap.get(message.streamId);
-    const isFirstMessage = !procStream;
+    const isInit = !procStream;
 
     // create a proc stream if it doesnt exist
     procStream ||= this.createNewProcStream(message);
@@ -123,7 +123,7 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
       return;
     }
 
-    await this.pushToStream(procStream, message, isFirstMessage);
+    await this.pushToStream(procStream, message, isInit);
   };
 
   // cleanup streams on session close
@@ -162,58 +162,58 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
     }
   }
 
-  createNewProcStream(message: OpaqueTransportMessage) {
-    if (!isStreamOpen(message.controlFlags)) {
+  createNewProcStream(initMessage: OpaqueTransportMessage) {
+    if (!isStreamOpen(initMessage.controlFlags)) {
       log?.error(
         `can't create a new procedure stream from a message that doesn't have the stream open bit set`,
         {
           clientId: this.transport.clientId,
-          transportMessage: message,
+          transportMessage: initMessage,
           tags: ['invariant-violation'],
         },
       );
       return;
     }
 
-    if (!message.procedureName || !message.serviceName) {
+    if (!initMessage.procedureName || !initMessage.serviceName) {
       log?.warn(`missing procedure or service name in stream open message`, {
         clientId: this.transport.clientId,
-        transportMessage: message,
+        transportMessage: initMessage,
       });
       return;
     }
 
-    if (!(message.serviceName in this.services)) {
-      log?.warn(`couldn't find service ${message.serviceName}`, {
+    if (!(initMessage.serviceName in this.services)) {
+      log?.warn(`couldn't find service ${initMessage.serviceName}`, {
         clientId: this.transport.clientId,
-        transportMessage: message,
+        transportMessage: initMessage,
       });
       return;
     }
 
-    const service = this.services[message.serviceName];
-    const serviceContext = this.getContext(service, message.serviceName);
-    if (!(message.procedureName in service.procedures)) {
+    const service = this.services[initMessage.serviceName];
+    const serviceContext = this.getContext(service, initMessage.serviceName);
+    if (!(initMessage.procedureName in service.procedures)) {
       log?.warn(
-        `couldn't find a matching procedure for ${message.serviceName}.${message.procedureName}`,
+        `couldn't find a matching procedure for ${initMessage.serviceName}.${initMessage.procedureName}`,
         {
           clientId: this.transport.clientId,
-          transportMessage: message,
+          transportMessage: initMessage,
         },
       );
       return;
     }
 
-    const session = this.transport.sessions.get(message.from);
+    const session = this.transport.sessions.get(initMessage.from);
     if (!session) {
-      log?.warn(`couldn't find session for ${message.from}`, {
+      log?.warn(`couldn't find session for ${initMessage.from}`, {
         clientId: this.transport.clientId,
-        transportMessage: message,
+        transportMessage: initMessage,
       });
       return;
     }
 
-    const procedure = service.procedures[message.procedureName];
+    const procedure = service.procedures[initMessage.procedureName];
     const readStreamRequestCloseNotImplemented = () => void 0;
     const incoming: ProcStream['incoming'] = new ReadStreamImpl(
       readStreamRequestCloseNotImplemented,
@@ -224,16 +224,16 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
     const outgoing: ProcStream['outgoing'] = new WriteStreamImpl(
       (response) => {
         this.transport.send(session.to, {
-          streamId: message.streamId,
+          streamId: initMessage.streamId,
           controlFlags: needsClose ? 0 : ControlFlags.StreamClosedBit,
           payload: response,
         });
       },
       () => {
-        if (needsClose && !this.disconnectedSessions.has(message.from)) {
+        if (needsClose && !this.disconnectedSessions.has(initMessage.from)) {
           // we ended, send a close bit back to the client
           // also, if the client has disconnected, we don't need to send a close
-          this.transport.sendCloseStream(session.to, message.streamId);
+          this.transport.sendCloseStream(session.to, initMessage.streamId);
         }
         // call disposables returned from handlers
         disposables.forEach((d) => d());
@@ -243,7 +243,7 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
     const errorHandler = (err: unknown, span: Span) => {
       const errorMsg = coerceErrorString(err);
       log?.error(
-        `procedure ${message.serviceName}.${message.procedureName} threw an uncaught error: ${errorMsg}`,
+        `procedure ${initMessage.serviceName}.${initMessage.procedureName} threw an uncaught error: ${errorMsg}`,
         session.loggingMetadata,
       );
 
@@ -268,13 +268,12 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
 
     // pump incoming message stream -> handler -> outgoing message stream
     let inputHandler: Promise<unknown>;
-    const procHasInitMessage = 'init' in procedure;
     const serviceContextWithTransportInfo: ServiceContextWithTransportInfo<object> =
       {
         ...serviceContext,
-        to: message.to,
-        from: message.from,
-        streamId: message.streamId,
+        to: initMessage.to,
+        from: initMessage.from,
+        streamId: initMessage.streamId,
         session,
         metadata: sessionMeta,
       };
@@ -283,15 +282,15 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
       case 'rpc':
         inputHandler = createHandlerSpan(
           procedure.type,
-          message,
+          initMessage,
           async (span) => {
-            if (!Value.Check(procedure.input, message.payload)) {
-              log?.error('subscription input failed validation', {
+            if (!Value.Check(procedure.init, initMessage.payload)) {
+              log?.error('rpc init failed validation', {
                 clientId: this.transport.clientId,
-                transportMessage: message,
+                transportMessage: initMessage,
               });
 
-              errorHandler('subscription input failed validation', span);
+              errorHandler('rpc init failed validation', span);
               span.end();
 
               return;
@@ -300,7 +299,7 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
             try {
               const outputMessage = await procedure.handler(
                 serviceContextWithTransportInfo,
-                message.payload,
+                initMessage.payload,
               );
               outgoing.write(outputMessage);
             } catch (err) {
@@ -312,82 +311,23 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
         );
         break;
       case 'stream':
-        if (procHasInitMessage) {
-          inputHandler = createHandlerSpan(
-            procedure.type,
-            message,
-            async (span) => {
-              if (!Value.Check(procedure.init, message.payload)) {
-                log?.error(
-                  'procedure requires init, but first message failed validation',
-                  {
-                    clientId: this.transport.clientId,
-                    transportMessage: message,
-                  },
-                );
-
-                errorHandler(
-                  'procedure requires init, but first message failed validation',
-                  span,
-                );
-                span.end();
-
-                return;
-              }
-
-              try {
-                const dispose = await procedure.handler(
-                  serviceContextWithTransportInfo,
-                  message.payload,
-                  incoming,
-                  outgoing,
-                );
-
-                if (dispose) {
-                  disposables.push(dispose);
-                }
-              } catch (err) {
-                errorHandler(err, span);
-              } finally {
-                span.end();
-              }
-            },
-          );
-        } else {
-          inputHandler = createHandlerSpan(
-            procedure.type,
-            message,
-            async (span) => {
-              try {
-                const dispose = await procedure.handler(
-                  serviceContextWithTransportInfo,
-                  incoming,
-                  outgoing,
-                );
-                if (dispose) {
-                  disposables.push(dispose);
-                }
-              } catch (err) {
-                errorHandler(err, span);
-              } finally {
-                span.end();
-              }
-            },
-          );
-        }
-        break;
-      case 'subscription':
         inputHandler = createHandlerSpan(
           procedure.type,
-          message,
+          initMessage,
           async (span) => {
-            if (!Value.Check(procedure.input, message.payload)) {
-              log?.error('subscription input failed validation', {
-                clientId: this.transport.clientId,
-                transportMessage: message,
-              });
+            if (!Value.Check(procedure.init, initMessage.payload)) {
+              log?.error(
+                'procedure requires init, but first message failed validation',
+                {
+                  clientId: this.transport.clientId,
+                  transportMessage: initMessage,
+                },
+              );
 
-              errorHandler('subscription input failed validation', span);
+              errorHandler(
+                'procedure requires init, but first message failed validation',
+                span,
+              );
               span.end();
 
               return;
@@ -396,7 +336,44 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
             try {
               const dispose = await procedure.handler(
                 serviceContextWithTransportInfo,
-                message.payload,
+                initMessage.payload,
+                incoming,
+                outgoing,
+              );
+
+              if (dispose) {
+                disposables.push(dispose);
+              }
+            } catch (err) {
+              errorHandler(err, span);
+            } finally {
+              span.end();
+            }
+          },
+        );
+
+        break;
+      case 'subscription':
+        inputHandler = createHandlerSpan(
+          procedure.type,
+          initMessage,
+          async (span) => {
+            if (!Value.Check(procedure.init, initMessage.payload)) {
+              log?.error('subscription init failed validation', {
+                clientId: this.transport.clientId,
+                transportMessage: initMessage,
+              });
+
+              errorHandler('subscription init failed validation', span);
+              span.end();
+
+              return;
+            }
+
+            try {
+              const dispose = await procedure.handler(
+                serviceContextWithTransportInfo,
+                initMessage.payload,
                 outgoing,
               );
 
@@ -412,68 +389,45 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
         );
         break;
       case 'upload':
-        if (procHasInitMessage) {
-          inputHandler = createHandlerSpan(
-            procedure.type,
-            message,
-            async (span) => {
-              if (!Value.Check(procedure.init, message.payload)) {
-                log?.error(
-                  'procedure requires init, but first message failed validation',
-                  {
-                    clientId: this.transport.clientId,
-                    transportMessage: message,
-                  },
-                );
+        inputHandler = createHandlerSpan(
+          procedure.type,
+          initMessage,
+          async (span) => {
+            if (!Value.Check(procedure.init, initMessage.payload)) {
+              log?.error(
+                'procedure requires init, but first message failed validation',
+                {
+                  clientId: this.transport.clientId,
+                  transportMessage: initMessage,
+                },
+              );
 
-                errorHandler(
-                  'procedure requires init, but first message failed validation',
-                  span,
-                );
-                span.end();
+              errorHandler(
+                'procedure requires init, but first message failed validation',
+                span,
+              );
+              span.end();
 
-                return;
+              return;
+            }
+
+            try {
+              const outputMessage = await procedure.handler(
+                serviceContextWithTransportInfo,
+                initMessage.payload,
+                incoming,
+              );
+
+              if (!this.disconnectedSessions.has(initMessage.from)) {
+                outgoing.write(outputMessage);
               }
-
-              try {
-                const outputMessage = await procedure.handler(
-                  serviceContextWithTransportInfo,
-                  message.payload,
-                  incoming,
-                );
-
-                if (!this.disconnectedSessions.has(message.from)) {
-                  outgoing.write(outputMessage);
-                }
-              } catch (err) {
-                errorHandler(err, span);
-              } finally {
-                span.end();
-              }
-            },
-          );
-        } else {
-          inputHandler = createHandlerSpan(
-            procedure.type,
-            message,
-            async (span) => {
-              try {
-                const outputMessage = await procedure.handler(
-                  serviceContextWithTransportInfo,
-                  incoming,
-                );
-
-                if (!this.disconnectedSessions.has(message.from)) {
-                  outgoing.write(outputMessage);
-                }
-              } catch (err) {
-                errorHandler(err, span);
-              } finally {
-                span.end();
-              }
-            },
-          );
-        }
+            } catch (err) {
+              errorHandler(err, span);
+            } finally {
+              span.end();
+            }
+          },
+        );
 
         break;
       default:
@@ -482,28 +436,28 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
         log?.warn(
           `got request for invalid procedure type ${
             (procedure as AnyProcedure).type
-          } at ${message.serviceName}.${message.procedureName}`,
-          { ...session.loggingMetadata, transportMessage: message },
+          } at ${initMessage.serviceName}.${initMessage.procedureName}`,
+          { ...session.loggingMetadata, transportMessage: initMessage },
         );
         return;
     }
 
     const procStream: ProcStream = {
-      id: message.streamId,
+      id: initMessage.streamId,
       incoming,
       outgoing,
-      serviceName: message.serviceName,
-      procedureName: message.procedureName,
+      serviceName: initMessage.serviceName,
+      procedureName: initMessage.procedureName,
       promises: { inputHandler },
     };
 
-    this.streamMap.set(message.streamId, procStream);
+    this.streamMap.set(initMessage.streamId, procStream);
 
     // add this stream to ones from that client so we can clean it up in the case of a disconnect without close
     const streamsFromThisClient =
-      this.clientStreams.get(message.from) ?? new Set();
-    streamsFromThisClient.add(message.streamId);
-    this.clientStreams.set(message.from, streamsFromThisClient);
+      this.clientStreams.get(initMessage.from) ?? new Set();
+    streamsFromThisClient.add(initMessage.streamId);
+    this.clientStreams.set(initMessage.from, streamsFromThisClient);
 
     return procStream;
   }
@@ -511,15 +465,14 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
   async pushToStream(
     procStream: ProcStream,
     message: OpaqueTransportMessage,
-    isFirstMessage?: boolean,
+    isInit?: boolean,
   ) {
     const { serviceName, procedureName } = procStream;
     const procedure = this.services[serviceName].procedures[procedureName];
-    const procHasInitMessage = 'init' in procedure;
 
-    if (!isFirstMessage || !procHasInitMessage) {
-      // Init message is consumed during stream instantiation
-      if (Value.Check(procedure.input, message.payload)) {
+    // Init message is consumed during stream instantiation
+    if (!isInit) {
+      if (Value.Check(procedure.init, message.payload)) {
         procStream.incoming.pushValue(message.payload as PayloadType);
       } else if (!Value.Check(ControlMessagePayloadSchema, message.payload)) {
         // whelp we got a message that isn't a control message and doesn't match the procedure input
@@ -530,7 +483,7 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
             clientId: this.transport.clientId,
             transportMessage: message,
             validationErrors: [
-              ...Value.Errors(procedure.input, message.payload),
+              ...Value.Errors(procedure.init, message.payload),
             ],
           },
         );

--- a/router/server.ts
+++ b/router/server.ts
@@ -472,7 +472,10 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
 
     // Init message is consumed during stream instantiation
     if (!isInit) {
-      if (Value.Check(procedure.init, message.payload)) {
+      if (
+        'input' in procedure &&
+        Value.Check(procedure.input, message.payload)
+      ) {
         procStream.incoming.pushValue(message.payload as PayloadType);
       } else if (!Value.Check(ControlMessagePayloadSchema, message.payload)) {
         // whelp we got a message that isn't a control message and doesn't match the procedure input


### PR DESCRIPTION
## Why

Follow up to #153 

## What changed

- `Init` is on every type of rpc
- `Input` only for `upload` and `stream`

Mostly deleted code after I did the replacement, hide whitespace to see that it's mostly deleting code https://github.com/replit/river/pull/159/files?w=1

Some tests don't work because it ended up affecting close semantics. Tests should start working once we implement half-closes, which I'm almost done with.
