### PR TITLE
Emit status events when transport status changes

### DIFF
--- a/__tests__/fixtures/cleanup.ts
+++ b/__tests__/fixtures/cleanup.ts
@@ -45,7 +45,7 @@ export async function advanceFakeTimersBySessionGrace() {
 
 async function ensureTransportIsClean(t: Transport<Connection>) {
   expect(
-    t.state,
+    t.getStatus(),
     `[post-test cleanup] transport ${t.clientId} should be closed after the test`,
   ).to.not.equal('open');
 

--- a/transport/events.ts
+++ b/transport/events.ts
@@ -1,3 +1,4 @@
+import { TransportStatus } from '.';
 import { OpaqueTransportMessage } from './message';
 import { Connection, Session } from './session';
 
@@ -25,6 +26,9 @@ export interface EventMap {
   protocolError: {
     type: ProtocolErrorType;
     message: string;
+  };
+  transportStatus: {
+    status: TransportStatus;
   };
 }
 

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -377,7 +377,7 @@ describe.each(testMatrix())(
       clientTransport.destroy();
 
       // this is not expected to be clean because we destroyed the transport
-      expect(clientTransport.state).toEqual('destroyed');
+      expect(clientTransport.getStatus()).toEqual('destroyed');
       await waitFor(() =>
         expect(
           clientTransport.connections,


### PR DESCRIPTION
## Why

I need this in #127, thought I'd pull it out. Doesn't hurt to have generally.

## What changed

- `state` is now private and called `status`
- emit status when status changes

## Versioning

- [ ] Breaking protocol change
- [x] Breaking ts/js API change
  -  public `state` on transport is now `getStatus()`

<!-- Kind reminder to add tests and updated documentation if needed -->
