### PR TITLE
[river] Prevent drift between sessions and connections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.23.8",
+  "version": "0.23.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.23.8",
+      "version": "0.23.9",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.23.8",
+  "version": "0.23.9",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Why

We have a few invariant violations caused because of the fact that during the initial connection establishment, we do not associate the connection with the session. That means that anything that tries to interact with the session and expects the connection to be there (e.g. the grace period timeout) will not see the connection there and proceed to close the session but not the connection!

## What changed

This change adds a new field to the session: `handshakingConn`, which is used to hold the associated handshaking connection but without promoting it to a full connection (which would cause some mayhem with the rest of the state machinery). It still allows the transport to request for it to be closed safely so that even if we are extremely unlucky and the grace period elapses mid-handshake in another session, we can be safe about the global state and won't leave the peer with a dangling connection that cannot be used. Finally, it also ensures to clear any existing grace period callbacks when installing a new one, to avoid the case where a partial connection overwrites an existing grace period timeout, and then the next time the client connects, the forgotten grace period fires and causes mayhem.

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change