### PR TITLE
Remove destroy state from transport, close is now destroy

### DIFF
--- a/__tests__/negative.test.ts
+++ b/__tests__/negative.test.ts
@@ -35,7 +35,7 @@ describe('should handle incompatabilities', async () => {
     });
   });
 
-  test('emits use after destroy events', async ({ onTestFinished }) => {
+  test('throws when sending after close', async ({ onTestFinished }) => {
     const clientTransport = new WebSocketClientTransport(
       () => Promise.resolve(createLocalWebSocketClient(port)),
       'client',
@@ -55,16 +55,13 @@ describe('should handle incompatabilities', async () => {
       });
     });
 
-    clientTransport.destroy();
-    const msg = createDummyTransportMessage();
-    clientTransport.send(serverTransport.clientId, msg);
-
-    expect(errMock).toHaveBeenCalledTimes(1);
-    expect(errMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: ProtocolError.UseAfterDestroy,
-      }),
-    );
+    clientTransport.close();
+    expect(() =>
+      clientTransport.send(
+        serverTransport.clientId,
+        createDummyTransportMessage(),
+      ),
+    ).toThrow();
   });
 
   test('retrying single connection attempt should hit retry limit reached', async ({

--- a/transport/events.ts
+++ b/transport/events.ts
@@ -6,7 +6,6 @@ type ConnectionStatus = 'connect' | 'disconnect';
 export const ProtocolError = {
   RetriesExceeded: 'conn_retry_exceeded',
   HandshakeFailed: 'handshake_failed',
-  UseAfterDestroy: 'use_after_destroy',
   MessageOrderingViolated: 'message_ordering_violated',
 } as const;
 

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -374,10 +374,10 @@ describe.each(testMatrix())(
         waitForMessage(serverTransport, (recv) => recv.id === msg1Id),
       ).resolves.toStrictEqual(msg1.payload);
 
-      clientTransport.destroy();
+      clientTransport.close();
 
-      // this is not expected to be clean because we destroyed the transport
-      expect(clientTransport.getStatus()).toEqual('destroyed');
+      // this is not expected to be clean because we closed the transport
+      expect(clientTransport.getStatus()).toEqual('closed');
       await waitFor(() =>
         expect(
           clientTransport.connections,


### PR DESCRIPTION
## Why

- Everywhere else in our code base, `close` is permanent and destructive
- There is currently no way of re-opening a transport, and I don't see us adding that

part of the stack at #184

## What changed

- get rid of `destroy` fn and `destroyed` state on transport
- send after `close` now throws an error


## Versioning

- [ ] Breaking protocol change
- [x] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
