### PR TITLE
[protocolv2] Add abort support, move protocol errors to abort status (docs only)

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -146,7 +146,7 @@ The `controlFlags` property is a [bit field](https://en.wikipedia.org/wiki/Bit_f
 - The `StreamOpenBit` (`0b00010`) MUST be set for the first message of a new stream.
 - The `StreamClosedBit` (`0b00100`) MUST be set for the last message of a stream.
 - The `StreamCloseRequestBit` (`0b10000`) MUST be set for a message that is requesting the other side to close the stream.
-- Bits `0b01000` is reserved for future use and is currently unused.
+- The `StreamAbortBit` (`0b01000`) MUST be set when a stream is to be abruptly closed due to cancellations or an internal error condition.
 
 All messages MUST have no control flags set (i.e., the `controlFlags` field is `0b00000`) unless:
 
@@ -159,6 +159,8 @@ All messages MUST have no control flags set (i.e., the `controlFlags` field is `
   - If this is sent with no payload, it is a control message the payload MUST Be a `ControlClose`.
 - It is a message requesting the other side to stop writing to the stream, in which case the `StreamCloseRequestBit` MUST be set.
   - This is a control message and the payload MUST be a `ControlClose`.
+- It is a message aborting the stream, in which case the `StreamAbortBit` MUST be set.
+  - This message MUST contain a `ProtocolError` payload.
 - It is an explicit heartbeat, so the `AckBit` MUST be the only bit set.
   - The payload MUST be `{ type: 'ACK' }`.
   - Because this is a control message that is not associated with a specific stream, you MUST NOT set `serviceName` or `procedureName` and `streamId` can be something arbitrary (e.g. `heartbeat`).
@@ -169,7 +171,7 @@ There are 2 error payloads that are defined in the protocol sent from server to 
 // When a client sends a malformed request. This can be
 // for a variety of reasons which would  be included
 // in the message.
-interface InvalidRequest extends BaseError {
+interface InvalidRequestError extends BaseError {
   code: 'INVALID_REQUEST';
   message: string;
 }
@@ -180,10 +182,18 @@ interface UncaughtError extends BaseError {
   message: string;
 }
 
-type ProtocolError = UncaughtError | InvalidRequest;
+// This is sent when one side wishes to cancel or "abort" the stream
+// abruptly from user-space. Handling this is up to the procedure
+// implementation or the caller.
+interface AbortError extends BaseError {
+  code: 'ABORT';
+  message: string;
+}
+
+type ProtocolError = UncaughtError | InvalidRequestError | AbortError;
 ```
 
-`ProtocolError`s, just like service-level errors, are wrapped with a `Result`, which is further wrapped with `TransportMessage` and MUST have a `StreamClosedBit` flag.
+`ProtocolError`s, just like service-level errors, are wrapped with a `Result`, which is further wrapped with `TransportMessage` and MUST have a `StreamAbortBit` flag. Please note that these are separate from user-defined errors, which should be treated just like any output message.
 
 There are 4 `Control` payloads:
 
@@ -269,6 +279,7 @@ When a message is received, it MUST be validated before being processed.
 - Either side can initiate a close by sending a message with a `StreamClosedBit`
   - The closing party MUST NOT send any more messages.
   - To get a full close, the other side MUST respond with a `StreamClosedBit` acknowledging the close.
+- In case of errors or if one side wishes to abruptly abort the stream, a message with a `StreamAbortBit` and a `ProtocolError` payload. 
 
 When a message is validated at this level, the implementor must update the bookkeeping information for the session (see the 'Transparent Reconnections' heading for more information).
 
@@ -296,7 +307,7 @@ For an incoming message to be considered valid on the server, the transport mess
 - If this is the first message of the stream, the internal payload of the message should match the JSON schema for the `Init` type of the associated handler, and the server should pass the `Init` message to the handler.
 - If this is not the first message of the stream AND the procedure accepts further input, the internal payload of the message should match the JSON schema for the `Input` type of the associated handler, and the server should pass the `Input` message to the handler.
 
-If the message is invalid, the server MUST discard the message and send back an `INVALID_REQUEST` error message with a `StreamClosedBit`, this is an abrupt full close, the server should cleanup all associated resources with the stream without expecting a close response from the client. The server may choose to keep track of `INVALID_REQUEST` stream ids to avoid sending multiple errors back.
+If the message is invalid, the server MUST discard the message and send back an `INVALID_REQUEST` error message with a `StreamAbortBit`, this is an abrupt full close, the server should cleanup all associated resources with the stream without expecting a close response from the client. The server may choose to keep track of `INVALID_REQUEST` stream ids to avoid sending multiple errors back.
 
 Otherwise, the message is a normal message. Unwrap the payload and pass it to the handler associated with the `streamId` of the message.
 
@@ -310,8 +321,9 @@ The legend is as follows:
 
 - `>` represents an `Init` message with the `StreamOpenBit` set.
 - `x` represents an `Init` message with both `StreamOpenBit`and `StreamClosedBit` set.
-- `<` represents a `Result` message with the `StreamClosedBit` set, errors in this message are only service-level errors.
-- `!` represents a `Result` message with the `StreamClosedBit` set and a `ProtocolError` in the payload (`{ ok: false, payload: ProtocolError }`).
+- `<` represents a `Result` message with the `StreamClosedBit` set.
+  - This message may contain service-level errors.
+- `!` represents a `Result` message with the `StreamAbortBit` set and a `ProtocolError` in the payload.
 - `{` represents a `ControlClose` message.
 - `-` represents any message with no control flags set.
 


### PR DESCRIPTION
## Why

`StreamClosedBit` should be reserved for normal closures where the writer decides to close gracefully, overloading it to transmit `ProtocolError`s which lead to abrupt closure can be confusing and problematic. Since we plan on adding abort/cancellation support, might as well go ahead and do this now while we're rolling out a breaking change 

## What changed

Added `StreamAbortBit` and moved protocol errors there. This also involves us adding abort support instead of clean closes.

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
