### PR TITLE
add telemetry info to log context, remove global logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,12 +168,19 @@ async handler(ctx, ...args) {
 
 ### Logging
 
-To add logging,
+To add logging, you can bind a logging function to a transport.
 
 ```ts
-import { bindLogger, stringLogger } from '@replit/river/logging';
+import { coloredStringLogger } from '@replit/river/logging';
 
-bindLogger(stringLogger, 'info');
+const transport = new WebSocketClientTransport(
+  async () => new WebSocket('ws://localhost:3000'),
+  'my-client-id',
+);
+
+transport.bindLogger(console.log);
+// or
+transport.bindLogger(coloredStringLogger);
 ```
 
 You can define your own logging functions that satisfy the `LogFn` type.

--- a/__tests__/fixtures/cleanup.ts
+++ b/__tests__/fixtures/cleanup.ts
@@ -7,7 +7,6 @@ import {
   Transport,
 } from '../../transport';
 import { Server } from '../../router';
-import { log } from '../../logging/log';
 import { AnyServiceSchemaMap } from '../../router/services';
 import { testingSessionOptions } from '../../util/testHelpers';
 
@@ -117,7 +116,10 @@ export async function testFinishesCleanly({
   serverTransport: ServerTransport<Connection>;
   server: Server<AnyServiceSchemaMap>;
 }>) {
-  log?.info('*** end of test cleanup ***');
+  for (const t of [...(clientTransports ?? []), serverTransport]) {
+    t?.log?.info('*** end of test cleanup ***');
+  }
+
   vi.useFakeTimers({ shouldAdvanceTime: true });
 
   if (clientTransports) {

--- a/logging/index.ts
+++ b/logging/index.ts
@@ -1,7 +1,2 @@
-export {
-  stringLogger,
-  coloredStringLogger,
-  jsonLogger,
-  bindLogger,
-} from './log';
+export { stringLogger, coloredStringLogger, jsonLogger } from './log';
 export type { Logger, LogFn, MessageMetadata } from './log';

--- a/logging/log.ts
+++ b/logging/log.ts
@@ -1,5 +1,6 @@
 import { ValueError } from '@sinclair/typebox/value';
 import { OpaqueTransportMessage } from '../transport';
+import { SpanContext } from '@opentelemetry/api';
 
 const LoggingLevels = {
   debug: -1,
@@ -44,6 +45,7 @@ export type MessageMetadata = Partial<{
   transportMessage: Partial<OpaqueTransportMessage>;
   validationErrors: Array<ValueError>;
   tags: Array<Tags>;
+  telemetry: Pick<SpanContext, 'traceId' | 'spanId'>;
 }>;
 
 class BaseLogger implements Logger {

--- a/logging/log.ts
+++ b/logging/log.ts
@@ -1,6 +1,5 @@
 import { ValueError } from '@sinclair/typebox/value';
 import { OpaqueTransportMessage } from '../transport';
-import { SpanContext } from '@opentelemetry/api';
 
 const LoggingLevels = {
   debug: -1,
@@ -45,7 +44,10 @@ export type MessageMetadata = Partial<{
   transportMessage: Partial<OpaqueTransportMessage>;
   validationErrors: Array<ValueError>;
   tags: Array<Tags>;
-  telemetry: Pick<SpanContext, 'traceId' | 'spanId'>;
+  telemetry: {
+    traceId: string;
+    spanId: string;
+  };
 }>;
 
 class BaseLogger implements Logger {

--- a/logging/log.ts
+++ b/logging/log.ts
@@ -1,5 +1,5 @@
 import { ValueError } from '@sinclair/typebox/value';
-import { OpaqueTransportMessage } from '../transport';
+import { OpaqueTransportMessage } from '../transport/message';
 
 const LoggingLevels = {
   debug: -1,
@@ -7,7 +7,7 @@ const LoggingLevels = {
   warn: 1,
   error: 2,
 } as const;
-type LoggingLevel = keyof typeof LoggingLevels;
+export type LoggingLevel = keyof typeof LoggingLevels;
 
 export type LogFn = (
   msg: string,
@@ -50,7 +50,7 @@ export type MessageMetadata = Partial<{
   };
 }>;
 
-class BaseLogger implements Logger {
+export class BaseLogger implements Logger {
   minLevel: LoggingLevel;
   private output: LogFn;
 
@@ -84,8 +84,9 @@ class BaseLogger implements Logger {
   }
 }
 
-export const stringLogger: LogFn = (msg, _ctx, level = 'info') => {
-  console.log(`[river:${level}] ${msg}`);
+export const stringLogger: LogFn = (msg, ctx, level = 'info') => {
+  const from = ctx?.clientId ? `${ctx.clientId} -- ` : '';
+  console.log(`[river:${level}] ${from}${msg}`);
 };
 
 const colorMap = {
@@ -95,45 +96,19 @@ const colorMap = {
   error: '\u001b[31m',
 };
 
-export const coloredStringLogger: LogFn = (msg, _ctx, level = 'info') => {
+export const coloredStringLogger: LogFn = (msg, ctx, level = 'info') => {
   const color = colorMap[level];
-  console.log(`[river:${color}${level}\u001b[0m] ${msg}`);
+  const from = ctx?.clientId ? `${ctx.clientId} -- ` : '';
+  console.log(`[river:${color}${level}\u001b[0m] ${from}${msg}`);
 };
 
 export const jsonLogger: LogFn = (msg, ctx, level) => {
   console.log(JSON.stringify({ msg, ctx, level }));
 };
 
-let _log: Logger | undefined = undefined;
-
-// log proxy to clean transport payloads
-export let log: Logger | undefined = undefined;
-const createLogProxy = (log: Logger) => ({
+export const createLogProxy = (log: Logger) => ({
   debug: cleanedLogFn(log.debug.bind(log)),
   info: cleanedLogFn(log.info.bind(log)),
   warn: cleanedLogFn(log.warn.bind(log)),
   error: cleanedLogFn(log.error.bind(log)),
 });
-
-export function bindLogger(
-  fn: LogFn | Logger | undefined,
-  level?: LoggingLevel,
-): void {
-  // clear logger
-  if (!fn) {
-    _log = undefined;
-    log = undefined;
-    return;
-  }
-
-  // construct logger from fn
-  if (typeof fn === 'function') {
-    _log = new BaseLogger(fn, level);
-    log = createLogProxy(_log);
-    return;
-  }
-
-  // just assign
-  _log = fn;
-  log = createLogProxy(_log);
-}

--- a/router/client.ts
+++ b/router/client.ts
@@ -258,7 +258,7 @@ function handleRpc(
 ) {
   const streamId = nanoid();
   const { span, ctx } = createProcTelemetryInfo(
-    transport.clientId,
+    transport,
     'rpc',
     serviceName,
     procedureName,
@@ -316,7 +316,7 @@ function handleStream(
 ) {
   const streamId = nanoid();
   const { span, ctx } = createProcTelemetryInfo(
-    transport.clientId,
+    transport,
     'stream',
     serviceName,
     procedureName,
@@ -414,7 +414,7 @@ function handleSubscribe(
 ) {
   const streamId = nanoid();
   const { span, ctx } = createProcTelemetryInfo(
-    transport.clientId,
+    transport,
     'subscription',
     serviceName,
     procedureName,
@@ -484,7 +484,7 @@ function handleUpload(
 ) {
   const streamId = nanoid();
   const { span, ctx } = createProcTelemetryInfo(
-    transport.clientId,
+    transport,
     'upload',
     serviceName,
     procedureName,

--- a/router/client.ts
+++ b/router/client.ts
@@ -24,7 +24,6 @@ import { nanoid } from 'nanoid';
 import { Err, Result, UNEXPECTED_DISCONNECT } from './result';
 import { EventMap } from '../transport/events';
 import { Connection } from '../transport/session';
-import { log } from '../logging/log';
 import { createProcTelemetryInfo, getPropagationContext } from '../tracing';
 import { ClientHandshakeOptions } from './handshake';
 
@@ -221,14 +220,6 @@ export function createClient<ServiceSchemaMap extends AnyServiceSchemaMap>(
     }
 
     const [input] = opts.args;
-    log?.info(`invoked ${procType} ${serviceName}.${procName}`, {
-      clientId: transport.clientId,
-      transportMessage: {
-        procedureName: procName,
-        serviceName,
-      },
-    });
-
     if (options.connectOnInvoke && !transport.connections.has(serverId)) {
       void transport.connect(serverId);
     }
@@ -267,6 +258,7 @@ function handleRpc(
 ) {
   const streamId = nanoid();
   const { span, ctx } = createProcTelemetryInfo(
+    transport.clientId,
     'rpc',
     serviceName,
     procedureName,
@@ -324,6 +316,7 @@ function handleStream(
 ) {
   const streamId = nanoid();
   const { span, ctx } = createProcTelemetryInfo(
+    transport.clientId,
     'stream',
     serviceName,
     procedureName,
@@ -421,6 +414,7 @@ function handleSubscribe(
 ) {
   const streamId = nanoid();
   const { span, ctx } = createProcTelemetryInfo(
+    transport.clientId,
     'subscription',
     serviceName,
     procedureName,
@@ -490,6 +484,7 @@ function handleUpload(
 ) {
   const streamId = nanoid();
   const { span, ctx } = createProcTelemetryInfo(
+    transport.clientId,
     'upload',
     serviceName,
     procedureName,

--- a/tracing/index.ts
+++ b/tracing/index.ts
@@ -8,8 +8,12 @@ import {
 } from '@opentelemetry/api';
 import { version as RIVER_VERSION } from '../package.json';
 import { ValidProcType } from '../router';
-import { Connection, OpaqueTransportMessage, Session } from '../transport';
-import { log } from '../logging/log';
+import {
+  ClientTransport,
+  Connection,
+  OpaqueTransportMessage,
+  Session,
+} from '../transport';
 
 export interface PropagationContext {
   traceparent: string;
@@ -78,7 +82,7 @@ export function createConnectionTelemetryInfo(
 }
 
 export function createProcTelemetryInfo(
-  clientId: string,
+  transport: ClientTransport<Connection>,
   kind: ValidProcType,
   serviceName: string,
   procedureName: string,
@@ -103,8 +107,8 @@ export function createProcTelemetryInfo(
 
   trace.setSpan(ctx, span);
 
-  log?.info(`invoked ${serviceName}.${procedureName}`, {
-    clientId,
+  transport.log?.info(`invoked ${serviceName}.${procedureName}`, {
+    clientId: transport.clientId,
     transportMessage: {
       procedureName,
       serviceName,

--- a/tracing/index.ts
+++ b/tracing/index.ts
@@ -9,6 +9,7 @@ import {
 import { version as RIVER_VERSION } from '../package.json';
 import { ValidProcType } from '../router';
 import { Connection, OpaqueTransportMessage, Session } from '../transport';
+import { log } from '../logging/log';
 
 export interface PropagationContext {
   traceparent: string;
@@ -52,6 +53,7 @@ export function createSessionTelemetryInfo(
     ctx,
   );
 
+  trace.setSpan(ctx, span);
   return { span, ctx };
 }
 
@@ -76,6 +78,7 @@ export function createConnectionTelemetryInfo(
 }
 
 export function createProcTelemetryInfo(
+  clientId: string,
   kind: ValidProcType,
   serviceName: string,
   procedureName: string,
@@ -98,6 +101,19 @@ export function createProcTelemetryInfo(
     ctx,
   );
 
+  trace.setSpan(ctx, span);
+
+  log?.info(`invoked ${serviceName}.${procedureName}`, {
+    clientId,
+    transportMessage: {
+      procedureName,
+      serviceName,
+    },
+    telemetry: {
+      traceId: span.spanContext().traceId,
+      spanId: span.spanContext().spanId,
+    },
+  });
   return { span, ctx };
 }
 

--- a/transport/impls/uds/client.ts
+++ b/transport/impls/uds/client.ts
@@ -1,5 +1,4 @@
 import { Socket } from 'node:net';
-import { log } from '../../../logging/log';
 import { UdsConnection } from './connection';
 import {
   ClientTransport,
@@ -25,7 +24,7 @@ export class UnixDomainSocketClientTransport extends ClientTransport<UdsConnecti
       oldConnection.close();
     }
 
-    log?.info(`establishing a new uds to ${to}`, {
+    this.log?.info(`establishing a new uds to ${to}`, {
       clientId: this.clientId,
       connectedTo: to,
     });

--- a/transport/impls/ws/client.ts
+++ b/transport/impls/ws/client.ts
@@ -3,7 +3,6 @@ import {
   ProvidedClientTransportOptions,
 } from '../../transport';
 import { TransportClientId } from '../../message';
-import { log } from '../../../logging/log';
 import { WebSocketConnection } from './connection';
 import { WsLike } from './wslike';
 
@@ -35,7 +34,7 @@ export class WebSocketClientTransport extends ClientTransport<WebSocketConnectio
   }
 
   async createNewOutgoingConnection(to: string) {
-    log?.info(`establishing a new websocket to ${to}`, {
+    this.log?.info(`establishing a new websocket to ${to}`, {
       clientId: this.clientId,
       connectedTo: to,
     });
@@ -63,7 +62,7 @@ export class WebSocketClientTransport extends ClientTransport<WebSocketConnectio
     });
 
     const conn = new WebSocketConnection(ws);
-    log?.info(`raw websocket to ${to} ok, starting handshake`, {
+    this.log?.info(`raw websocket to ${to} ok, starting handshake`, {
       clientId: this.clientId,
       connectedTo: to,
     });

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -14,7 +14,13 @@ import {
   isAck,
   PROTOCOL_VERSION,
 } from './message';
-import { log } from '../logging/log';
+import {
+  BaseLogger,
+  LogFn,
+  Logger,
+  LoggingLevel,
+  createLogProxy,
+} from '../logging/log';
 import {
   EventDispatcher,
   EventHandler,
@@ -155,6 +161,7 @@ export abstract class Transport<ConnType extends Connection> {
    * The options for this transport.
    */
   protected options: TransportOptions;
+  log?: Logger;
 
   /**
    * Creates a new Transport instance.
@@ -172,6 +179,17 @@ export abstract class Transport<ConnType extends Connection> {
     this.codec = this.options.codec;
     this.clientId = clientId;
     this.state = 'open';
+  }
+
+  bindLogger(fn: LogFn | Logger, level?: LoggingLevel) {
+    // construct logger from fn
+    if (typeof fn === 'function') {
+      this.log = createLogProxy(new BaseLogger(fn, level));
+      return;
+    }
+
+    // object case, just assign
+    this.log = createLogProxy(fn);
   }
 
   /**
@@ -210,7 +228,12 @@ export abstract class Transport<ConnType extends Connection> {
 
     if (isReconnect) {
       session.replaceWithNewConnection(conn);
-      log?.info(`reconnected to ${connectedTo}`, conn.loggingMetadata);
+      this.log?.info(`reconnected to ${connectedTo}`, {
+        ...conn.loggingMetadata,
+        ...session.loggingMetadata,
+        clientId: this.clientId,
+        connectedTo,
+      });
     }
   }
 
@@ -226,6 +249,11 @@ export abstract class Transport<ConnType extends Connection> {
       this.options,
       propagationCtx,
     );
+
+    if (this.log) {
+      session.bindLogger(this.log);
+    }
+
     this.sessions.set(session.to, session);
     this.eventDispatcher.dispatchEvent('sessionStatus', {
       status: 'connect',
@@ -248,7 +276,7 @@ export abstract class Transport<ConnType extends Connection> {
       sessionId !== undefined &&
       session.advertisedSessionId !== sessionId
     ) {
-      log?.info(
+      this.log?.info(
         `session for ${to} already exists but has a different session id (expected: ${session.advertisedSessionId}, got: ${sessionId}), creating a new one`,
         session.loggingMetadata,
       );
@@ -259,7 +287,7 @@ export abstract class Transport<ConnType extends Connection> {
 
     if (!session) {
       session = this.createSession(to, conn, propagationCtx);
-      log?.info(
+      this.log?.info(
         `no session for ${to}, created a new one`,
         session.loggingMetadata,
       );
@@ -276,7 +304,7 @@ export abstract class Transport<ConnType extends Connection> {
     session.close();
     session.telemetry.span.end();
     this.sessions.delete(session.to);
-    log?.info(
+    this.log?.info(
       `session ${session.id} disconnect from ${session.to}`,
       session.loggingMetadata,
     );
@@ -318,15 +346,18 @@ export abstract class Transport<ConnType extends Connection> {
 
     if (parsedMsg === null) {
       const decodedBuffer = new TextDecoder().decode(Buffer.from(msg));
-      log?.error(`received malformed msg, killing conn: ${decodedBuffer}`, {
-        clientId: this.clientId,
-        ...conn.loggingMetadata,
-      });
+      this.log?.error(
+        `received malformed msg, killing conn: ${decodedBuffer}`,
+        {
+          clientId: this.clientId,
+          ...conn.loggingMetadata,
+        },
+      );
       return null;
     }
 
     if (!Value.Check(OpaqueTransportMessageSchema, parsedMsg)) {
-      log?.error(`received invalid msg: ${JSON.stringify(parsedMsg)}`, {
+      this.log?.error(`received invalid msg: ${JSON.stringify(parsedMsg)}`, {
         clientId: this.clientId,
         ...conn.loggingMetadata,
         validationErrors: [
@@ -348,7 +379,7 @@ export abstract class Transport<ConnType extends Connection> {
     if (this.state !== 'open') return;
     const session = this.sessions.get(msg.from);
     if (!session) {
-      log?.error(`no existing session for ${msg.from}`, {
+      this.log?.error(`no existing session for ${msg.from}`, {
         clientId: this.clientId,
         transportMessage: msg,
         ...conn.loggingMetadata,
@@ -360,14 +391,14 @@ export abstract class Transport<ConnType extends Connection> {
     // got a msg so we know the other end is alive, reset the grace period
     session.cancelGrace();
 
-    log?.debug(`received msg`, {
+    this.log?.debug(`received msg`, {
       clientId: this.clientId,
       transportMessage: msg,
       ...conn.loggingMetadata,
     });
     if (msg.seq !== session.nextExpectedSeq) {
       if (msg.seq < session.nextExpectedSeq) {
-        log?.debug(
+        this.log?.debug(
           `received duplicate msg (got seq: ${msg.seq}, wanted seq: ${session.nextExpectedSeq}), discarding`,
           {
             clientId: this.clientId,
@@ -377,7 +408,7 @@ export abstract class Transport<ConnType extends Connection> {
         );
       } else {
         const errMsg = `received out-of-order msg (got seq: ${msg.seq}, wanted seq: ${session.nextExpectedSeq})`;
-        log?.error(`${errMsg}, marking connection as dead`, {
+        this.log?.error(`${errMsg}, marking connection as dead`, {
           clientId: this.clientId,
           transportMessage: msg,
           ...conn.loggingMetadata,
@@ -400,7 +431,7 @@ export abstract class Transport<ConnType extends Connection> {
     if (!isAck(msg.controlFlags)) {
       this.eventDispatcher.dispatchEvent('message', msg);
     } else {
-      log?.debug(`discarding msg (ack bit set)`, {
+      this.log?.debug(`discarding msg (ack bit set)`, {
         clientId: this.clientId,
         transportMessage: msg,
         ...conn.loggingMetadata,
@@ -444,7 +475,7 @@ export abstract class Transport<ConnType extends Connection> {
   ): string | undefined {
     if (this.state === 'destroyed') {
       const err = 'transport is destroyed, cant send';
-      log?.error(err, {
+      this.log?.error(err, {
         clientId: this.clientId,
         transportMessage: msg,
         tags: ['invariant-violation'],
@@ -452,7 +483,7 @@ export abstract class Transport<ConnType extends Connection> {
       this.protocolError(ProtocolError.UseAfterDestroy, err);
       return undefined;
     } else if (this.state === 'closed') {
-      log?.info(`transport closed when sending, discarding`, {
+      this.log?.info(`transport closed when sending, discarding`, {
         clientId: this.clientId,
         transportMessage: msg,
       });
@@ -488,7 +519,7 @@ export abstract class Transport<ConnType extends Connection> {
       this.deleteSession(session);
     }
 
-    log?.info(`manually closed transport`, { clientId: this.clientId });
+    this.log?.info(`manually closed transport`, { clientId: this.clientId });
   }
 
   /**
@@ -502,7 +533,7 @@ export abstract class Transport<ConnType extends Connection> {
       this.deleteSession(session);
     }
 
-    log?.info(`manually destroyed transport`, { clientId: this.clientId });
+    this.log?.info(`manually destroyed transport`, { clientId: this.clientId });
   }
 }
 
@@ -557,7 +588,7 @@ export abstract class ClientTransport<
     // kill the conn after the grace period if we haven't received a handshake
     const handshakeTimeout = setTimeout(() => {
       if (!session) {
-        log?.warn(
+        this.log?.warn(
           `connection to ${to} timed out waiting for handshake, closing`,
           { ...conn.loggingMetadata, clientId: this.clientId, connectedTo: to },
         );
@@ -598,7 +629,7 @@ export abstract class ClientTransport<
       if (session) {
         this.onDisconnect(conn, session);
       }
-      log?.info(`connection to ${to} disconnected`, {
+      this.log?.info(`connection to ${to} disconnected`, {
         ...conn.loggingMetadata,
         ...session?.loggingMetadata,
         clientId: this.clientId,
@@ -614,12 +645,15 @@ export abstract class ClientTransport<
         code: SpanStatusCode.ERROR,
         message: 'connection error',
       });
-      log?.warn(`error in connection to ${to}: ${coerceErrorString(err)}`, {
-        ...conn.loggingMetadata,
-        ...session?.loggingMetadata,
-        clientId: this.clientId,
-        connectedTo: to,
-      });
+      this.log?.warn(
+        `error in connection to ${to}: ${coerceErrorString(err)}`,
+        {
+          ...conn.loggingMetadata,
+          ...session?.loggingMetadata,
+          clientId: this.clientId,
+          connectedTo: to,
+        },
+      );
     });
   }
 
@@ -645,7 +679,7 @@ export abstract class ClientTransport<
         code: SpanStatusCode.ERROR,
         message: 'invalid handshake response',
       });
-      log?.warn(`received invalid handshake resp`, {
+      this.log?.warn(`received invalid handshake resp`, {
         ...conn.loggingMetadata,
         clientId: this.clientId,
         connectedTo: parsed.from,
@@ -669,7 +703,7 @@ export abstract class ClientTransport<
         code: SpanStatusCode.ERROR,
         message: 'handshake rejected',
       });
-      log?.warn(`received handshake rejection`, {
+      this.log?.warn(`received handshake rejection`, {
         ...conn.loggingMetadata,
         clientId: this.clientId,
         connectedTo: parsed.from,
@@ -682,7 +716,7 @@ export abstract class ClientTransport<
       return false;
     }
 
-    log?.debug(`handshake from ${parsed.from} ok`, {
+    this.log?.debug(`handshake from ${parsed.from} ok`, {
       ...conn.loggingMetadata,
       clientId: this.clientId,
       connectedTo: parsed.from,
@@ -723,7 +757,7 @@ export abstract class ClientTransport<
   async connect(to: TransportClientId): Promise<void> {
     const canProceedWithConnection = () => this.state === 'open';
     if (!canProceedWithConnection()) {
-      log?.info(
+      this.log?.info(
         `transport state is no longer open, cancelling attempt to connect to ${to}`,
         { clientId: this.clientId, connectedTo: to },
       );
@@ -736,7 +770,7 @@ export abstract class ClientTransport<
       const budgetConsumed = this.retryBudget.getBudgetConsumed(to);
       if (!this.retryBudget.hasBudget(to)) {
         const errMsg = `tried to connect to ${to} but retry budget exceeded (more than ${budgetConsumed} attempts in the last ${this.retryBudget.totalBudgetRestoreTime}ms)`;
-        log?.warn(errMsg, { clientId: this.clientId, connectedTo: to });
+        this.log?.warn(errMsg, { clientId: this.clientId, connectedTo: to });
         this.protocolError(ProtocolError.RetriesExceeded, errMsg);
         return;
       }
@@ -747,10 +781,13 @@ export abstract class ClientTransport<
         sleep = new Promise((resolve) => setTimeout(resolve, backoffMs));
       }
 
-      log?.info(`attempting connection to ${to} (${backoffMs}ms backoff)`, {
-        clientId: this.clientId,
-        connectedTo: to,
-      });
+      this.log?.info(
+        `attempting connection to ${to} (${backoffMs}ms backoff)`,
+        {
+          clientId: this.clientId,
+          connectedTo: to,
+        },
+      );
       this.retryBudget.consumeBudget(to);
       reconnectPromise = tracer.startActiveSpan('connect', async (span) => {
         try {
@@ -763,7 +800,7 @@ export abstract class ClientTransport<
           span.addEvent('connecting');
           const conn = await this.createNewOutgoingConnection(to);
           if (!canProceedWithConnection()) {
-            log?.info(
+            this.log?.info(
               `transport state is no longer open, closing pre-handshake connection to ${to}`,
               {
                 ...conn.loggingMetadata,
@@ -797,10 +834,13 @@ export abstract class ClientTransport<
 
       this.inflightConnectionPromises.set(to, reconnectPromise);
     } else {
-      log?.info(`attempting connection to ${to} (reusing previous attempt)`, {
-        clientId: this.clientId,
-        connectedTo: to,
-      });
+      this.log?.info(
+        `attempting connection to ${to} (reusing previous attempt)`,
+        {
+          clientId: this.clientId,
+          connectedTo: to,
+        },
+      );
     }
 
     try {
@@ -810,12 +850,12 @@ export abstract class ClientTransport<
       const errStr = coerceErrorString(error);
 
       if (!this.reconnectOnConnectionDrop || !canProceedWithConnection()) {
-        log?.warn(`connection to ${to} failed (${errStr})`, {
+        this.log?.warn(`connection to ${to} failed (${errStr})`, {
           clientId: this.clientId,
           connectedTo: to,
         });
       } else {
-        log?.warn(`connection to ${to} failed (${errStr}), retrying`, {
+        this.log?.warn(`connection to ${to} failed (${errStr}), retrying`, {
           clientId: this.clientId,
           connectedTo: to,
         });
@@ -835,7 +875,7 @@ export abstract class ClientTransport<
     if (this.handshakeExtensions) {
       metadata = await this.handshakeExtensions.construct();
       if (!Value.Check(this.handshakeExtensions.schema, metadata)) {
-        log?.error(`constructed handshake metadata did not match schema`, {
+        this.log?.error(`constructed handshake metadata did not match schema`, {
           ...conn.loggingMetadata,
           clientId: this.clientId,
           connectedTo: to,
@@ -866,7 +906,7 @@ export abstract class ClientTransport<
       metadata,
       getPropagationContext(session.telemetry.ctx),
     );
-    log?.debug(`sending handshake request to ${to}`, {
+    this.log?.debug(`sending handshake request to ${to}`, {
       ...conn.loggingMetadata,
       clientId: this.clientId,
       connectedTo: to,
@@ -910,7 +950,7 @@ export abstract class ServerTransport<
       ...providedOptions,
     };
     this.sessionHandshakeMetadata = new WeakMap();
-    log?.info(`initiated server transport`, {
+    this.log?.info(`initiated server transport`, {
       clientId: this.clientId,
       protocolVersion: PROTOCOL_VERSION,
     });
@@ -923,7 +963,7 @@ export abstract class ServerTransport<
   protected handleConnection(conn: ConnType) {
     if (this.state !== 'open') return;
 
-    log?.info(`new incoming connection`, {
+    this.log?.info(`new incoming connection`, {
       ...conn.loggingMetadata,
       clientId: this.clientId,
     });
@@ -934,7 +974,7 @@ export abstract class ServerTransport<
     // kill the conn after the grace period if we haven't received a handshake
     const handshakeTimeout = setTimeout(() => {
       if (!session) {
-        log?.warn(
+        this.log?.warn(
           `connection to ${client()} timed out waiting for handshake, closing`,
           {
             ...conn.loggingMetadata,
@@ -999,7 +1039,7 @@ export abstract class ServerTransport<
     conn.addDataListener(handshakeHandler);
     conn.addCloseListener(() => {
       if (!session) return;
-      log?.info(`connection to ${client()} disconnected`, {
+      this.log?.info(`connection to ${client()} disconnected`, {
         ...conn.loggingMetadata,
         clientId: this.clientId,
       });
@@ -1012,7 +1052,7 @@ export abstract class ServerTransport<
         message: 'connection error',
       });
       if (!session) return;
-      log?.warn(
+      this.log?.warn(
         `connection to ${client()} got an error: ${coerceErrorString(err)}`,
         { ...conn.loggingMetadata, clientId: this.clientId },
       );
@@ -1041,7 +1081,7 @@ export abstract class ServerTransport<
           reason,
         });
         conn.send(this.codec.toBuffer(responseMsg));
-        log?.warn(`received malformed handshake metadata from ${from}`, {
+        this.log?.warn(`received malformed handshake metadata from ${from}`, {
           ...conn.loggingMetadata,
           clientId: this.clientId,
           validationErrors: [
@@ -1073,7 +1113,7 @@ export abstract class ServerTransport<
           reason,
         });
         conn.send(this.codec.toBuffer(responseMsg));
-        log?.warn(`rejected handshake from ${from}`, {
+        this.log?.warn(`rejected handshake from ${from}`, {
           ...conn.loggingMetadata,
           clientId: this.clientId,
         });
@@ -1113,10 +1153,10 @@ export abstract class ServerTransport<
         reason,
       });
       conn.send(this.codec.toBuffer(responseMsg));
-      log?.warn(reason, {
+      this.log?.warn(reason, {
         ...conn.loggingMetadata,
         clientId: this.clientId,
-        // safe to log metadata here as we remove the payload
+        // safe to this.log metadata here as we remove the payload
         // before passing it to user-land
         transportMessage: parsed,
         validationErrors: [
@@ -1144,7 +1184,7 @@ export abstract class ServerTransport<
         reason,
       });
       conn.send(this.codec.toBuffer(responseMsg));
-      log?.warn(
+      this.log?.warn(
         `received handshake msg with incompatible protocol version (got: ${gotVersion}, expected: ${PROTOCOL_VERSION})`,
         { ...conn.loggingMetadata, clientId: this.clientId },
       );
@@ -1173,7 +1213,7 @@ export abstract class ServerTransport<
 
     this.sessionHandshakeMetadata.set(session, parsedMetadata);
 
-    log?.debug(
+    this.log?.debug(
       `handshake from ${parsed.from} ok, responding with handshake success`,
       conn.loggingMetadata,
     );


### PR DESCRIPTION
## Why + What Changed

<!-- Describe what you are trying to accomplish with this pull request -->

- we weren't setting active spans correctly
- using a module global for the longer meant that you couldn't have two instances of river in the same codebase if they had the same dep version

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [x] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
