### PR TITLE
Support diffing server schemas for API incompatibilities

### DIFF
--- a/__tests__/diff.test.ts
+++ b/__tests__/diff.test.ts
@@ -1,7 +1,7 @@
 import { expect, describe, test } from 'vitest';
 import { diffServerSchema } from '../router/diff';
 import { Procedure, ServiceSchema, serializeSchema } from '../router';
-import { Type } from '@sinclair/typebox';
+import { Kind, TSchema, Type, TypeRegistry } from '@sinclair/typebox';
 
 describe('schema backwards incompatible changes', () => {
   test('service removal is incompatible', () => {
@@ -14,7 +14,9 @@ describe('schema backwards incompatible changes', () => {
           add: Procedure.rpc({
             input: Type.Object({}),
             output: Type.Object({}),
-            handler: async (_) => ({ ok: true, payload: {} }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
           }),
         },
       ),
@@ -42,7 +44,9 @@ describe('schema backwards incompatible changes', () => {
           add: Procedure.rpc({
             input: Type.Object({}),
             output: Type.Object({}),
-            handler: async (_) => ({ ok: true, payload: {} }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
           }),
         },
       ),
@@ -80,7 +84,9 @@ describe('schema backwards incompatible changes', () => {
           add: Procedure.rpc({
             input: Type.Object({}),
             output: Type.Object({}),
-            handler: async (_) => ({ ok: true, payload: {} }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
           }),
         },
       ),
@@ -147,7 +153,9 @@ describe('schema backwards incompatible changes', () => {
           add: Procedure.rpc({
             input: Type.Object({}),
             output: Type.Object({}),
-            handler: async (_) => ({ ok: true, payload: {} }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
           }),
         },
       ),
@@ -161,8 +169,13 @@ describe('schema backwards incompatible changes', () => {
             add: {
               output: {
                 fieldBreakages: {
-                  total: {
-                    reason: 'removed-required',
+                  properties: {
+                    fieldBreakages: {
+                      total: {
+                        reason: 'removed-required',
+                      },
+                    },
+                    reason: 'field-breakage',
                   },
                 },
                 reason: 'field-breakage',
@@ -186,7 +199,9 @@ describe('schema backwards incompatible changes', () => {
           add: Procedure.rpc({
             input: Type.Object({}),
             output: Type.Object({}),
-            handler: async (_) => ({ ok: true, payload: {} }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
           }),
         },
       ),
@@ -203,7 +218,9 @@ describe('schema backwards incompatible changes', () => {
               total: Type.Number(),
             }),
             output: Type.Object({}),
-            handler: async (_) => ({ ok: true, payload: {} }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
           }),
         },
       ),
@@ -217,8 +234,13 @@ describe('schema backwards incompatible changes', () => {
             add: {
               input: {
                 fieldBreakages: {
-                  total: {
-                    reason: 'new-required',
+                  properties: {
+                    fieldBreakages: {
+                      total: {
+                        reason: 'new-required',
+                      },
+                    },
+                    reason: 'field-breakage',
                   },
                 },
                 reason: 'field-breakage',
@@ -244,7 +266,9 @@ describe('schema backwards incompatible changes', () => {
               total: Type.String(),
             }),
             output: Type.Object({}),
-            handler: async (_) => ({ ok: true, payload: {} }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
           }),
         },
       ),
@@ -261,7 +285,9 @@ describe('schema backwards incompatible changes', () => {
               total: Type.Number(),
             }),
             output: Type.Object({}),
-            handler: async (_) => ({ ok: true, payload: {} }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
           }),
         },
       ),
@@ -275,10 +301,1454 @@ describe('schema backwards incompatible changes', () => {
             add: {
               input: {
                 fieldBreakages: {
-                  total: {
+                  properties: {
+                    reason: 'field-breakage',
+                    fieldBreakages: {
+                      total: {
+                        reason: 'type-changed',
+                        oldType: 'string',
+                        newType: 'number',
+                      },
+                    },
+                  },
+                },
+                reason: 'field-breakage',
+              },
+              reason: 'modified',
+            },
+          },
+          reason: 'modified',
+        },
+      },
+    });
+  });
+
+  test('replaced union with object is incompatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Union([
+              Type.Object({ total: Type.Number() }),
+              Type.Object({ wat: Type.Number() }),
+            ]),
+            output: Type.Object({}),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({
+              total: Type.Number(),
+            }),
+            output: Type.Object({}),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          procedureBreakages: {
+            add: {
+              input: {
+                newType: 'object',
+                oldType: 'anyOf',
+                reason: 'type-changed',
+              },
+              reason: 'modified',
+            },
+          },
+          reason: 'modified',
+        },
+      },
+    });
+  });
+
+  test('swapping record and objects is incompatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Record(Type.String(), Type.String()),
+            output: Type.Object({}),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({}),
+            output: Type.Record(Type.String(), Type.String()),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          reason: 'modified',
+          procedureBreakages: {
+            add: {
+              reason: 'modified',
+              input: {
+                reason: 'type-changed',
+                oldType: 'probably-record',
+                newType: 'probably-object',
+              },
+              output: {
+                reason: 'type-changed',
+                oldType: 'probably-object',
+                newType: 'probably-record',
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  test('changing record keys is incompatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Record(Type.Number(), Type.String()),
+            output: Type.Object({}),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Record(Type.String(), Type.String()),
+            output: Type.Object({}),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          procedureBreakages: {
+            add: {
+              input: {
+                fieldBreakages: {
+                  patternProperties: {
+                    fieldBreakages: {
+                      '^(0|[1-9][0-9]*)$': {
+                        reason: 'removed-required',
+                      },
+                    },
+                    reason: 'field-breakage',
+                  },
+                },
+                reason: 'field-breakage',
+              },
+              reason: 'modified',
+            },
+          },
+          reason: 'modified',
+        },
+      },
+    });
+  });
+
+  test('changing record values is incompatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Record(Type.Number(), Type.Number()),
+            output: Type.Object({}),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Record(Type.Number(), Type.String()),
+            output: Type.Object({}),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          procedureBreakages: {
+            add: {
+              input: {
+                fieldBreakages: {
+                  patternProperties: {
+                    fieldBreakages: {
+                      '^(0|[1-9][0-9]*)$': {
+                        newType: 'string',
+                        oldType: 'number',
+                        reason: 'type-changed',
+                      },
+                    },
+                    reason: 'field-breakage',
+                  },
+                },
+                reason: 'field-breakage',
+              },
+              reason: 'modified',
+            },
+          },
+          reason: 'modified',
+        },
+      },
+    });
+  });
+
+  test('replaced not with union is incompatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Not(Type.Object({ total: Type.Number() })),
+            output: Type.Object({}),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Union([
+              Type.Object({ total: Type.Number() }),
+              Type.Object({ wat: Type.Number() }),
+            ]),
+            output: Type.Object({}),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          procedureBreakages: {
+            add: {
+              input: {
+                newType: 'anyOf',
+                oldType: 'not',
+                reason: 'type-changed',
+              },
+              reason: 'modified',
+            },
+          },
+          reason: 'modified',
+        },
+      },
+    });
+  });
+
+  test("replaced not's schema is incompatible", () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Not(Type.Number()),
+            output: Type.Object({}),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Not(Type.String()),
+            output: Type.Object({}),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          reason: 'modified',
+          procedureBreakages: {
+            add: {
+              reason: 'modified',
+              input: {
+                reason: 'field-breakage',
+                fieldBreakages: {
+                  not: {
                     reason: 'type-changed',
+                    oldType: 'number',
+                    newType: 'string',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  test('changing intersection type is incompatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Intersect([
+              Type.Object({ x: Type.Number() }),
+              Type.Object({ y: Type.Number() }),
+            ]),
+            output: Type.Intersect([
+              Type.Object({ x: Type.Number() }),
+              Type.Object({ y: Type.Number() }),
+            ]),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Intersect([
+              Type.Object({ x: Type.Number() }),
+              Type.Object({ z: Type.Number() }),
+            ]),
+            output: Type.Intersect([
+              Type.Object({ x: Type.Number() }),
+              Type.Object({ z: Type.Number() }),
+            ]),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          reason: 'modified',
+          procedureBreakages: {
+            add: {
+              reason: 'modified',
+              input: {
+                reason: 'field-breakage',
+                fieldBreakages: {
+                  allOf: {
+                    reason: 'field-breakage',
+                    fieldBreakages: {
+                      properties: {
+                        reason: 'field-breakage',
+                        fieldBreakages: {
+                          y: {
+                            reason: 'removed-required',
+                          },
+                          z: {
+                            reason: 'new-required',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              output: {
+                reason: 'field-breakage',
+                fieldBreakages: {
+                  allOf: {
+                    reason: 'field-breakage',
+                    fieldBreakages: {
+                      properties: {
+                        reason: 'field-breakage',
+                        fieldBreakages: {
+                          y: {
+                            reason: 'removed-required',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  test('removing from union type input is incompatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Union([
+              Type.Object({ x: Type.Number() }),
+              Type.Object({ y: Type.Number() }),
+              Type.Object({ z: Type.Number() }),
+            ]),
+            output: Type.Object({}),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Union([
+              Type.Object({ x: Type.Number() }),
+              Type.Object({ y: Type.Number() }),
+            ]),
+            output: Type.Object({}),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          procedureBreakages: {
+            add: {
+              input: {
+                fieldBreakages: {
+                  anyOf: {
+                    fieldBreakages: {
+                      'old-2': {
+                        reason: 'removed-required',
+                      },
+                    },
+                    reason: 'field-breakage',
+                  },
+                },
+                reason: 'field-breakage',
+              },
+              reason: 'modified',
+            },
+          },
+          reason: 'modified',
+        },
+      },
+    });
+  });
+
+  test('adding to union type output is incompatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({}),
+            output: Type.Union([
+              Type.Object({ x: Type.Number() }),
+              Type.Object({ y: Type.Number() }),
+            ]),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({}),
+            output: Type.Union([
+              Type.Object({ x: Type.Number() }),
+              Type.Object({ y: Type.Number() }),
+              Type.Object({ z: Type.Number() }),
+            ]),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          procedureBreakages: {
+            add: {
+              output: {
+                fieldBreakages: {
+                  anyOf: {
+                    fieldBreakages: {
+                      'new-2': {
+                        reason: 'new-required',
+                      },
+                    },
+                    reason: 'field-breakage',
+                  },
+                },
+                reason: 'field-breakage',
+              },
+              reason: 'modified',
+            },
+          },
+          reason: 'modified',
+        },
+      },
+    });
+  });
+
+  test('changing literal value is incompatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Literal('old'),
+            output: Type.Literal('old'),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Literal('new'),
+            output: Type.Literal('new'),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          procedureBreakages: {
+            add: {
+              input: {
+                newType: 'string-const-new',
+                oldType: 'string-const-old',
+                reason: 'type-changed',
+              },
+              output: {
+                newType: 'string-const-new',
+                oldType: 'string-const-old',
+                reason: 'type-changed',
+              },
+              reason: 'modified',
+            },
+          },
+          reason: 'modified',
+        },
+      },
+    });
+  });
+
+  test('replaced non-literal with literal for input is incompatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.String(),
+            output: Type.Object({}),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Literal('mystring'),
+            output: Type.Object({}),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          procedureBreakages: {
+            add: {
+              input: {
+                newType: 'string-const-mystring',
+                oldType: 'string',
+                reason: 'type-changed',
+              },
+              reason: 'modified',
+            },
+          },
+          reason: 'modified',
+        },
+      },
+    });
+  });
+
+  test('replaced literal with non-literal for output is incompatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.String(),
+            output: Type.Literal('mystring'),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.String(),
+            output: Type.String(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          procedureBreakages: {
+            add: {
+              output: {
+                newType: 'string',
+                oldType: 'string-const-mystring',
+                reason: 'type-changed',
+              },
+              reason: 'modified',
+            },
+          },
+          reason: 'modified',
+        },
+      },
+    });
+  });
+
+  test('array minItems increasing for input is not compatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Array(Type.String(), { minItems: 1 }),
+            output: Type.String(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Array(Type.String(), { minItems: 2 }),
+            output: Type.String(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          procedureBreakages: {
+            add: {
+              input: {
+                fieldBreakages: {
+                  minItems: {
+                    newType: '2',
+                    oldType: '1',
+                    reason: 'type-changed',
+                  },
+                },
+                reason: 'field-breakage',
+              },
+              reason: 'modified',
+            },
+          },
+          reason: 'modified',
+        },
+      },
+    });
+  });
+
+  test('array minItems decreasing for output is not compatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.String(),
+            output: Type.Array(Type.String(), { minItems: 2 }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.String(),
+            output: Type.Array(Type.String(), { minItems: 1 }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          procedureBreakages: {
+            add: {
+              output: {
+                fieldBreakages: {
+                  minItems: {
+                    newType: '1',
+                    oldType: '2',
+                    reason: 'type-changed',
+                  },
+                },
+                reason: 'field-breakage',
+              },
+              reason: 'modified',
+            },
+          },
+          reason: 'modified',
+        },
+      },
+    });
+  });
+
+  test('array maxItems increasing for output is not compatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.String(),
+            output: Type.Array(Type.String(), { maxItems: 1 }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.String(),
+            output: Type.Array(Type.String(), { maxItems: 2 }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          procedureBreakages: {
+            add: {
+              output: {
+                fieldBreakages: {
+                  maxItems: {
+                    newType: '2',
+                    oldType: '1',
+                    reason: 'type-changed',
+                  },
+                },
+                reason: 'field-breakage',
+              },
+              reason: 'modified',
+            },
+          },
+          reason: 'modified',
+        },
+      },
+    });
+  });
+
+  test('array maxItems decreasing for input is not compatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Array(Type.String(), { maxItems: 2 }),
+            output: Type.String(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Array(Type.String(), { maxItems: 1 }),
+            output: Type.String(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          procedureBreakages: {
+            add: {
+              input: {
+                fieldBreakages: {
+                  maxItems: {
+                    newType: '1',
+                    oldType: '2',
+                    reason: 'type-changed',
+                  },
+                },
+                reason: 'field-breakage',
+              },
+              reason: 'modified',
+            },
+          },
+          reason: 'modified',
+        },
+      },
+    });
+  });
+
+  test('array minContains increasing for input is not compatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Array(Type.String(), { minContains: 1 }),
+            output: Type.String(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Array(Type.String(), { minContains: 2 }),
+            output: Type.String(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          procedureBreakages: {
+            add: {
+              input: {
+                fieldBreakages: {
+                  minContains: {
+                    newType: '2',
+                    oldType: '1',
+                    reason: 'type-changed',
+                  },
+                },
+                reason: 'field-breakage',
+              },
+              reason: 'modified',
+            },
+          },
+          reason: 'modified',
+        },
+      },
+    });
+  });
+
+  test('array minContains decreasing for output is not compatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.String(),
+            output: Type.Array(Type.String(), { minContains: 2 }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.String(),
+            output: Type.Array(Type.String(), { minContains: 1 }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          procedureBreakages: {
+            add: {
+              output: {
+                fieldBreakages: {
+                  minContains: {
+                    newType: '1',
+                    oldType: '2',
+                    reason: 'type-changed',
+                  },
+                },
+                reason: 'field-breakage',
+              },
+              reason: 'modified',
+            },
+          },
+          reason: 'modified',
+        },
+      },
+    });
+  });
+
+  test('array maxContains increasing for output is not compatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.String(),
+            output: Type.Array(Type.String(), { maxContains: 1 }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.String(),
+            output: Type.Array(Type.String(), { maxContains: 2 }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          procedureBreakages: {
+            add: {
+              output: {
+                fieldBreakages: {
+                  maxContains: {
+                    newType: '2',
+                    oldType: '1',
+                    reason: 'type-changed',
+                  },
+                },
+                reason: 'field-breakage',
+              },
+              reason: 'modified',
+            },
+          },
+          reason: 'modified',
+        },
+      },
+    });
+  });
+
+  test('array maxContains decreasing for input is not compatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Array(Type.String(), { maxContains: 2 }),
+            output: Type.String(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Array(Type.String(), { maxContains: 1 }),
+            output: Type.String(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          procedureBreakages: {
+            add: {
+              input: {
+                fieldBreakages: {
+                  maxContains: {
+                    newType: '1',
+                    oldType: '2',
+                    reason: 'type-changed',
+                  },
+                },
+                reason: 'field-breakage',
+              },
+              reason: 'modified',
+            },
+          },
+          reason: 'modified',
+        },
+      },
+    });
+  });
+
+  test('array unique items turned on for client is not compatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Array(Type.String(), { uniqueItems: false }),
+            output: Type.String(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Array(Type.String(), { uniqueItems: true }),
+            output: Type.String(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          procedureBreakages: {
+            add: {
+              input: {
+                fieldBreakages: {
+                  uniqueItems: {
+                    newType: 'true',
+                    oldType: 'false',
+                    reason: 'type-changed',
+                  },
+                },
+                reason: 'field-breakage',
+              },
+              reason: 'modified',
+            },
+          },
+          reason: 'modified',
+        },
+      },
+    });
+  });
+
+  test('array contains added for input is incompatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Array(Type.String()),
+            output: Type.String(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Array(Type.String(), { contains: Type.Literal('wow') }),
+            output: Type.String(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          procedureBreakages: {
+            add: {
+              input: {
+                fieldBreakages: {
+                  contains: {
+                    newType: 'contains',
+                    oldType: 'no-contains',
+                    reason: 'type-changed',
+                  },
+                },
+                reason: 'field-breakage',
+              },
+              reason: 'modified',
+            },
+          },
+          reason: 'modified',
+        },
+      },
+    });
+  });
+
+  test('array contains type changed is incompatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Array(Type.String(), { contains: Type.String() }),
+            output: Type.String(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Array(Type.String(), { contains: Type.Object({}) }),
+            output: Type.String(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          procedureBreakages: {
+            add: {
+              input: {
+                fieldBreakages: {
+                  contains: {
+                    newType: 'object',
                     oldType: 'string',
-                    newType: 'number',
+                    reason: 'type-changed',
                   },
                 },
                 reason: 'field-breakage',
@@ -306,7 +1776,9 @@ describe('schema backwards compatible changes', () => {
           add: Procedure.rpc({
             input: Type.Object({}),
             output: Type.Object({}),
-            handler: async (_) => ({ ok: true, payload: {} }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
           }),
         },
       ),
@@ -335,7 +1807,9 @@ describe('schema backwards compatible changes', () => {
           add: Procedure.rpc({
             input: Type.Object({}),
             output: Type.Object({}),
-            handler: async (_) => ({ ok: true, payload: {} }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
           }),
         },
       ),
@@ -372,7 +1846,9 @@ describe('schema backwards compatible changes', () => {
               total: Type.Optional(Type.Number()),
             }),
             output: Type.Object({}),
-            handler: async (_) => ({ ok: true, payload: {} }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
           }),
         },
       ),
@@ -409,7 +1885,9 @@ describe('schema backwards compatible changes', () => {
           add: Procedure.rpc({
             input: Type.Object({}),
             output: Type.Object({}),
-            handler: async (_) => ({ ok: true, payload: {} }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
           }),
         },
       ),
@@ -417,5 +1895,682 @@ describe('schema backwards compatible changes', () => {
 
     const diff = diffServerSchema(oldSchema, newSchema);
     expect(diff).toBeNull();
+  });
+
+  test('replaced non-literal with literal from the same type for output is compatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({}),
+            output: Type.String({}),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({}),
+            output: Type.Literal('mystring'),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual(null);
+  });
+
+  test('array minItems increasing for output is compatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.String(),
+            output: Type.Array(Type.String(), { minItems: 1 }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.String(),
+            output: Type.Array(Type.String(), { minItems: 2 }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual(null);
+  });
+
+  test('array minItems decreasing for input is compatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Array(Type.String(), { minItems: 2 }),
+            output: Type.String(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Array(Type.String(), { minItems: 1 }),
+            output: Type.String(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual(null);
+  });
+
+  test('array maxItems decreasing for output is compatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.String(),
+            output: Type.Array(Type.String(), { maxItems: 2 }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.String(),
+            output: Type.Array(Type.String(), { maxItems: 1 }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual(null);
+  });
+
+  test('array maxItems increasing for input is compatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Array(Type.String(), { maxItems: 1 }),
+            output: Type.String(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Array(Type.String(), { maxItems: 2 }),
+            output: Type.String(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual(null);
+  });
+
+  test('array minContains increasing for output is compatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.String(),
+            output: Type.Array(Type.String(), { minContains: 1 }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.String(),
+            output: Type.Array(Type.String(), { minContains: 2 }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual(null);
+  });
+
+  test('array minContains decreasing for input is compatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Array(Type.String(), { minContains: 2 }),
+            output: Type.String(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Array(Type.String(), { minContains: 1 }),
+            output: Type.String(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual(null);
+  });
+
+  test('array maxContains decreasing for output is compatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.String(),
+            output: Type.Array(Type.String(), { maxContains: 2 }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.String(),
+            output: Type.Array(Type.String(), { maxContains: 1 }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual(null);
+  });
+
+  test('array maxContains increasing for input is compatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Array(Type.String(), { maxContains: 1 }),
+            output: Type.String(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Array(Type.String(), { maxContains: 2 }),
+            output: Type.String(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual(null);
+  });
+
+  test('array unique items turned off for input is compatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Array(Type.String(), { uniqueItems: true }),
+            output: Type.String(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Array(Type.String(), { uniqueItems: false }),
+            output: Type.String(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual(null);
+  });
+
+  test('array unique items turned on for output is compatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.String(),
+            output: Type.Array(Type.String(), { uniqueItems: false }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.String(),
+            output: Type.Array(Type.String(), { uniqueItems: true }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual(null);
+  });
+
+  test('array contains added for output is compatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.String(),
+            output: Type.Array(Type.String()),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.String(),
+            output: Type.Array(Type.String(), {
+              contains: Type.Literal('wow'),
+            }),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual(null);
+  });
+
+  test('adding to union type input is compatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Union([
+              Type.Object({ x: Type.Number() }),
+              Type.Object({ y: Type.Number() }),
+            ]),
+            output: Type.Object({}),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Union([
+              Type.Object({ x: Type.Number() }),
+              Type.Object({ y: Type.Number() }),
+              Type.Object({ z: Type.Number() }),
+            ]),
+            output: Type.Object({}),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual(null);
+  });
+
+  test('removing from union type output is incompatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({}),
+            output: Type.Union([
+              Type.Object({ x: Type.Number() }),
+              Type.Object({ y: Type.Number() }),
+              Type.Object({ z: Type.Number() }),
+            ]),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({}),
+            output: Type.Union([
+              Type.Object({ x: Type.Number() }),
+              Type.Object({ y: Type.Number() }),
+            ]),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual(null);
+  });
+});
+
+describe('unsupported schema', () => {
+  test('oneof', () => {
+    function UnionOneOf(): TSchema {
+      if (!TypeRegistry.Has('TESTING_ONEOF')) {
+        TypeRegistry.Set('TESTING_ONEOF', () => true);
+      }
+
+      return { [Kind]: 'UnionOneOf', oneOf: [] } as unknown as TSchema;
+    }
+
+    const schema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({}),
+            output: UnionOneOf(),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    expect(() => diffServerSchema(schema, schema)).toThrow();
+  });
+
+  test('object additionalProperties', () => {
+    const schema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({}),
+            output: Type.Object(
+              {
+                hey: Type.Boolean(),
+              },
+              {
+                additionalProperties: Type.Literal('wat'),
+              },
+            ),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    expect(() => diffServerSchema(schema, schema)).toThrow();
+  });
+
+  test('object maxProperties', () => {
+    const schema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({}),
+            output: Type.Object(
+              {
+                hey: Type.Boolean(),
+              },
+              {
+                maxProperties: 1,
+              },
+            ),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    expect(() => diffServerSchema(schema, schema)).toThrow();
+  });
+
+  test('object minProperties', () => {
+    const schema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({}),
+            output: Type.Object(
+              {
+                hey: Type.Boolean(),
+              },
+              {
+                minProperties: 1,
+              },
+            ),
+            handler: () => {
+              throw new Error('unimplemented');
+            },
+          }),
+        },
+      ),
+    });
+
+    expect(() => diffServerSchema(schema, schema)).toThrow();
   });
 });

--- a/__tests__/diff.test.ts
+++ b/__tests__/diff.test.ts
@@ -1,0 +1,421 @@
+import { expect, describe, test } from 'vitest';
+import { diffServerSchema } from '../router/diff';
+import { Procedure, ServiceSchema, serializeSchema } from '../router';
+import { Type } from '@sinclair/typebox';
+
+describe('schema backwards incompatible changes', () => {
+  test('service removal is incompatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({}),
+            output: Type.Object({}),
+            handler: async (_) => ({ ok: true, payload: {} }),
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({});
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          reason: 'removed',
+        },
+      },
+    });
+  });
+
+  test('procedure removal is incompatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({}),
+            output: Type.Object({}),
+            handler: async (_) => ({ ok: true, payload: {} }),
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {},
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          reason: 'modified',
+          procedureBreakages: {
+            add: { reason: 'removed' },
+          },
+        },
+      },
+    });
+  });
+
+  test('procedure type change is incompatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({}),
+            output: Type.Object({}),
+            handler: async (_) => ({ ok: true, payload: {} }),
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.stream({
+            input: Type.Object({}),
+            output: Type.Object({}),
+            handler: async (_) => {
+              return;
+            },
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          procedureBreakages: {
+            add: {
+              newType: 'stream',
+              oldType: 'rpc',
+              reason: 'type-changed',
+            },
+          },
+          reason: 'modified',
+        },
+      },
+    });
+  });
+
+  test('removed required output field is incompatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({}),
+            output: Type.Object({
+              total: Type.Number(),
+            }),
+            handler: async (_) => ({ ok: true, payload: { total: 0 } }),
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({}),
+            output: Type.Object({}),
+            handler: async (_) => ({ ok: true, payload: {} }),
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          procedureBreakages: {
+            add: {
+              output: {
+                fieldBreakages: {
+                  total: {
+                    reason: 'removed-required',
+                  },
+                },
+                reason: 'field-breakage',
+              },
+              reason: 'modified',
+            },
+          },
+          reason: 'modified',
+        },
+      },
+    });
+  });
+
+  test('new required input field is incompatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({}),
+            output: Type.Object({}),
+            handler: async (_) => ({ ok: true, payload: {} }),
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({
+              total: Type.Number(),
+            }),
+            output: Type.Object({}),
+            handler: async (_) => ({ ok: true, payload: {} }),
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          procedureBreakages: {
+            add: {
+              input: {
+                fieldBreakages: {
+                  total: {
+                    reason: 'new-required',
+                  },
+                },
+                reason: 'field-breakage',
+              },
+              reason: 'modified',
+            },
+          },
+          reason: 'modified',
+        },
+      },
+    });
+  });
+
+  test('field type change is incompatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({
+              total: Type.String(),
+            }),
+            output: Type.Object({}),
+            handler: async (_) => ({ ok: true, payload: {} }),
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({
+              total: Type.Number(),
+            }),
+            output: Type.Object({}),
+            handler: async (_) => ({ ok: true, payload: {} }),
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toEqual({
+      serviceBreakages: {
+        adder: {
+          procedureBreakages: {
+            add: {
+              input: {
+                fieldBreakages: {
+                  total: {
+                    reason: 'type-changed',
+                    oldType: 'string',
+                    newType: 'number',
+                  },
+                },
+                reason: 'field-breakage',
+              },
+              reason: 'modified',
+            },
+          },
+          reason: 'modified',
+        },
+      },
+    });
+  });
+});
+
+describe('schema backwards compatible changes', () => {
+  test('new service is compatible', () => {
+    const oldSchema = serializeSchema({});
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({}),
+            output: Type.Object({}),
+            handler: async (_) => ({ ok: true, payload: {} }),
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toBeNull();
+  });
+
+  test('new procedure is compatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {},
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({}),
+            output: Type.Object({}),
+            handler: async (_) => ({ ok: true, payload: {} }),
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toBeNull();
+  });
+
+  test('new optional field is compatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({}),
+            output: Type.Object({}),
+            handler: async (_) => ({ ok: true, payload: { total: 0 } }),
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({
+              total: Type.Optional(Type.Number()),
+            }),
+            output: Type.Object({}),
+            handler: async (_) => ({ ok: true, payload: {} }),
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toBeNull();
+  });
+
+  test('removed optional output field is compatible', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({}),
+            output: Type.Object({
+              total: Type.Optional(Type.Number()),
+            }),
+            handler: async (_) => ({ ok: true, payload: { total: 0 } }),
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({}),
+            output: Type.Object({}),
+            handler: async (_) => ({ ok: true, payload: {} }),
+          }),
+        },
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema);
+    expect(diff).toBeNull();
+  });
+});

--- a/router/diff.ts
+++ b/router/diff.ts
@@ -1,0 +1,220 @@
+import type {
+  SerializedServerSchema,
+  SerializedServiceSchema,
+  SerializedProcedureSchema,
+  PayloadType,
+} from '../router';
+
+export interface ServerBreakage {
+  serviceBreakages: Record<string, ServiceBreakage>;
+}
+
+export type ServiceBreakage =
+  | {
+      reason: 'removed';
+    }
+  | {
+      reason: 'modified';
+      procedureBreakages: Record<string, ProcedureBreakage>;
+    };
+
+export type ProcedureBreakage =
+  | {
+      reason: 'removed';
+    }
+  | { reason: 'type-changed'; oldType: string; newType: string }
+  | {
+      reason: 'modified';
+      input?: PayloadBreakage;
+      init?: PayloadBreakage;
+      output?: PayloadBreakage;
+    };
+
+export type PayloadBreakage =
+  | { reason: 'type-changed'; oldType: string; newType: string }
+  | { reason: 'new-required' }
+  | { reason: 'removed-required' }
+  | {
+      reason: 'field-breakage';
+      fieldBreakages: Record<string, PayloadBreakage>;
+    };
+
+export function diffServerSchema(
+  oldServer: SerializedServerSchema,
+  newServer: SerializedServerSchema,
+): ServerBreakage | null {
+  const allServices = new Set([
+    ...Object.keys(oldServer.services),
+    ...Object.keys(newServer.services),
+  ]);
+
+  const breakages: Record<string, ServiceBreakage> = {};
+  for (const serviceName of allServices) {
+    const oldService = oldServer.services[serviceName];
+    const newService = newServer.services[serviceName];
+
+    const breakage = diffService(oldService, newService);
+    if (breakage) {
+      breakages[serviceName] = breakage;
+    }
+  }
+
+  if (Object.keys(breakages).length) {
+    return { serviceBreakages: breakages };
+  }
+
+  return null;
+}
+
+function diffService(
+  oldService: SerializedServiceSchema | null,
+  newService: SerializedServiceSchema | null,
+): ServiceBreakage | null {
+  if (!newService) {
+    return { reason: 'removed' };
+  }
+  // New service, perfectly fine.
+  if (!oldService) {
+    return null;
+  }
+
+  const allProcedures = new Set([
+    ...Object.keys(oldService.procedures),
+    ...Object.keys(newService.procedures),
+  ]);
+
+  const breakages: Record<string, ProcedureBreakage> = {};
+  for (const procedureName of allProcedures) {
+    const aProcedure = oldService.procedures[procedureName];
+    const bProcedure = newService.procedures[procedureName];
+
+    const breakage = diffProcedure(aProcedure, bProcedure);
+    if (breakage) {
+      breakages[procedureName] = breakage;
+    }
+  }
+  if (Object.keys(breakages).length) {
+    return { reason: 'modified', procedureBreakages: breakages };
+  }
+
+  return null;
+}
+
+function diffProcedure(
+  oldProcedure: SerializedProcedureSchema | null,
+  newProcedure: SerializedProcedureSchema | null,
+): ProcedureBreakage | null {
+  if (!newProcedure) {
+    return { reason: 'removed' };
+  }
+  // New service, perfectly fine.
+  if (!oldProcedure) {
+    return null;
+  }
+
+  if (oldProcedure.type !== newProcedure.type) {
+    return {
+      reason: 'type-changed',
+      oldType: oldProcedure.type,
+      newType: newProcedure.type,
+    };
+  }
+
+  const inputBreakage = diffPayload(
+    oldProcedure.input,
+    newProcedure.input,
+    'client',
+  );
+  const initBreakage = diffPayload(
+    oldProcedure.init,
+    newProcedure.init,
+    'client',
+  );
+  const outputBreakage = diffPayload(
+    oldProcedure.output,
+    newProcedure.output,
+    'server',
+  );
+
+  if (inputBreakage ?? initBreakage ?? outputBreakage) {
+    const result: ProcedureBreakage = {
+      reason: 'modified',
+    };
+    if (inputBreakage) {
+      result.input = inputBreakage;
+    }
+    if (initBreakage) {
+      result.init = initBreakage;
+    }
+    if (outputBreakage) {
+      result.output = outputBreakage;
+    }
+    return result;
+  }
+
+  return null;
+}
+
+function diffPayload(
+  oldPayload: PayloadType | undefined,
+  newPayload: PayloadType | undefined,
+  origin: 'server' | 'client',
+  oldRequired?: boolean,
+  newRequired?: boolean,
+): PayloadBreakage | null {
+  if (!newPayload && !oldPayload) {
+    return null;
+  }
+  // old server will send this field, new client will not
+  if (!newPayload) {
+    // This is only okay if the the field was optional and the origin is the server.
+    if (!oldRequired && origin == 'server') {
+      return null;
+    }
+    return { reason: 'removed-required' };
+  }
+  if (!oldPayload) {
+    if (newRequired && origin === 'client') {
+      return { reason: 'new-required' };
+    }
+    // New service, perfectly fine.
+    return null;
+  }
+
+  if (oldPayload.type !== newPayload.type) {
+    return {
+      reason: 'type-changed',
+      oldType: oldPayload.type,
+      newType: newPayload.type,
+    };
+  }
+
+  if (newPayload.type === 'object') {
+    const allProperties = new Set([
+      ...Object.keys(oldPayload.properties),
+      ...Object.keys(newPayload.properties),
+    ]);
+
+    const breakages: Record<string, PayloadBreakage> = {};
+    for (const propertyName of allProperties) {
+      const propertyBreakage = diffPayload(
+        oldPayload.properties[propertyName],
+        newPayload.properties[propertyName],
+        origin,
+        (oldPayload.required ?? []).includes(propertyName),
+        (newPayload.required ?? []).includes(propertyName),
+      );
+      if (propertyBreakage) {
+        breakages[propertyName] = propertyBreakage;
+      }
+    }
+    if (Object.keys(breakages).length) {
+      return {
+        reason: 'field-breakage',
+        fieldBreakages: breakages,
+      };
+    }
+  }
+
+  return null;
+}

--- a/router/diff.ts
+++ b/router/diff.ts
@@ -1,8 +1,13 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+import { TProperties, TAnySchema } from '@sinclair/typebox';
 import type {
   SerializedServerSchema,
   SerializedServiceSchema,
   SerializedProcedureSchema,
-  PayloadType,
 } from '../router';
 
 export interface ServerBreakage {
@@ -31,7 +36,11 @@ export type ProcedureBreakage =
     };
 
 export type PayloadBreakage =
-  | { reason: 'type-changed'; oldType: string; newType: string }
+  | {
+      reason: 'type-changed';
+      oldType: string;
+      newType: string;
+    }
   | { reason: 'new-required' }
   | { reason: 'removed-required' }
   | {
@@ -120,17 +129,17 @@ function diffProcedure(
     };
   }
 
-  const inputBreakage = diffPayload(
+  const inputBreakage = diffProcedureField(
     oldProcedure.input,
     newProcedure.input,
     'client',
   );
-  const initBreakage = diffPayload(
+  const initBreakage = diffProcedureField(
     oldProcedure.init,
     newProcedure.init,
     'client',
   );
-  const outputBreakage = diffPayload(
+  const outputBreakage = diffProcedureField(
     oldProcedure.output,
     newProcedure.output,
     'server',
@@ -155,66 +164,494 @@ function diffProcedure(
   return null;
 }
 
-function diffPayload(
-  oldPayload: PayloadType | undefined,
-  newPayload: PayloadType | undefined,
+function diffProcedureField(
+  oldSchema: TAnySchema | undefined,
+  newSchema: TAnySchema | undefined,
   origin: 'server' | 'client',
-  oldRequired?: boolean,
-  newRequired?: boolean,
 ): PayloadBreakage | null {
-  if (!newPayload && !oldPayload) {
+  if (!oldSchema && !newSchema) {
     return null;
   }
+
+  const diffBreakage = diffRequired(oldSchema, newSchema, origin, false, false);
+  if (diffBreakage) {
+    return diffBreakage;
+  }
+
+  if (!oldSchema || !newSchema) {
+    throw new Error('Appease typescript, this should never happen');
+  }
+
+  return diffJSONSchema(oldSchema, newSchema, origin);
+}
+
+function diffRequired(
+  oldSchema: TAnySchema | undefined,
+  newSchema: TAnySchema | undefined,
+  origin: 'server' | 'client',
+  oldRequired: boolean,
+  newRequired: boolean,
+): PayloadBreakage | null {
+  if (!newSchema && !oldSchema) {
+    throw new Error('Both old and new schema are undefined');
+  }
+
   // old server will send this field, new client will not
-  if (!newPayload) {
+  if (!newSchema) {
     // This is only okay if the the field was optional and the origin is the server.
     if (!oldRequired && origin == 'server') {
       return null;
     }
     return { reason: 'removed-required' };
   }
-  if (!oldPayload) {
+  if (!oldSchema) {
     if (newRequired && origin === 'client') {
       return { reason: 'new-required' };
     }
-    // New service, perfectly fine.
+    // New field, perfectly fine.
     return null;
   }
 
-  if (oldPayload.type !== newPayload.type) {
+  return null;
+}
+
+function diffJSONSchema(
+  oldSchema: TAnySchema,
+  newSchema: TAnySchema,
+  origin: 'server' | 'client',
+): PayloadBreakage | null {
+  if (oldSchema.type !== newSchema.type) {
     return {
       reason: 'type-changed',
-      oldType: oldPayload.type,
-      newType: newPayload.type,
+      oldType: getReportingType(oldSchema),
+      newType: getReportingType(newSchema),
     };
   }
 
-  if (newPayload.type === 'object') {
-    const allProperties = new Set([
-      ...Object.keys(oldPayload.properties),
-      ...Object.keys(newPayload.properties),
-    ]);
+  if (getReportingType(oldSchema) !== getReportingType(newSchema)) {
+    return {
+      reason: 'type-changed',
+      oldType: getReportingType(oldSchema),
+      newType: getReportingType(newSchema),
+    };
+  }
 
-    const breakages: Record<string, PayloadBreakage> = {};
-    for (const propertyName of allProperties) {
-      const propertyBreakage = diffPayload(
-        oldPayload.properties[propertyName],
-        newPayload.properties[propertyName],
+  if (
+    'const' in oldSchema &&
+    'const' in newSchema &&
+    oldSchema.const !== newSchema.const
+  ) {
+    return {
+      reason: 'type-changed',
+      oldType: `${getReportingType(oldSchema)}-const-${oldSchema.const}`,
+      newType: `${getReportingType(newSchema)}-const-${newSchema.const}`,
+    };
+  }
+
+  // if const in old and coming from the server, then it's not okay
+  if ('const' in oldSchema && !('const' in newSchema) && origin === 'server') {
+    return {
+      reason: 'type-changed',
+      oldType: `${getReportingType(oldSchema)}-const-${oldSchema.const}`,
+      newType: getReportingType(newSchema),
+    };
+  }
+
+  if ('const' in newSchema && !('const' in oldSchema) && origin === 'client') {
+    return {
+      reason: 'type-changed',
+      oldType: getReportingType(oldSchema),
+      newType: `${getReportingType(newSchema)}-const-${newSchema.const}`,
+    };
+  }
+
+  const breakages: Record<string, PayloadBreakage> = {};
+  if ('$ref' in newSchema) {
+    // TRef
+    if (newSchema.$ref !== oldSchema.$ref) {
+      return {
+        reason: 'type-changed',
+        oldType: getReportingType(oldSchema),
+        newType: getReportingType(newSchema),
+      };
+    }
+  } else if ('not' in newSchema) {
+    // TNot
+    const notBreakage = diffJSONSchema(
+      oldSchema.not as TAnySchema,
+      newSchema.not as TAnySchema,
+      origin,
+    );
+
+    if (notBreakage) {
+      breakages.not = notBreakage;
+    }
+  } else if ('anyOf' in newSchema) {
+    // TUnion or TEnum
+
+    // best effort, permissiveness relies on not changing order, but it's the best
+    // we can do without going too wild doing a matrix diff
+
+    const oldAnyOfStringified = oldSchema.anyOf
+      .map((el: unknown) => JSON.stringify(el))
+      .sort();
+    const newAnyOfStringified = newSchema.anyOf
+      .map((el: unknown) => JSON.stringify(el))
+      .sort();
+
+    const anyOfBreakages: Record<string, PayloadBreakage> = {};
+
+    for (let i = 0; i < oldAnyOfStringified.length; i++) {
+      if (newAnyOfStringified.includes(oldAnyOfStringified[i])) {
+        // perfect match
+        continue;
+      }
+
+      if (!newAnyOfStringified[i]) {
+        if (origin === 'server') {
+          continue;
+        }
+
+        anyOfBreakages[`old-${i}`] = { reason: 'removed-required' };
+      } else {
+        const breakage = diffJSONSchema(
+          JSON.parse(oldAnyOfStringified[i]),
+          JSON.parse(newAnyOfStringified[i]),
+          origin,
+        );
+
+        if (breakage) {
+          anyOfBreakages[`old-${i}`] = breakage;
+        }
+      }
+    }
+
+    for (let i = 0; i < newAnyOfStringified.length; i++) {
+      if (oldAnyOfStringified.includes(newAnyOfStringified[i])) {
+        // perfect match
+        continue;
+      }
+
+      if (!oldAnyOfStringified[i]) {
+        if (origin === 'client') {
+          continue;
+        }
+
+        anyOfBreakages[`new-${i}`] = { reason: 'new-required' };
+      } else {
+        const breakage = diffJSONSchema(
+          JSON.parse(oldAnyOfStringified[i]),
+          JSON.parse(newAnyOfStringified[i]),
+          origin,
+        );
+
+        if (breakage) {
+          anyOfBreakages[`new-${i}`] = breakage;
+        }
+      }
+    }
+
+    if (Object.keys(anyOfBreakages).length > 0) {
+      breakages.anyOf = {
+        reason: 'field-breakage',
+        fieldBreakages: anyOfBreakages,
+      };
+    }
+  } else if ('oneOf' in newSchema) {
+    throw new Error('oneOf is not supported, typebox does not emit it');
+  } else if ('allOf' in newSchema) {
+    // TIntersect
+
+    // best effort, permissiveness relies on not changing order and not changing the
+    // types in the intersection
+
+    if (newSchema.allOf.length !== oldSchema.allOf.length) {
+      breakages.allOf = {
+        reason: 'type-changed',
+        oldType: `${oldSchema.allOf}`,
+        newType: `${newSchema.allOf}`,
+      };
+    } else {
+      for (let i = 0; i < newSchema.allOf.length; i++) {
+        const breakage = diffJSONSchema(
+          oldSchema.allOf[i],
+          newSchema.allOf[i],
+          origin,
+        );
+
+        if (breakage) {
+          breakages.allOf = breakage;
+          break;
+        }
+      }
+    }
+  } else if (newSchema.type === 'array') {
+    // TArray or TTuple
+    const itemsBreakages = diffJSONSchema(
+      oldSchema.items as TAnySchema,
+      newSchema.items as TAnySchema,
+      origin,
+    );
+
+    if (itemsBreakages) {
+      breakages.items = itemsBreakages;
+    }
+
+    if (oldSchema.minItems < newSchema.minItems) {
+      if (origin === 'client') {
+        breakages.minItems = {
+          reason: 'type-changed',
+          oldType: `${oldSchema.minItems}`,
+          newType: `${newSchema.minItems}`,
+        };
+      }
+    } else if (oldSchema.minItems > newSchema.minItems) {
+      if (origin === 'server') {
+        breakages.minItems = {
+          reason: 'type-changed',
+          oldType: `${oldSchema.minItems}`,
+          newType: `${newSchema.minItems}`,
+        };
+      }
+    }
+
+    if (oldSchema.maxItems < newSchema.maxItems) {
+      if (origin === 'server') {
+        breakages.maxItems = {
+          reason: 'type-changed',
+          oldType: `${oldSchema.maxItems}`,
+          newType: `${newSchema.maxItems}`,
+        };
+      }
+    } else if (oldSchema.maxItems > newSchema.maxItems) {
+      if (origin === 'client') {
+        breakages.maxItems = {
+          reason: 'type-changed',
+          oldType: `${oldSchema.maxItems}`,
+          newType: `${newSchema.maxItems}`,
+        };
+      }
+    }
+
+    if (
+      !oldSchema.uniqueItems &&
+      newSchema.uniqueItems &&
+      origin === 'client'
+    ) {
+      breakages.uniqueItems = {
+        reason: 'type-changed',
+        oldType: `${!!oldSchema.uniqueItems}`,
+        newType: `${!!newSchema.uniqueItems}`,
+      };
+    }
+
+    if ('contains' in newSchema !== 'contains' in oldSchema) {
+      if (
+        'contains' in newSchema &&
+        !('contains' in oldSchema) &&
+        origin === 'client'
+      ) {
+        breakages.contains = {
+          reason: 'type-changed',
+          oldType: 'no-contains',
+          newType: 'contains',
+        };
+      }
+    } else if ('contains' in newSchema) {
+      const containsBreakage = diffJSONSchema(
+        oldSchema.contains,
+        newSchema.contains,
         origin,
-        (oldPayload.required ?? []).includes(propertyName),
-        (newPayload.required ?? []).includes(propertyName),
       );
+
+      if (containsBreakage) {
+        breakages.contains = containsBreakage;
+      }
+    }
+
+    if (oldSchema.minContains < newSchema.minContains) {
+      if (origin === 'client') {
+        breakages.minContains = {
+          reason: 'type-changed',
+          oldType: `${oldSchema.minContains}`,
+          newType: `${newSchema.minContains}`,
+        };
+      }
+    } else if (oldSchema.minContains > newSchema.minContains) {
+      if (origin === 'server') {
+        breakages.minContains = {
+          reason: 'type-changed',
+          oldType: `${oldSchema.minContains}`,
+          newType: `${newSchema.minContains}`,
+        };
+      }
+    }
+
+    if (oldSchema.maxContains < newSchema.maxContains) {
+      if (origin === 'server') {
+        breakages.maxContains = {
+          reason: 'type-changed',
+          oldType: `${oldSchema.maxContains}`,
+          newType: `${newSchema.maxContains}`,
+        };
+      }
+    } else if (oldSchema.maxContains > newSchema.maxContains) {
+      if (origin === 'client') {
+        breakages.maxContains = {
+          reason: 'type-changed',
+          oldType: `${oldSchema.maxContains}`,
+          newType: `${newSchema.maxContains}`,
+        };
+      }
+    }
+    /**
+     * ignoring `additionalItems` since it's not represented in typebox
+     */
+  } else if (newSchema.type === 'object') {
+    // TRecord or TObject or TComposite or TMapped
+
+    if ('properties' in newSchema !== 'properties' in oldSchema) {
+      // In theory we can get fancy in this case since Objects are Records with literals as keys
+      // but reporting breakage to keep things simpler
+      return {
+        reason: 'type-changed',
+        oldType:
+          'properties' in oldSchema ? 'probably-object' : 'probably-record',
+        newType:
+          'properties' in newSchema ? 'probably-object' : 'probably-record',
+      };
+    }
+
+    if ('properties' in newSchema) {
+      // TObject
+      const propertiesBreakages = diffObjectProperties(
+        oldSchema.properties,
+        newSchema.properties,
+        origin,
+        oldSchema.required,
+        newSchema.required,
+      );
+
+      if (Object.keys(propertiesBreakages).length) {
+        breakages.properties = {
+          reason: 'field-breakage',
+          fieldBreakages: propertiesBreakages,
+        };
+      }
+    }
+
+    if ('patternProperties' in newSchema) {
+      // TRecord
+
+      const patternPropertiesBreakages = diffObjectProperties(
+        oldSchema.patternProperties,
+        newSchema.patternProperties,
+        origin,
+        oldSchema.required,
+        newSchema.required,
+      );
+
+      if (Object.keys(patternPropertiesBreakages).length) {
+        breakages.patternProperties = {
+          reason: 'field-breakage',
+          fieldBreakages: patternPropertiesBreakages,
+        };
+      }
+    }
+    console.log('yo', newSchema);
+
+    if (
+      'additionalProperties' in newSchema ||
+      'additionalProperties' in oldSchema
+    ) {
+      throw new Error('additionalProperties is not supported');
+    }
+
+    if ('minProperties' in newSchema || 'minProperties' in oldSchema) {
+      throw new Error('minProperties is not supported');
+    }
+
+    if ('maxProperties' in newSchema || 'maxProperties' in oldSchema) {
+      throw new Error('maxProperties is not supported');
+    }
+  }
+
+  if (Object.keys(breakages).length) {
+    return {
+      reason: 'field-breakage',
+      fieldBreakages: breakages,
+    };
+  }
+
+  return null;
+}
+
+function diffObjectProperties(
+  oldProperties: TProperties,
+  newProperties: TProperties,
+  origin: 'server' | 'client',
+  oldRequiredProperties: Array<string> = [],
+  newRequiredProperties: Array<string> = [],
+): Record<string, PayloadBreakage> {
+  // TRecord
+  const allProperties = new Set([
+    ...Object.keys(oldProperties),
+    ...Object.keys(newProperties),
+  ]);
+
+  const breakages: Record<string, PayloadBreakage> = {};
+
+  for (const propertyName of allProperties) {
+    const requiredBreakage = diffRequired(
+      oldProperties[propertyName],
+      newProperties[propertyName],
+      origin,
+      oldRequiredProperties.includes(propertyName),
+      newRequiredProperties.includes(propertyName),
+    );
+
+    if (requiredBreakage) {
+      breakages[propertyName] = requiredBreakage;
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    } else if (oldProperties[propertyName] && newProperties[propertyName]) {
+      const propertyBreakage = diffJSONSchema(
+        oldProperties[propertyName],
+        newProperties[propertyName],
+        origin,
+      );
+
       if (propertyBreakage) {
         breakages[propertyName] = propertyBreakage;
       }
     }
-    if (Object.keys(breakages).length) {
-      return {
-        reason: 'field-breakage',
-        fieldBreakages: breakages,
-      };
-    }
   }
 
-  return null;
+  return breakages;
+}
+
+function getReportingType(schema: TAnySchema): string {
+  if ('not' in schema) {
+    return 'not';
+  }
+
+  if ('anyOf' in schema) {
+    return 'anyOf';
+  }
+
+  if ('allOf' in schema) {
+    return 'allOf';
+  }
+
+  if ('$ref' in schema) {
+    return '$ref';
+  }
+
+  if (schema.type && typeof schema.type === 'string') {
+    return schema.type;
+  }
+
+  console.error(schema);
+  throw new Error(
+    'Subschema not supported, probably a conditional subschema. Check logs.',
+  );
 }

--- a/router/diff.ts
+++ b/router/diff.ts
@@ -212,6 +212,13 @@ function diffRequired(
     return null;
   }
 
+  if (origin === 'client' && !oldRequired && newRequired) {
+    return { reason: 'new-required' };
+  }
+  if (origin === 'server' && oldRequired && !newRequired) {
+    return { reason: 'removed-required' };
+  }
+
   return null;
 }
 
@@ -558,7 +565,6 @@ function diffJSONSchema(
         };
       }
     }
-    console.log('yo', newSchema);
 
     if (
       'additionalProperties' in newSchema ||

--- a/router/index.ts
+++ b/router/index.ts
@@ -12,6 +12,8 @@ export {
   ServiceSchema,
   serializeSchema,
   SerializedServerSchema,
+  SerializedServiceSchema,
+  SerializedProcedureSchema,
 } from './services';
 export type {
   ValidProcType,

--- a/router/services.ts
+++ b/router/services.ts
@@ -137,17 +137,16 @@ export interface ServiceConfiguration<State extends object> {
   initializeState: () => State;
 }
 
+export interface SerializedProcedureSchema {
+  input: PayloadType;
+  output: PayloadType;
+  errors?: RiverError;
+  type: 'rpc' | 'subscription' | 'upload' | 'stream';
+  init?: PayloadType;
+}
+
 export interface SerializedServiceSchema {
-  procedures: Record<
-    string,
-    {
-      input: PayloadType;
-      output: PayloadType;
-      errors?: RiverError;
-      type: 'rpc' | 'subscription' | 'upload' | 'stream';
-      init?: PayloadType;
-    }
-  >;
+  procedures: Record<string, SerializedProcedureSchema>;
 }
 
 export interface SerializedServerSchema {


### PR DESCRIPTION
## Why

With upcoming versioning work, we want a way to be able to programmatically detect API compatibility breakages between different River schemas.

This adds a first pass at schema diffing which detects a number of incompatibilities:
- Removed services
- Removed procedures
- Procedure type changes
- Payload incompatibilities
    - Type changes
    - New required fields on client->server messages
    - Removed required fields on server->client messages
    - The check support nested objects
    - Array changes
    - Union changes
    - Intersection changes

## What changed

- Add `diffServerSchema` which diffs two server schemas and returns all detected API incompatibilies
- Includes a test suite checking for the incompatibilies mentioned above

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
