### PR TITLE
Fix mutating listeners during a notification changing behavior of current notification

### DIFF
--- a/transport/events.test.ts
+++ b/transport/events.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test, vitest } from 'vitest';
+import { EventDispatcher } from './events';
+import { OpaqueTransportMessage } from '.';
+import { nanoid } from 'nanoid';
+
+function dummyMessage(): OpaqueTransportMessage {
+  return {
+    id: nanoid(),
+    from: nanoid(),
+    to: nanoid(),
+    seq: 0,
+    ack: 0,
+    streamId: nanoid(),
+    controlFlags: 0,
+    payload: nanoid(),
+  };
+}
+
+describe('EventDispatcher', () => {
+  test('notifies all handlers in order they were registered', () => {
+    const dispatcher = new EventDispatcher();
+
+    const handler1 = vitest.fn();
+    const handler2 = vitest.fn();
+    const sessionStatusHandler = vitest.fn();
+
+    dispatcher.addEventListener('message', handler1);
+    dispatcher.addEventListener('message', handler2);
+    dispatcher.addEventListener('sessionStatus', sessionStatusHandler);
+
+    expect(dispatcher.numberOfListeners('message')).toEqual(2);
+
+    const message = dummyMessage();
+
+    dispatcher.dispatchEvent('message', message);
+
+    expect(handler1).toHaveBeenCalledTimes(1);
+    expect(handler2).toHaveBeenCalledTimes(1);
+    expect(handler1).toHaveBeenCalledWith(message);
+    expect(handler2).toHaveBeenCalledWith(message);
+    expect(handler1.mock.invocationCallOrder[0]).toBeLessThan(
+      handler2.mock.invocationCallOrder[0],
+    );
+    expect(sessionStatusHandler).toHaveBeenCalledTimes(0);
+  });
+
+  test('does not notify removed handlers', () => {
+    const dispatcher = new EventDispatcher();
+
+    const handler1 = vitest.fn();
+    const handler2 = vitest.fn();
+
+    dispatcher.addEventListener('message', handler1);
+    dispatcher.addEventListener('message', handler2);
+
+    dispatcher.removeEventListener('message', handler1);
+    dispatcher.removeEventListener('message', function neverRegistered() {
+      /** */
+    });
+
+    expect(dispatcher.numberOfListeners('message')).toEqual(1);
+
+    const message = dummyMessage();
+
+    dispatcher.dispatchEvent('message', message);
+
+    expect(handler1).toHaveBeenCalledTimes(0);
+    expect(handler2).toHaveBeenCalledTimes(1);
+    expect(handler2).toHaveBeenCalledWith(message);
+  });
+
+  test('does not notify handlers added while notifying another handler', () => {
+    const dispatcher = new EventDispatcher();
+
+    const handler1 = vitest.fn(() => {
+      dispatcher.addEventListener('message', handler2);
+    });
+    const handler2 = vitest.fn();
+
+    dispatcher.addEventListener('message', handler1);
+
+    const message = dummyMessage();
+
+    dispatcher.dispatchEvent('message', message);
+
+    expect(handler1).toHaveBeenCalledTimes(1);
+    expect(handler2).toHaveBeenCalledTimes(0);
+
+    dispatcher.dispatchEvent('message', message);
+
+    expect(handler1).toHaveBeenCalledTimes(2);
+    expect(handler2).toHaveBeenCalledTimes(1);
+  });
+
+  test('does notify handlers removed while notifying another handler', () => {
+    const dispatcher = new EventDispatcher();
+
+    const handler1 = vitest.fn();
+    const handler2 = vitest.fn(() => {
+      dispatcher.removeEventListener('message', handler1);
+    });
+
+    dispatcher.addEventListener('message', handler1);
+    dispatcher.addEventListener('message', handler2);
+
+    const message = dummyMessage();
+
+    dispatcher.dispatchEvent('message', message);
+
+    expect(handler1).toHaveBeenCalledTimes(1);
+    expect(handler2).toHaveBeenCalledTimes(1);
+
+    dispatcher.dispatchEvent('message', message);
+
+    expect(handler1).toHaveBeenCalledTimes(1);
+    expect(handler2).toHaveBeenCalledTimes(2);
+  });
+});

--- a/transport/events.ts
+++ b/transport/events.ts
@@ -58,7 +58,10 @@ export class EventDispatcher<T extends EventTypes> {
   dispatchEvent<K extends T>(eventType: K, event: EventMap[K]) {
     const handlers = this.eventListeners[eventType];
     if (handlers) {
-      for (const handler of handlers) {
+      // copying ensures that adding more listeners in a handler doesn't
+      // affect the current dispatch.
+      const copy = [...handlers];
+      for (const handler of copy) {
         handler(event);
       }
     }


### PR DESCRIPTION


## Why

Standard behavior of event emitter is to just emit to currently registered handler, any handler registered during the emit phase is not emitted to.

## What changed

- Copy the handler list before notifying
- Added some tests

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
