### PR TITLE
[dev] Deflake the tests

### DIFF
--- a/__tests__/cleanup.test.ts
+++ b/__tests__/cleanup.test.ts
@@ -1,12 +1,4 @@
-import {
-  afterAll,
-  assert,
-  describe,
-  expect,
-  test,
-  vi,
-  onTestFinished,
-} from 'vitest';
+import { afterAll, assert, describe, expect, test, vi } from 'vitest';
 import { iterNext } from '../util/testHelpers';
 import {
   SubscribableServiceSchema,
@@ -31,7 +23,9 @@ describe.each(testMatrix())(
       await transport.setup({ client: opts, server: opts });
     afterAll(cleanup);
 
-    test('closing a transport from the client cleans up connection on the server', async () => {
+    test('closing a transport from the client cleans up connection on the server', async ({
+      onTestFinished,
+    }) => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
@@ -71,7 +65,9 @@ describe.each(testMatrix())(
       await ensureTransportBuffersAreEventuallyEmpty(serverTransport);
     });
 
-    test('closing a transport from the server cleans up connection on the client', async () => {
+    test('closing a transport from the server cleans up connection on the client', async ({
+      onTestFinished,
+    }) => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
@@ -111,7 +107,7 @@ describe.each(testMatrix())(
       await ensureTransportBuffersAreEventuallyEmpty(serverTransport);
     });
 
-    test('rpc', async () => {
+    test('rpc', async ({ onTestFinished }) => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
@@ -158,7 +154,7 @@ describe.each(testMatrix())(
       await ensureTransportBuffersAreEventuallyEmpty(serverTransport);
     });
 
-    test('stream', async () => {
+    test('stream', async ({ onTestFinished }) => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
@@ -226,7 +222,7 @@ describe.each(testMatrix())(
       await ensureTransportBuffersAreEventuallyEmpty(serverTransport);
     });
 
-    test('subscription', async () => {
+    test('subscription', async ({ onTestFinished }) => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
@@ -289,7 +285,7 @@ describe.each(testMatrix())(
       expect(server.services.subscribable.state.count.listenerCount).toEqual(0);
     });
 
-    test('upload', async () => {
+    test('upload', async ({ onTestFinished }) => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
@@ -344,7 +340,9 @@ describe.each(testMatrix())(
       await ensureTransportBuffersAreEventuallyEmpty(serverTransport);
     });
 
-    test("shouldn't send messages across stale sessions", async () => {
+    test("shouldn't send messages across stale sessions", async ({
+      onTestFinished,
+    }) => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();

--- a/__tests__/disconnects.test.ts
+++ b/__tests__/disconnects.test.ts
@@ -1,12 +1,4 @@
-import {
-  afterAll,
-  assert,
-  describe,
-  expect,
-  onTestFinished,
-  test,
-  vi,
-} from 'vitest';
+import { afterAll, assert, describe, expect, test, vi } from 'vitest';
 import { iterNext } from '../util/testHelpers';
 import {
   SubscribableServiceSchema,
@@ -30,7 +22,7 @@ describe.each(testMatrix())(
       await transport.setup({ client: opts, server: opts });
     afterAll(cleanup);
 
-    test('rpc', async () => {
+    test('rpc', async ({ onTestFinished }) => {
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
       const services = { test: TestServiceSchema };
@@ -73,7 +65,7 @@ describe.each(testMatrix())(
       await waitFor(() => expect(serverTransport.connections.size).toEqual(0));
     });
 
-    test('stream', async () => {
+    test('stream', async ({ onTestFinished }) => {
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
       const services = { test: TestServiceSchema };
@@ -120,7 +112,7 @@ describe.each(testMatrix())(
       await waitFor(() => expect(serverTransport.connections.size).toEqual(0));
     });
 
-    test('subscription', async () => {
+    test('subscription', async ({ onTestFinished }) => {
       const client1Transport = getClientTransport('client1');
       const client2Transport = getClientTransport('client2');
       const serverTransport = getServerTransport();
@@ -211,7 +203,7 @@ describe.each(testMatrix())(
       close2();
     });
 
-    test('upload', async () => {
+    test('upload', async ({ onTestFinished }) => {
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
       const services = {

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -1,12 +1,4 @@
-import {
-  afterAll,
-  assert,
-  describe,
-  expect,
-  onTestFinished,
-  test,
-  vi,
-} from 'vitest';
+import { afterAll, assert, describe, expect, test, vi } from 'vitest';
 import { iterNext } from '../util/testHelpers';
 import { createServer } from '../router/server';
 import { createClient } from '../router/client';
@@ -44,7 +36,7 @@ describe.each(testMatrix())(
       await transport.setup({ client: opts, server: opts });
     afterAll(cleanup);
 
-    test('rpc', async () => {
+    test('rpc', async ({ onTestFinished }) => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
@@ -68,7 +60,7 @@ describe.each(testMatrix())(
       expect(result.payload).toStrictEqual({ result: 3 });
     });
 
-    test('fallible rpc', async () => {
+    test('fallible rpc', async ({ onTestFinished }) => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
@@ -103,7 +95,7 @@ describe.each(testMatrix())(
       });
     });
 
-    test('rpc with binary (uint8array)', async () => {
+    test('rpc with binary (uint8array)', async ({ onTestFinished }) => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
@@ -132,7 +124,7 @@ describe.each(testMatrix())(
       );
     });
 
-    test('stream', async () => {
+    test('stream', async ({ onTestFinished }) => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
@@ -176,7 +168,7 @@ describe.each(testMatrix())(
       close();
     });
 
-    test('stream with init message', async () => {
+    test('stream with init message', async ({ onTestFinished }) => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
@@ -214,7 +206,7 @@ describe.each(testMatrix())(
       close();
     });
 
-    test('fallible stream', async () => {
+    test('fallible stream', async ({ onTestFinished }) => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
@@ -257,7 +249,7 @@ describe.each(testMatrix())(
       close();
     });
 
-    test('subscription', async () => {
+    test('subscription', async ({ onTestFinished }) => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
@@ -302,7 +294,7 @@ describe.each(testMatrix())(
       close();
     });
 
-    test('upload', async () => {
+    test('upload', async ({ onTestFinished }) => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
@@ -333,7 +325,7 @@ describe.each(testMatrix())(
       expect(result.payload).toStrictEqual({ result: 3 });
     });
 
-    test('upload with init message', async () => {
+    test('upload with init message', async ({ onTestFinished }) => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
@@ -366,7 +358,9 @@ describe.each(testMatrix())(
       expect(result.payload).toStrictEqual({ result: 'test 3' });
     });
 
-    test('message order is preserved in the face of disconnects', async () => {
+    test('message order is preserved in the face of disconnects', async ({
+      onTestFinished,
+    }) => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
@@ -416,7 +410,7 @@ describe.each(testMatrix())(
     });
 
     const CONCURRENCY = 10;
-    test('concurrent rpcs', async () => {
+    test('concurrent rpcs', async ({ onTestFinished }) => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
@@ -449,7 +443,7 @@ describe.each(testMatrix())(
       }
     });
 
-    test('concurrent streams', async () => {
+    test('concurrent streams', async ({ onTestFinished }) => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
@@ -495,7 +489,9 @@ describe.each(testMatrix())(
       }
     });
 
-    test('eagerlyConnect should actually eagerly connect', async () => {
+    test('eagerlyConnect should actually eagerly connect', async ({
+      onTestFinished,
+    }) => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
@@ -518,7 +514,9 @@ describe.each(testMatrix())(
       await waitFor(() => expect(clientTransport.connections.size).toEqual(1));
     });
 
-    test('client reconnects even after session grace', async () => {
+    test('client reconnects even after session grace', async ({
+      onTestFinished,
+    }) => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
@@ -561,7 +559,9 @@ describe.each(testMatrix())(
       expect(result.payload).toStrictEqual({ result: 7 });
     });
 
-    test("client doesn't reconnect after session grace if connectOnInvoke is false", async () => {
+    test("client doesn't reconnect after session grace if connectOnInvoke is false", async ({
+      onTestFinished,
+    }) => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
@@ -602,7 +602,7 @@ describe.each(testMatrix())(
       expect(connectMock).not.toHaveBeenCalled();
     });
 
-    test('works with non-object schemas', async () => {
+    test('works with non-object schemas', async ({ onTestFinished }) => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
@@ -638,7 +638,9 @@ describe.each(testMatrix())(
       expect(result2.payload).toStrictEqual(weirdRecursivePayload);
     });
 
-    test('calls service dispose methods on cleanup', async () => {
+    test('calls service dispose methods on cleanup', async ({
+      onTestFinished,
+    }) => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
@@ -660,7 +662,7 @@ describe.each(testMatrix())(
       expect(dispose).toBeCalledTimes(1);
     });
 
-    test('procedure can use metadata', async () => {
+    test('procedure can use metadata', async ({ onTestFinished }) => {
       // setup
       const requestSchema = Type.Object({
         data: Type.String(),

--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -1,5 +1,5 @@
 // test a ws <-> uds multiplex proxy (many uds servers behind a ws server so there is only a single ws connection but multiple servers)
-import { test, onTestFinished, assert, expect } from 'vitest';
+import { describe, test, assert, expect } from 'vitest';
 import net from 'node:net';
 import http from 'node:http';
 import {
@@ -19,80 +19,82 @@ import { testFinishesCleanly } from './fixtures/cleanup';
 import { UnixDomainSocketServerTransport } from '../transport/impls/uds/server';
 import { MessageFramer } from '../transport/transforms/messageFraming';
 
-test('ws <-> uds proxy works', async () => {
-  // Setup uds server
-  const socketPath = getUnixSocketPath();
-  const udsServer = net.createServer();
-  await onUdsServeReady(udsServer, socketPath);
+describe('proxy', () => {
+  test('ws <-> uds proxy works', async ({ onTestFinished }) => {
+    // Setup uds server
+    const socketPath = getUnixSocketPath();
+    const udsServer = net.createServer();
+    await onUdsServeReady(udsServer, socketPath);
 
-  // setup ws server (acting as a proxy)
-  const proxyServer = http.createServer();
-  const port = await onWsServerReady(proxyServer);
-  const wss = createWebSocketServer(proxyServer);
+    // setup ws server (acting as a proxy)
+    const proxyServer = http.createServer();
+    const port = await onWsServerReady(proxyServer);
+    const wss = createWebSocketServer(proxyServer);
 
-  // dumb proxy
-  // assume that we are using the binary msgpack protocol
-  wss.on('connection', (ws) => {
-    const framer = MessageFramer.createFramedStream();
-    ws.onmessage = (msg) => {
-      const data = msg.data as Uint8Array;
-      const res = BinaryCodec.fromBuffer(data);
-      if (!res) return;
-      if (!Value.Check(OpaqueTransportMessageSchema, res)) {
-        return;
-      }
+    // dumb proxy
+    // assume that we are using the binary msgpack protocol
+    wss.on('connection', (ws) => {
+      const framer = MessageFramer.createFramedStream();
+      ws.onmessage = (msg) => {
+        const data = msg.data as Uint8Array;
+        const res = BinaryCodec.fromBuffer(data);
+        if (!res) return;
+        if (!Value.Check(OpaqueTransportMessageSchema, res)) {
+          return;
+        }
 
-      uds.write(MessageFramer.write(data));
-    };
+        uds.write(MessageFramer.write(data));
+      };
 
-    // forward messages from uds servers to ws
-    const uds = net.createConnection(socketPath);
-    uds.pipe(framer).on('data', (data: Uint8Array) => {
-      const res = BinaryCodec.fromBuffer(data);
-      if (!res) return;
-      if (!Value.Check(OpaqueTransportMessageSchema, res)) {
-        return;
-      }
+      // forward messages from uds servers to ws
+      const uds = net.createConnection(socketPath);
+      uds.pipe(framer).on('data', (data: Uint8Array) => {
+        const res = BinaryCodec.fromBuffer(data);
+        if (!res) return;
+        if (!Value.Check(OpaqueTransportMessageSchema, res)) {
+          return;
+        }
 
-      ws.send(data);
+        ws.send(data);
+      });
+
+      ws.onclose = () => {
+        uds.destroy();
+      };
     });
 
-    ws.onclose = () => {
-      uds.destroy();
-    };
-  });
+    // setup transports
+    const serverTransport = new UnixDomainSocketServerTransport(
+      udsServer,
+      'uds',
+      { codec: BinaryCodec },
+    );
+    const services = { test: TestServiceSchema };
+    const server = createServer(serverTransport, services);
+    const clientTransport = new WebSocketClientTransport(
+      () => Promise.resolve(createLocalWebSocketClient(port)),
+      'ws',
+      { codec: BinaryCodec },
+    );
+    const client = createClient<typeof services>(
+      clientTransport,
+      serverTransport.clientId,
+    );
+    onTestFinished(async () => {
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+        server,
+      });
 
-  // setup transports
-  const serverTransport = new UnixDomainSocketServerTransport(
-    udsServer,
-    'uds',
-    { codec: BinaryCodec },
-  );
-  const services = { test: TestServiceSchema };
-  const server = createServer(serverTransport, services);
-  const clientTransport = new WebSocketClientTransport(
-    () => Promise.resolve(createLocalWebSocketClient(port)),
-    'ws',
-    { codec: BinaryCodec },
-  );
-  const client = createClient<typeof services>(
-    clientTransport,
-    serverTransport.clientId,
-  );
-  onTestFinished(async () => {
-    await testFinishesCleanly({
-      clientTransports: [clientTransport],
-      serverTransport,
-      server,
+      udsServer.close();
+      wss.close();
+      proxyServer.close();
     });
 
-    udsServer.close();
-    wss.close();
-    proxyServer.close();
+    // test
+    const result = await client.test.add.rpc({ n: 3 });
+    assert(result.ok);
+    expect(result.payload).toStrictEqual({ result: 3 });
   });
-
-  // test
-  const result = await client.test.add.rpc({ n: 3 });
-  assert(result.ok);
-  expect(result.payload).toStrictEqual({ result: 3 });
 });

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -1,12 +1,4 @@
-import {
-  describe,
-  test,
-  expect,
-  afterAll,
-  vi,
-  onTestFinished,
-  assert,
-} from 'vitest';
+import { describe, test, expect, afterAll, vi, assert } from 'vitest';
 import {
   createDummyTransportMessage,
   payloadToTransportMessage,
@@ -31,7 +23,9 @@ describe.each(testMatrix())(
       await transport.setup({ client: opts, server: opts });
     afterAll(cleanup);
 
-    test('connection is recreated after clean client disconnect', async () => {
+    test('connection is recreated after clean client disconnect', async ({
+      onTestFinished,
+    }) => {
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
       onTestFinished(async () => {
@@ -58,7 +52,7 @@ describe.each(testMatrix())(
       ).resolves.toStrictEqual(msg2.payload);
     });
 
-    test('idle transport cleans up nicely', async () => {
+    test('idle transport cleans up nicely', async ({ onTestFinished }) => {
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
       await waitFor(() => expect(serverTransport.connections.size).toBe(1));
@@ -70,7 +64,9 @@ describe.each(testMatrix())(
       });
     });
 
-    test('heartbeats should not interupt normal operation', async () => {
+    test('heartbeats should not interupt normal operation', async ({
+      onTestFinished,
+    }) => {
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
       onTestFinished(async () => {
@@ -97,7 +93,9 @@ describe.each(testMatrix())(
       }
     });
 
-    test('sending right after session event should not cause invalid handshake', async () => {
+    test('sending right after session event should not cause invalid handshake', async ({
+      onTestFinished,
+    }) => {
       const clientTransport = getClientTransport('client');
       const protocolError = vi.fn();
       clientTransport.addEventListener('protocolError', protocolError);
@@ -125,7 +123,9 @@ describe.each(testMatrix())(
       expect(protocolError).toHaveBeenCalledTimes(0);
     });
 
-    test('seq numbers should be persisted across transparent reconnects', async () => {
+    test('seq numbers should be persisted across transparent reconnects', async ({
+      onTestFinished,
+    }) => {
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
       onTestFinished(async () => {
@@ -196,7 +196,9 @@ describe.each(testMatrix())(
       ).resolves.toStrictEqual(clientMsgs.map((msg) => msg.payload));
     });
 
-    test('both client and server transport get connect/disconnect notifs', async () => {
+    test('both client and server transport get connect/disconnect notifs', async ({
+      onTestFinished,
+    }) => {
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
       const clientConnStart = vi.fn();
@@ -387,7 +389,7 @@ describe.each(testMatrix())(
       serverTransport.close();
     });
 
-    test('multiple connections works', async () => {
+    test('multiple connections works', async ({ onTestFinished }) => {
       const clientId1 = 'client1';
       const clientId2 = 'client2';
       const serverId = 'SERVER';
@@ -439,12 +441,13 @@ describe.each(testMatrix())(
 describe.each(testMatrix())(
   'transport connection edge cases ($transport.name transport, $codec.name codec)',
   ({ transport, codec }) => {
-    test('messages should not be resent when the client loses all state and reconnects to the server', async () => {
+    test('messages should not be resent when the client loses all state and reconnects to the server', async ({
+      onTestFinished,
+    }) => {
       const opts = { codec: codec.codec };
       const { getClientTransport, getServerTransport, cleanup } =
         await transport.setup({ client: opts, server: opts });
       onTestFinished(cleanup);
-
       let clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
       const serverConnStart = vi.fn();
@@ -531,7 +534,9 @@ describe.each(testMatrix())(
       ).resolves.toStrictEqual(msg4.payload);
     });
 
-    test('messages should not be resent when client reconnects to a different instance of the server', async () => {
+    test('messages should not be resent when client reconnects to a different instance of the server', async ({
+      onTestFinished,
+    }) => {
       const opts = { codec: codec.codec };
       const { getClientTransport, getServerTransport, restartServer, cleanup } =
         await transport.setup({ client: opts, server: opts });
@@ -634,7 +639,7 @@ describe.each(testMatrix())(
       ).resolves.toStrictEqual(msg4.payload);
     });
 
-    test('recovers from phantom disconnects', async () => {
+    test('recovers from phantom disconnects', async ({ onTestFinished }) => {
       const opts = { codec: codec.codec };
       const {
         getClientTransport,
@@ -774,7 +779,9 @@ describe.each(testMatrix())(
       await transport.setup({ client: opts, server: opts });
     afterAll(cleanup);
 
-    test('handshakes and stores parsed metadata in session', async () => {
+    test('handshakes and stores parsed metadata in session', async ({
+      onTestFinished,
+    }) => {
       const schema = Type.Object({
         kept: Type.String(),
         discarded: Type.String(),
@@ -813,11 +820,13 @@ describe.each(testMatrix())(
         kept: 'kept',
       });
 
-      expect(clientTransport.connections.size).toBe(1);
+      await waitFor(() => expect(clientTransport.connections.size).toBe(1));
       expect(serverTransport.connections.size).toBe(1);
     });
 
-    test('client checks request schema on construction', async () => {
+    test('client checks request schema on construction', async ({
+      onTestFinished,
+    }) => {
       const schema = Type.Object({
         foo: Type.String(),
       });
@@ -868,7 +877,9 @@ describe.each(testMatrix())(
       expect(serverTransport.connections.size).toBe(0);
     });
 
-    test('server checks request schema on receive', async () => {
+    test('server checks request schema on receive', async ({
+      onTestFinished,
+    }) => {
       const clientRequestSchema = Type.Object({
         foo: Type.Number(),
       });
@@ -932,7 +943,9 @@ describe.each(testMatrix())(
       });
     });
 
-    test('server gets previous parsed metadata on reconnect', async () => {
+    test('server gets previous parsed metadata on reconnect', async ({
+      onTestFinished,
+    }) => {
       const schema = Type.Object({
         kept: Type.String(),
         discarded: Type.String(),
@@ -978,7 +991,7 @@ describe.each(testMatrix())(
         kept: 'kept',
       });
 
-      expect(clientTransport.connections.size).toBe(1);
+      await waitFor(() => expect(clientTransport.connections.size).toBe(1));
       expect(serverTransport.connections.size).toBe(1);
 
       // now, let's wait until the connection is considered dead
@@ -1001,7 +1014,7 @@ describe.each(testMatrix())(
       );
     });
 
-    test('parse can reject connection', async () => {
+    test('parse can reject connection', async ({ onTestFinished }) => {
       const schema = Type.Object({
         foo: Type.String(),
       });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,5 +7,9 @@ export default defineConfig({
     coverage: {
       exclude: [...coverageConfigDefaults.exclude, '**/.direnv/**'],
     },
+    sequence: {
+      hooks: 'stack',
+    },
+    fileParallelism: false,
   },
 });


### PR DESCRIPTION
## Why

The tests were flaky. Really flaky. They didn't show up their flakiness because they were only run once, but any time they were repeated more than once, it was Flake City, USA.

## What changed

This change does quite a few things:
* Stops using vitest's global `onTestFinished` in favor of the per-test one: the former runs _asynchronously_, and also runs only once per test suite (not per test case). This means that all the cleanup and timer shenanigans are done concurrently with other tests (even if vitest only does file-level parallelism!), so that messes up the global state a lot.
  * in other words, it is completely legal for two copies of `cleanup.ts`' `testFinishesCleanly()` to run concurrently with each other. The first copy will call `vi.useFakeTimers(...)`, hit an `await` point, and then control passes to the second copy, which will hit the line where `vi.useRealTimers()` is reached. Then the first copy runs again and will continue running thinking everything is fine, try to advance a timer and explode.
* Tells vitest to run all hooks as stacks, and avoid file parallelism for extra correctness.

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change