### PR TITLE
[protocolv2] Adapt to stream changes from #172 PR

### DIFF
--- a/__tests__/disconnects.test.ts
+++ b/__tests__/disconnects.test.ts
@@ -13,13 +13,16 @@ import {
   TestServiceSchema,
   UploadableServiceSchema,
 } from './fixtures/services';
-import { createClient, createServer } from '../router';
+import {
+  createClient,
+  createServer,
+  UNEXPECTED_DISCONNECT_CODE,
+} from '../router';
 import {
   advanceFakeTimersBySessionGrace,
   testFinishesCleanly,
   waitFor,
 } from './fixtures/cleanup';
-import { Err, UNEXPECTED_DISCONNECT } from '../router/result';
 import { testMatrix } from './fixtures/matrix';
 
 describe.each(testMatrix())(
@@ -63,11 +66,11 @@ describe.each(testMatrix())(
       await advanceFakeTimersBySessionGrace();
 
       // we should get an error + expect the streams to be cleaned up
-      await expect(procPromise).resolves.toMatchObject(
-        Err({
-          code: UNEXPECTED_DISCONNECT,
-        }),
-      );
+      await expect(procPromise).resolves.toMatchObject({
+        ok: false,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        payload: expect.objectContaining({ code: UNEXPECTED_DISCONNECT_CODE }),
+      });
 
       await waitFor(() => expect(clientTransport.connections.size).toEqual(0));
       await waitFor(() => expect(serverTransport.connections.size).toEqual(0));
@@ -112,11 +115,11 @@ describe.each(testMatrix())(
       await advanceFakeTimersBySessionGrace();
 
       // we should get an error + expect the streams to be cleaned up
-      await expect(nextResPromise).resolves.toMatchObject(
-        Err({
-          code: UNEXPECTED_DISCONNECT,
-        }),
-      );
+      await expect(nextResPromise).resolves.toMatchObject({
+        ok: false,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        payload: expect.objectContaining({ code: UNEXPECTED_DISCONNECT_CODE }),
+      });
 
       await waitFor(() => expect(clientTransport.connections.size).toEqual(0));
       await waitFor(() => expect(serverTransport.connections.size).toEqual(0));
@@ -192,12 +195,11 @@ describe.each(testMatrix())(
       // after we've disconnected, hit end of grace period
       await advanceFakeTimersBySessionGrace();
 
-      // we should get an error from the subscription on client2
-      await expect(nextResPromise).resolves.toMatchObject(
-        Err({
-          code: UNEXPECTED_DISCONNECT,
-        }),
-      );
+      await expect(nextResPromise).resolves.toMatchObject({
+        ok: false,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        payload: expect.objectContaining({ code: UNEXPECTED_DISCONNECT_CODE }),
+      });
 
       // client1 who is still connected can still add values and receive updates
       assert((await add2Promise).ok);
@@ -252,11 +254,11 @@ describe.each(testMatrix())(
       await advanceFakeTimersBySessionGrace();
 
       // we should get an error + expect the streams to be cleaned up
-      await expect(getAddResult()).resolves.toMatchObject(
-        Err({
-          code: UNEXPECTED_DISCONNECT,
-        }),
-      );
+      await expect(getAddResult()).resolves.toMatchObject({
+        ok: false,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        payload: expect.objectContaining({ code: UNEXPECTED_DISCONNECT_CODE }),
+      });
 
       await waitFor(() => expect(clientTransport.connections.size).toEqual(0));
       await waitFor(() => expect(serverTransport.connections.size).toEqual(0));

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -22,7 +22,6 @@ import {
   NonObjectSchemas,
   SchemaWithDisposableState,
 } from './fixtures/services';
-import { Ok, UNCAUGHT_ERROR } from '../router/result';
 import {
   advanceFakeTimersBySessionGrace,
   testFinishesCleanly,
@@ -30,7 +29,7 @@ import {
 } from './fixtures/cleanup';
 import { testMatrix } from './fixtures/matrix';
 import { Type } from '@sinclair/typebox';
-import { Procedure, ServiceSchema } from '../router';
+import { Procedure, ServiceSchema, Ok, UNCAUGHT_ERROR_CODE } from '../router';
 import {
   createClientHandshakeOptions,
   createServerHandshakeOptions,
@@ -255,7 +254,7 @@ describe.each(testMatrix())(
       const result3 = await iterNext(outputIterator);
       assert(!result3.ok);
       expect(result3.payload).toStrictEqual({
-        code: UNCAUGHT_ERROR,
+        code: UNCAUGHT_ERROR_CODE,
         message: 'some message',
       });
       inputWriter.close();

--- a/__tests__/handler.test.ts
+++ b/__tests__/handler.test.ts
@@ -15,7 +15,7 @@ import {
   SubscribableServiceSchema,
   UploadableServiceSchema,
 } from './fixtures/services';
-import { UNCAUGHT_ERROR } from '../router/result';
+import { UNCAUGHT_ERROR_CODE } from '../router';
 import { Observable } from './fixtures/observable';
 
 describe('server-side test', () => {
@@ -131,7 +131,7 @@ describe('server-side test', () => {
     const result3 = await iterNext(outputIterator);
     assert(!result3.ok);
     expect(result3.payload).toStrictEqual({
-      code: UNCAUGHT_ERROR,
+      code: UNCAUGHT_ERROR_CODE,
       message: 'some message',
     });
 
@@ -161,7 +161,7 @@ describe('server-side test', () => {
 
   test('uploads', async () => {
     const service = UploadableServiceSchema.instantiate();
-    const [inputWriter, result] = asClientUpload(
+    const [inputWriter, getAddResult] = asClientUpload(
       {},
       service.procedures.addMultiple,
     );
@@ -169,12 +169,15 @@ describe('server-side test', () => {
     inputWriter.write({ n: 1 });
     inputWriter.write({ n: 2 });
     inputWriter.close();
-    expect(await result).toStrictEqual({ ok: true, payload: { result: 3 } });
+    expect(await getAddResult()).toStrictEqual({
+      ok: true,
+      payload: { result: 3 },
+    });
   });
 
   test('uploads with initialization', async () => {
     const service = UploadableServiceSchema.instantiate();
-    const [inputWriter, result] = asClientUpload(
+    const [inputWriter, getAddResult] = asClientUpload(
       {},
       service.procedures.addMultipleWithPrefix,
       { prefix: 'test' },
@@ -183,7 +186,7 @@ describe('server-side test', () => {
     inputWriter.write({ n: 1 });
     inputWriter.write({ n: 2 });
     inputWriter.close();
-    expect(await result).toStrictEqual({
+    expect(await getAddResult()).toStrictEqual({
       ok: true,
       payload: { result: 'test 3' },
     });

--- a/__tests__/typescript-stress.test.ts
+++ b/__tests__/typescript-stress.test.ts
@@ -11,6 +11,7 @@ import {
   Output,
   ResultUnwrapErr,
   ResultUnwrapOk,
+  unwrap,
 } from '../router/result';
 import { TestServiceSchema } from './fixtures/services';
 import { getIteratorFromStream, iterNext } from '../util/testHelpers';
@@ -269,7 +270,9 @@ describe('Output<> type', () => {
 
     // Then
     const [, outputReader] = client.test.stream.stream({});
-    void iterNext(getIteratorFromStream(outputReader)).then(acceptOutput);
+    void iterNext(getIteratorFromStream(outputReader))
+      .then(unwrap)
+      .then(acceptOutput);
     expect(client).toBeTruthy();
   });
 
@@ -283,7 +286,9 @@ describe('Output<> type', () => {
 
     // Then
     const outputReader = client.test.subscription.subscribe({ n: 1 });
-    void iterNext(getIteratorFromStream(outputReader)).then(acceptOutput);
+    void iterNext(getIteratorFromStream(outputReader))
+      .then(unwrap)
+      .then(acceptOutput);
 
     expect(client).toBeTruthy();
   });
@@ -319,7 +324,7 @@ describe('ResultUwrap types', () => {
 
   test('it unwraps Err correctly', () => {
     // Given
-    const result = Err({ hello: 'world' });
+    const result = Err({ code: 'world', message: 'hello' });
 
     // When
     function acceptErr(payload: ResultUnwrapErr<typeof result>) {
@@ -328,7 +333,10 @@ describe('ResultUwrap types', () => {
 
     // Then
     assert(!result.ok);
-    expect(acceptErr(result.payload)).toEqual({ hello: 'world' });
+    expect(acceptErr(result.payload)).toEqual({
+      code: 'world',
+      message: 'hello',
+    });
   });
 });
 

--- a/router/index.ts
+++ b/router/index.ts
@@ -17,13 +17,20 @@ export type {
   ValidProcType,
   PayloadType,
   ProcedureMap,
-  ProcedureResult,
   RpcProcedure as RPCProcedure,
   UploadProcedure,
   SubscriptionProcedure,
   StreamProcedure,
+  ProcedureErrorSchemaType,
 } from './procedures';
-export { Procedure } from './procedures';
+export {
+  Procedure,
+  UNCAUGHT_ERROR_CODE,
+  UNEXPECTED_DISCONNECT_CODE,
+  INVALID_REQUEST_CODE,
+  OutputReaderErrorSchema,
+  InputReaderErrorSchema,
+} from './procedures';
 export { createClient } from './client';
 export type { Client } from './client';
 export { createServer } from './server';
@@ -34,11 +41,11 @@ export type {
   ServiceContextWithState,
   ServiceContextWithTransportInfo,
 } from './context';
-export { Ok, Err, UNCAUGHT_ERROR, RiverUncaughtSchema } from './result';
+export { Ok, Err } from './result';
 export type {
-  RiverErrorSchema,
-  RiverError,
   Result,
+  ErrResult,
+  OkResult,
   ResultUnwrapOk,
   ResultUnwrapErr,
   Output,

--- a/router/server.ts
+++ b/router/server.ts
@@ -1,6 +1,13 @@
 import { Static } from '@sinclair/typebox';
 import { ServerTransport } from '../transport/transport';
-import { AnyProcedure, PayloadType } from './procedures';
+import {
+  AnyProcedure,
+  PayloadType,
+  ProcedureErrorSchemaType,
+  OutputReaderErrorSchema,
+  InputReaderErrorSchema,
+  UNCAUGHT_ERROR_CODE,
+} from './procedures';
 import {
   AnyService,
   InstantiatedServiceSchemaMap,
@@ -22,13 +29,7 @@ import {
 } from './context';
 import { log } from '../logging/log';
 import { Value } from '@sinclair/typebox/value';
-import {
-  Err,
-  Result,
-  RiverError,
-  RiverUncaughtSchema,
-  UNCAUGHT_ERROR,
-} from './result';
+import { Err, Result, Ok } from './result';
 import { EventMap } from '../transport/events';
 import { Connection } from '../transport/session';
 import { coerceErrorString } from '../util/stringify';
@@ -53,9 +54,12 @@ interface ProcStream {
   id: string;
   serviceName: string;
   procedureName: string;
-  inputReader: ReadStreamImpl<PayloadType>;
+  inputReader: ReadStreamImpl<
+    Static<PayloadType>,
+    Static<typeof InputReaderErrorSchema>
+  >;
   outputWriter: WriteStreamImpl<
-    Result<Static<PayloadType>, Static<RiverError>>
+    Result<Static<PayloadType>, Static<ProcedureErrorSchemaType>>
   >;
   inputHandlerPromise: InputHandlerReturn;
 }
@@ -282,9 +286,9 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
       if (!outputWriter.isClosed()) {
         outputWriter.write(
           Err({
-            code: UNCAUGHT_ERROR,
+            code: UNCAUGHT_ERROR_CODE,
             message: errorMsg,
-          } satisfies Static<typeof RiverUncaughtSchema>),
+          } satisfies Static<typeof OutputReaderErrorSchema>),
         );
         outputWriter.close();
       }
@@ -455,7 +459,7 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
         'input' in procedure &&
         Value.Check(procedure.input, message.payload)
       ) {
-        procStream.inputReader.pushValue(message.payload as PayloadType);
+        procStream.inputReader.pushValue(Ok(message.payload));
       } else if (!Value.Check(ControlMessagePayloadSchema, message.payload)) {
         // whelp we got a message that isn't a control message and doesn't match the procedure input
         // so definitely not a valid payload

--- a/router/services.ts
+++ b/router/services.ts
@@ -1,11 +1,12 @@
-import { Type, TUnion, TSchema } from '@sinclair/typebox';
-import { RiverError, RiverUncaughtSchema } from './result';
+import { Type, TSchema, Static } from '@sinclair/typebox';
 import {
   Branded,
   ProcedureMap,
   Unbranded,
   AnyProcedure,
   PayloadType,
+  ProcedureErrorSchemaType,
+  OutputReaderErrorSchema,
 } from './procedures';
 
 /**
@@ -67,7 +68,7 @@ export type ProcHandler<
 export type ProcInit<
   S extends AnyService,
   ProcName extends keyof S['procedures'],
-> = S['procedures'][ProcName]['init'];
+> = Static<S['procedures'][ProcName]['init']>;
 
 /**
  * Helper to get the type definition for the procedure input of a service.
@@ -78,7 +79,7 @@ export type ProcInput<
   S extends AnyService,
   ProcName extends keyof S['procedures'],
 > = S['procedures'][ProcName] extends { input: PayloadType }
-  ? S['procedures'][ProcName]['input']
+  ? Static<S['procedures'][ProcName]['input']>
   : never;
 
 /**
@@ -89,7 +90,7 @@ export type ProcInput<
 export type ProcOutput<
   S extends AnyService,
   ProcName extends keyof S['procedures'],
-> = S['procedures'][ProcName]['output'];
+> = Static<S['procedures'][ProcName]['output']>;
 
 /**
  * Helper to get the type definition for the procedure errors of a service.
@@ -99,7 +100,9 @@ export type ProcOutput<
 export type ProcErrors<
   S extends AnyService,
   ProcName extends keyof S['procedures'],
-> = TUnion<[S['procedures'][ProcName]['errors'], typeof RiverUncaughtSchema]>;
+> =
+  | Static<S['procedures'][ProcName]['errors']>
+  | Static<typeof OutputReaderErrorSchema>;
 
 /**
  * Helper to get the type of procedure in a service.
@@ -134,7 +137,7 @@ export interface SerializedServiceSchema {
       init: PayloadType;
       input?: PayloadType;
       output: PayloadType;
-      errors?: RiverError;
+      errors?: ProcedureErrorSchemaType;
       type: 'rpc' | 'subscription' | 'upload' | 'stream';
     }
   >;

--- a/router/streams.ts
+++ b/router/streams.ts
@@ -1,10 +1,4 @@
-import { Err, Result } from './result';
-
-interface BaseError {
-  code: string;
-  message: string;
-  extra?: Record<string, unknown>;
-}
+import { BaseError, Err, Result } from './result';
 
 export const StreamDrainedError = {
   code: 'STREAM_DRAINED',
@@ -303,7 +297,7 @@ export class ReadStreamImpl<T, E extends BaseError>
    *
    * Pushes a value to the stream.
    */
-  public pushValue(value: ReadStreamResult<T, E>): undefined {
+  public pushValue(value: Result<T, E>): undefined {
     if (this.drained) {
       return;
     }

--- a/util/testHelpers.ts
+++ b/util/testHelpers.ts
@@ -2,15 +2,16 @@ import NodeWs, { WebSocketServer } from 'ws';
 import http from 'node:http';
 import {
   Err,
+  Ok,
   PayloadType,
   Procedure,
-  ProcedureResult,
   Result,
-  RiverError,
-  RiverUncaughtSchema,
+  ProcedureErrorSchemaType,
+  InputReaderErrorSchema,
+  OutputReaderErrorSchema,
   ServiceContext,
   ServiceContextWithTransportInfo,
-  UNCAUGHT_ERROR,
+  UNCAUGHT_ERROR_CODE,
 } from '../router';
 import { Static } from '@sinclair/typebox';
 import { nanoid } from 'nanoid';
@@ -29,6 +30,7 @@ import {
   WriteStreamImpl,
 } from '../router/streams';
 import { WsLike } from '../transport/impls/ws/wslike';
+import { BaseError } from '../router/result';
 
 /**
  * Creates a WebSocket client that connects to a local server at the specified port.
@@ -82,7 +84,9 @@ export function onUdsServeReady(
   });
 }
 
-export function getIteratorFromStream<T>(readStream: ReadStream<T>) {
+export function getIteratorFromStream<T, E extends BaseError>(
+  readStream: ReadStream<T, E>,
+) {
   return readStream[Symbol.asyncIterator]();
 }
 
@@ -155,7 +159,7 @@ export async function waitForMessage(
 
 function catchProcError(err: unknown) {
   const errorMsg = coerceErrorString(err);
-  return Err({ code: UNCAUGHT_ERROR, message: errorMsg });
+  return Err({ code: UNCAUGHT_ERROR_CODE, message: errorMsg });
 }
 
 export const testingSessionOptions: SessionOptions = defaultTransportOptions;
@@ -189,7 +193,7 @@ export function asClientRpc<
   State extends object,
   Init extends PayloadType,
   Output extends PayloadType,
-  Err extends RiverError,
+  Err extends ProcedureErrorSchemaType,
 >(
   state: State,
   proc: Procedure<State, 'rpc', Init, null, Output, Err>,
@@ -199,7 +203,7 @@ export function asClientRpc<
   return async (
     msg: Static<Init>,
   ): Promise<
-    Result<Static<Output>, Static<Err> | Static<typeof RiverUncaughtSchema>>
+    Result<Static<Output>, Static<Err> | Static<typeof OutputReaderErrorSchema>>
   > => {
     return proc
       .handler(dummyCtx(state, session, extendedContext), msg)
@@ -207,17 +211,59 @@ export function asClientRpc<
   };
 }
 
-function createPipe<T>(): { reader: ReadStream<T>; writer: WriteStream<T> } {
-  const reader = new ReadStreamImpl<T>(() => {
+function createOutputPipe<
+  Output extends PayloadType,
+  Err extends ProcedureErrorSchemaType,
+>(): {
+  reader: ReadStream<
+    Static<Output>,
+    Static<Err> | Static<typeof OutputReaderErrorSchema>
+  >;
+  writer: WriteStream<Result<Static<Output>, Static<Err>>>;
+} {
+  const reader = new ReadStreamImpl<
+    Static<Output>,
+    Static<Err> | Static<typeof OutputReaderErrorSchema>
+  >(() => {
     // Make it async to simulate request going over the wire
     // using promises so that we don't get affected by fake timers.
     void Promise.resolve().then(() => {
       writer.triggerCloseRequest();
     });
   });
-  const writer = new WriteStreamImpl<T>(
+  const writer = new WriteStreamImpl<Result<Static<Output>, Static<Err>>>(
     (v) => {
       reader.pushValue(v);
+    },
+    () => {
+      // Make it async to simulate request going over the wire
+      // using promises so that we don't get affected by fake timers.
+      void Promise.resolve().then(() => {
+        reader.triggerClose();
+      });
+    },
+  );
+
+  return { reader, writer };
+}
+
+function createInputPipe<Input extends PayloadType>(): {
+  reader: ReadStream<Static<Input>, Static<typeof InputReaderErrorSchema>>;
+  writer: WriteStream<Static<Input>>;
+} {
+  const reader = new ReadStreamImpl<
+    Static<Input>,
+    Static<typeof InputReaderErrorSchema>
+  >(() => {
+    // Make it async to simulate request going over the wire
+    // using promises so that we don't get affected by fake timers.
+    void Promise.resolve().then(() => {
+      writer.triggerCloseRequest();
+    });
+  });
+  const writer = new WriteStreamImpl<Static<Input>>(
+    (v) => {
+      reader.pushValue(Ok(v));
     },
     () => {
       // Make it async to simulate request going over the wire
@@ -236,16 +282,16 @@ export function asClientStream<
   Init extends PayloadType,
   Input extends PayloadType,
   Output extends PayloadType,
-  Err extends RiverError,
+  Err extends ProcedureErrorSchemaType,
 >(
   state: State,
   proc: Procedure<State, 'stream', Init, Input, Output, Err>,
   init?: Static<Init>,
   extendedContext?: Omit<ServiceContext, 'state'>,
   session: Session<Connection> = dummySession(),
-): [WriteStream<Static<Input>>, ReadStream<ProcedureResult<Output, Err>>] {
-  const inputPipe = createPipe<Static<Input>>();
-  const outputPipe = createPipe<ProcedureResult<Output, Err>>();
+): [WriteStream<Static<Input>>, ReadStream<Static<Output>, Static<Err>>] {
+  const inputPipe = createInputPipe<Input>();
+  const outputPipe = createOutputPipe<Output, Err>();
 
   void proc
     .handler(
@@ -263,14 +309,14 @@ export function asClientSubscription<
   State extends object,
   Init extends PayloadType,
   Output extends PayloadType,
-  Err extends RiverError,
+  Err extends ProcedureErrorSchemaType,
 >(
   state: State,
   proc: Procedure<State, 'subscription', Init, null, Output, Err>,
   extendedContext?: Omit<ServiceContext, 'state'>,
   session: Session<Connection> = dummySession(),
-): (msg: Static<Init>) => ReadStream<ProcedureResult<Output, Err>> {
-  const outputPipe = createPipe<ProcedureResult<Output, Err>>();
+): (msg: Static<Init>) => ReadStream<Static<Output>, Static<Err>> {
+  const outputPipe = createOutputPipe<Output, Err>();
 
   return (msg: Static<Init>) => {
     void proc
@@ -290,15 +336,18 @@ export function asClientUpload<
   Init extends PayloadType,
   Input extends PayloadType,
   Output extends PayloadType,
-  Err extends RiverError,
+  Err extends ProcedureErrorSchemaType,
 >(
   state: State,
   proc: Procedure<State, 'upload', Init, Input, Output, Err>,
   init?: Static<Init>,
   extendedContext?: Omit<ServiceContext, 'state'>,
   session: Session<Connection> = dummySession(),
-): [WriteStream<Static<Input>>, Promise<ProcedureResult<Output, Err>>] {
-  const inputPipe = createPipe<Static<Input>>();
+): [
+  WriteStream<Static<Input>>,
+  () => Promise<Result<Static<Output>, Static<Err>>>,
+] {
+  const inputPipe = createInputPipe<Input>();
   const result = proc
     .handler(
       dummyCtx(state, session, extendedContext),
@@ -306,7 +355,8 @@ export function asClientUpload<
       inputPipe.reader,
     )
     .catch(catchProcError);
-  return [inputPipe.writer, result];
+
+  return [inputPipe.writer, () => result];
 }
 
 export const getUnixSocketPath = () => {


### PR DESCRIPTION
## Why

This is just a follow up to #172, I'll merge this into the other PR but split them up for readability.

## What changed
More changes than I anticipated but turned out better than before.

- `Result` is now a union of `OkResult` and `ErrResult`
- `ErrResult`s always follow our error shape with `code`, `message`, and `extras`.
- Renamed error code constants to end with `_CODE`.
- Renamed `RiverError` to `ProcedureErrorSchemaType` so i can stop being confused.
- Renamed `RiverUncaughtSchema` is now `OutputReaderErrorSchema` since these errors are only relevant when reading from the output read stream on the client.
- Added `InputReaderErrorSchema` for the input read stream errors on the server.
- Moved some error schemas that are procedure specific from `router/result` to `router/procedure`.
- `ProcInit`, `ProcInput`, `ProcOutput`, and `ProcError` now emit types instead of schema types.
  - The only place that uses them doesn't need the schema, but the real motivation behind this change was some weird infinite recursion error.
- Wrap payloads with `Ok` before passing to the input read stream.
- Add `unwrap` function helper with result.
- Fixed a bug with `asClientUpload` where it was returning a promise
- Fixed all locations that use `ReadStream` to pass the errors

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
