### PR TITLE
Tie server lifetime to transport

### DIFF
--- a/__tests__/fixtures/cleanup.ts
+++ b/__tests__/fixtures/cleanup.ts
@@ -136,7 +136,6 @@ export async function testFinishesCleanly({
   if (server) {
     await advanceFakeTimersBySessionGrace();
     await ensureServerIsClean(server);
-    await server.close();
   }
 
   if (serverTransport) {

--- a/router/server.ts
+++ b/router/server.ts
@@ -44,7 +44,6 @@ import { ServerHandshakeOptions } from './handshake';
 export interface Server<Services extends AnyServiceSchemaMap> {
   services: InstantiatedServiceSchemaMap<Services>;
   streams: Map<string, ProcStream>;
-  close(): Promise<void>;
 }
 
 interface ProcStream {
@@ -102,6 +101,16 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
     this.transport.addEventListener('message', this.onMessage);
     this.transport.addEventListener('sessionStatus', this.onSessionStatus);
     this.log = transport.log;
+
+    this.transport.addEventListener('transportStatus', async ({ status }) => {
+      if (status !== 'closed') {
+        return;
+      }
+
+      this.transport.removeEventListener('message', this.onMessage);
+      this.transport.removeEventListener('sessionStatus', this.onSessionStatus);
+      await Promise.all([...this.streamMap.keys()].map(this.cleanupStream));
+    });
   }
 
   get streams() {
@@ -153,12 +162,6 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
     this.disconnectedSessions.delete(disconnectedClientId);
     this.clientStreams.delete(disconnectedClientId);
   };
-
-  async close() {
-    this.transport.removeEventListener('message', this.onMessage);
-    this.transport.removeEventListener('sessionStatus', this.onSessionStatus);
-    await Promise.all([...this.streamMap.keys()].map(this.cleanupStream));
-  }
 
   createNewProcStream(message: OpaqueTransportMessage) {
     if (!isStreamOpen(message.controlFlags)) {

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -497,6 +497,7 @@ export abstract class Transport<ConnType extends Connection> {
    * @param msg The message to send.
    * @returns The ID of the sent message or undefined if it wasn't sent
    */
+
   send(to: TransportClientId, msg: PartialTransportMessage): string {
     if (this.getStatus() === 'closed') {
       const err = 'transport is closed, cant send';


### PR DESCRIPTION
## Why

It's a little odd that the lifetime of a server can be disconnected from the transport's, I don't see us needing to close each separately.


## What changed

- Don't expose `close` on the server, run the server's cleanup after `transport` emits the closed event introduced in #184 


## Versioning

- [ ] Breaking protocol change
- [x] Breaking ts/js API change
  - Removed `server.close()`

<!-- Kind reminder to add tests and updated documentation if needed -->
