### PR TITLE
Remove all transport listeners on close

### DIFF
--- a/__tests__/fixtures/cleanup.ts
+++ b/__tests__/fixtures/cleanup.ts
@@ -56,21 +56,6 @@ async function ensureTransportIsClean(t: Transport<Connection>) {
       `[post-test cleanup] transport ${t.clientId} should not have open sessions after the test`,
     ).toStrictEqual(new Map()),
   );
-
-  expect(
-    t.eventDispatcher.numberOfListeners('message'),
-    `[post-test cleanup] transport ${t.clientId} should not have open message handlers after the test`,
-  ).equal(0);
-
-  expect(
-    t.eventDispatcher.numberOfListeners('sessionStatus'),
-    `[post-test cleanup] transport ${t.clientId} should not have open session status handlers after the test`,
-  ).equal(0);
-
-  expect(
-    t.eventDispatcher.numberOfListeners('connectionStatus'),
-    `[post-test cleanup] transport ${t.clientId} should not have open connection status handlers after the test`,
-  ).equal(0);
 }
 
 export function waitFor<T>(cb: () => T | Promise<T>) {

--- a/transport/events.test.ts
+++ b/transport/events.test.ts
@@ -115,4 +115,35 @@ describe('EventDispatcher', () => {
     expect(handler1).toHaveBeenCalledTimes(1);
     expect(handler2).toHaveBeenCalledTimes(2);
   });
+
+  test('removes all listeners', () => {
+    const dispatcher = new EventDispatcher();
+
+    const handler = vitest.fn();
+    dispatcher.addEventListener('message', handler);
+    dispatcher.addEventListener('connectionStatus', handler);
+    dispatcher.addEventListener('protocolError', handler);
+    dispatcher.addEventListener('sessionStatus', handler);
+    dispatcher.addEventListener('transportStatus', handler);
+
+    dispatcher.removeAllListeners();
+    expect(dispatcher.numberOfListeners('message')).toEqual(0);
+    expect(dispatcher.numberOfListeners('connectionStatus')).toEqual(0);
+    expect(dispatcher.numberOfListeners('protocolError')).toEqual(0);
+    expect(dispatcher.numberOfListeners('sessionStatus')).toEqual(0);
+    expect(dispatcher.numberOfListeners('transportStatus')).toEqual(0);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+    dispatcher.dispatchEvent('message', {} as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+    dispatcher.dispatchEvent('connectionStatus', {} as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+    dispatcher.dispatchEvent('protocolError', {} as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+    dispatcher.dispatchEvent('sessionStatus', {} as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+    dispatcher.dispatchEvent('transportStatus', {} as any);
+
+    expect(handler).toHaveBeenCalledTimes(0);
+  });
 });

--- a/transport/events.ts
+++ b/transport/events.ts
@@ -39,6 +39,10 @@ export type EventHandler<K extends EventTypes> = (
 export class EventDispatcher<T extends EventTypes> {
   private eventListeners: { [K in T]?: Set<EventHandler<K>> } = {};
 
+  removeAllListeners() {
+    this.eventListeners = {};
+  }
+
   numberOfListeners<K extends T>(eventType: K) {
     return this.eventListeners[eventType]?.size ?? 0;
   }

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -544,6 +544,8 @@ export abstract class Transport<ConnType extends Connection> {
       status: this.status,
     });
 
+    this.eventDispatcher.removeAllListeners();
+
     this.log?.info(`manually closed transport`, { clientId: this.clientId });
   }
 


### PR DESCRIPTION
## Why

Better cleanup to avoid leaks

## What changed

Introduced `removeAllListeners()` on `EventDispatcher`, and called it in `transport.close`

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
