### PR TITLE
🧹  Use nix cache for eslint language server on replit

### DIFF
--- a/.replit
+++ b/.replit
@@ -15,7 +15,7 @@ externalPort = 80
 [languages.eslint]
 pattern = "**{*.ts,*.js,*.tsx,*.jsx}"
 [languages.eslint.languageServer]
-start = "./node_modules/vscode-langservers-extracted/bin/vscode-eslint-language-server --stdio"
+start = "vscode-eslint-language-server --stdio"
 [languages.eslint.languageServer.configuration]
 nodePath = "node"        # this should resolve to nvm
 validate = "probe"

--- a/package.json
+++ b/package.json
@@ -68,8 +68,7 @@
     "prettier": "^3.0.0",
     "tsup": "^7.2.0",
     "typescript": "^5.4.5",
-    "vitest": "^1.3.1",
-    "vscode-langservers-extracted": "4.8.0"
+    "vitest": "^1.3.1"
   },
   "scripts": {
     "check": "tsc --noEmit && npm run format && npm run lint",

--- a/replit.nix
+++ b/replit.nix
@@ -1,0 +1,5 @@
+{ pkgs }: {
+    deps = [
+        pkgs.nodePackages.vscode-langservers-extracted
+    ];
+}


### PR DESCRIPTION
## Why

we don't have to pollute the package.json to have eslint in river on replit. we can use the nix cache for the package

<!-- Describe what you are trying to accomplish with this pull request -->

## What changed

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

eslint still works 
![image](https://github.com/replit/river/assets/16962017/c83f0422-a0d4-4e12-93c6-df5e23682905)


## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
