### PR TITLE
Don't share servers among tests

### DIFF
--- a/__tests__/cleanup.test.ts
+++ b/__tests__/cleanup.test.ts
@@ -8,7 +8,7 @@ import {
 import { createClient, createServer } from '../router';
 import {
   advanceFakeTimersBySessionGrace,
-  createPostTestChecks,
+  createPostTestCleanups,
   ensureTransportBuffersAreEventuallyEmpty,
   testFinishesCleanly,
   waitFor,
@@ -22,7 +22,7 @@ describe.each(testMatrix())(
   async ({ transport, codec }) => {
     const opts = { codec: codec.codec };
 
-    const { onTestFinished, postTestChecks } = createPostTestChecks();
+    const { addPostTestCleanup, postTestCleanup } = createPostTestCleanups();
     let getClientTransport: TestSetupHelpers['getClientTransport'];
     let getServerTransport: TestSetupHelpers['getServerTransport'];
     beforeEach(async () => {
@@ -30,7 +30,7 @@ describe.each(testMatrix())(
       getClientTransport = setup.getClientTransport;
       getServerTransport = setup.getServerTransport;
       return async () => {
-        await postTestChecks();
+        await postTestCleanup();
         await setup.cleanup();
       };
     });
@@ -45,7 +45,7 @@ describe.each(testMatrix())(
         clientTransport,
         serverTransport.clientId,
       );
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -85,7 +85,7 @@ describe.each(testMatrix())(
         clientTransport,
         serverTransport.clientId,
       );
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -125,7 +125,7 @@ describe.each(testMatrix())(
         clientTransport,
         serverTransport.clientId,
       );
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -172,7 +172,7 @@ describe.each(testMatrix())(
         clientTransport,
         serverTransport.clientId,
       );
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -242,7 +242,7 @@ describe.each(testMatrix())(
         clientTransport,
         serverTransport.clientId,
       );
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -303,7 +303,7 @@ describe.each(testMatrix())(
         clientTransport,
         serverTransport.clientId,
       );
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -359,7 +359,7 @@ describe.each(testMatrix())(
         serverTransport.clientId,
       );
 
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,

--- a/__tests__/cleanup.test.ts
+++ b/__tests__/cleanup.test.ts
@@ -8,6 +8,7 @@ import {
 import { createClient, createServer } from '../router';
 import {
   advanceFakeTimersBySessionGrace,
+  createPostTestChecks,
   ensureTransportBuffersAreEventuallyEmpty,
   testFinishesCleanly,
   waitFor,
@@ -15,20 +16,6 @@ import {
 } from './fixtures/cleanup';
 import { testMatrix } from './fixtures/matrix';
 import { TestSetupHelpers } from './fixtures/transports';
-
-export const createPostTestChecks = () => {
-  const cleanupFns: Array<() => Promise<void>> = [];
-  return {
-    onTestFinished: (fn: () => Promise<void>) => {
-      cleanupFns.push(fn);
-    },
-    postTestChecks: async () => {
-      while (cleanupFns.length > 0) {
-        await cleanupFns.pop()?.();
-      }
-    },
-  };
-};
 
 describe.each(testMatrix())(
   'procedures should clean up after themselves ($transport.name transport, $codec.name codec)',

--- a/__tests__/disconnects.test.ts
+++ b/__tests__/disconnects.test.ts
@@ -14,7 +14,7 @@ import {
 import { Err, UNEXPECTED_DISCONNECT } from '../router/result';
 import { testMatrix } from './fixtures/matrix';
 import { TestSetupHelpers } from './fixtures/transports';
-import { createPostTestChecks } from './cleanup.test';
+import { createPostTestChecks } from './fixtures/cleanup';
 
 describe.each(testMatrix())(
   'procedures should handle unexpected disconnects ($transport.name transport, $codec.name codec)',

--- a/__tests__/disconnects.test.ts
+++ b/__tests__/disconnects.test.ts
@@ -14,14 +14,14 @@ import {
 import { Err, UNEXPECTED_DISCONNECT } from '../router/result';
 import { testMatrix } from './fixtures/matrix';
 import { TestSetupHelpers } from './fixtures/transports';
-import { createPostTestChecks } from './fixtures/cleanup';
+import { createPostTestCleanups } from './fixtures/cleanup';
 
 describe.each(testMatrix())(
   'procedures should handle unexpected disconnects ($transport.name transport, $codec.name codec)',
   async ({ transport, codec }) => {
     const opts = { codec: codec.codec };
 
-    const { onTestFinished, postTestChecks } = createPostTestChecks();
+    const { addPostTestCleanup, postTestCleanup } = createPostTestCleanups();
     let getClientTransport: TestSetupHelpers['getClientTransport'];
     let getServerTransport: TestSetupHelpers['getServerTransport'];
     beforeEach(async () => {
@@ -29,7 +29,7 @@ describe.each(testMatrix())(
       getClientTransport = setup.getClientTransport;
       getServerTransport = setup.getServerTransport;
       return async () => {
-        await postTestChecks();
+        await postTestCleanup();
         await setup.cleanup();
       };
     });
@@ -43,7 +43,7 @@ describe.each(testMatrix())(
         clientTransport,
         serverTransport.clientId,
       );
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -86,7 +86,7 @@ describe.each(testMatrix())(
         clientTransport,
         serverTransport.clientId,
       );
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -141,7 +141,7 @@ describe.each(testMatrix())(
         client2Transport,
         serverTransport.clientId,
       );
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [client1Transport, client2Transport],
           serverTransport,
@@ -226,7 +226,7 @@ describe.each(testMatrix())(
         clientTransport,
         serverTransport.clientId,
       );
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,

--- a/__tests__/disconnects.test.ts
+++ b/__tests__/disconnects.test.ts
@@ -1,4 +1,4 @@
-import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
+import { assert, beforeEach, describe, expect, test } from 'vitest';
 import { iterNext } from '../util/testHelpers';
 import {
   SubscribableServiceSchema,
@@ -8,6 +8,7 @@ import {
 import { createClient, createServer } from '../router';
 import {
   advanceFakeTimersBySessionGrace,
+  cleanupTransports,
   testFinishesCleanly,
   waitFor,
 } from './fixtures/cleanup';
@@ -44,11 +45,7 @@ describe.each(testMatrix())(
         serverTransport.clientId,
       );
       addPostTestCleanup(async () => {
-        await testFinishesCleanly({
-          clientTransports: [clientTransport],
-          serverTransport,
-          server,
-        });
+        await cleanupTransports([clientTransport, serverTransport]);
       });
 
       // start procedure
@@ -56,7 +53,6 @@ describe.each(testMatrix())(
       expect(clientTransport.connections.size).toEqual(1);
       expect(serverTransport.connections.size).toEqual(1);
 
-      vi.useFakeTimers({ shouldAdvanceTime: true });
       clientTransport.reconnectOnConnectionDrop = false;
       clientTransport.connections.forEach((conn) => conn.close());
 
@@ -75,6 +71,11 @@ describe.each(testMatrix())(
 
       await waitFor(() => expect(clientTransport.connections.size).toEqual(0));
       await waitFor(() => expect(serverTransport.connections.size).toEqual(0));
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+        server,
+      });
     });
 
     test('stream', async () => {
@@ -87,11 +88,7 @@ describe.each(testMatrix())(
         serverTransport.clientId,
       );
       addPostTestCleanup(async () => {
-        await testFinishesCleanly({
-          clientTransports: [clientTransport],
-          serverTransport,
-          server,
-        });
+        await cleanupTransports([clientTransport, serverTransport]);
       });
 
       // start procedure
@@ -103,7 +100,6 @@ describe.each(testMatrix())(
       expect(clientTransport.connections.size).toEqual(1);
       expect(serverTransport.connections.size).toEqual(1);
 
-      vi.useFakeTimers({ shouldAdvanceTime: true });
       clientTransport.reconnectOnConnectionDrop = false;
       clientTransport.connections.forEach((conn) => conn.close());
 
@@ -122,6 +118,11 @@ describe.each(testMatrix())(
 
       await waitFor(() => expect(clientTransport.connections.size).toEqual(0));
       await waitFor(() => expect(serverTransport.connections.size).toEqual(0));
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+        server,
+      });
     });
 
     test('subscription', async () => {
@@ -142,11 +143,11 @@ describe.each(testMatrix())(
         serverTransport.clientId,
       );
       addPostTestCleanup(async () => {
-        await testFinishesCleanly({
-          clientTransports: [client1Transport, client2Transport],
+        await cleanupTransports([
+          client1Transport,
+          client2Transport,
           serverTransport,
-          server,
-        });
+        ]);
       });
 
       // start procedure
@@ -181,7 +182,6 @@ describe.each(testMatrix())(
       expect(serverTransport.connections.size).toEqual(2);
 
       // kill the connection for client2
-      vi.useFakeTimers({ shouldAdvanceTime: true });
       client2Transport.reconnectOnConnectionDrop = false;
       client2Transport.connections.forEach((conn) => conn.close());
 
@@ -213,6 +213,11 @@ describe.each(testMatrix())(
       // cleanup client1 (client2 is already disconnected)
       close1();
       close2();
+      await testFinishesCleanly({
+        clientTransports: [client1Transport, client2Transport],
+        serverTransport,
+        server,
+      });
     });
 
     test('upload', async () => {
@@ -227,11 +232,7 @@ describe.each(testMatrix())(
         serverTransport.clientId,
       );
       addPostTestCleanup(async () => {
-        await testFinishesCleanly({
-          clientTransports: [clientTransport],
-          serverTransport,
-          server,
-        });
+        await cleanupTransports([clientTransport, serverTransport]);
       });
 
       // start procedure
@@ -245,7 +246,6 @@ describe.each(testMatrix())(
       await waitFor(() => expect(clientTransport.connections.size).toEqual(1));
       await waitFor(() => expect(serverTransport.connections.size).toEqual(1));
 
-      vi.useFakeTimers({ shouldAdvanceTime: true });
       clientTransport.reconnectOnConnectionDrop = false;
       clientTransport.connections.forEach((conn) => conn.close());
 
@@ -261,6 +261,11 @@ describe.each(testMatrix())(
 
       await waitFor(() => expect(clientTransport.connections.size).toEqual(0));
       await waitFor(() => expect(serverTransport.connections.size).toEqual(0));
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+        server,
+      });
     });
   },
 );

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -16,7 +16,7 @@ import {
 import { Ok, UNCAUGHT_ERROR } from '../router/result';
 import {
   advanceFakeTimersBySessionGrace,
-  createPostTestChecks,
+  createPostTestCleanups,
   testFinishesCleanly,
   waitFor,
 } from './fixtures/cleanup';
@@ -34,7 +34,7 @@ describe.each(testMatrix())(
   async ({ transport, codec }) => {
     const opts = { codec: codec.codec };
 
-    const { onTestFinished, postTestChecks } = createPostTestChecks();
+    const { addPostTestCleanup, postTestCleanup } = createPostTestCleanups();
     let getClientTransport: TestSetupHelpers['getClientTransport'];
     let getServerTransport: TestSetupHelpers['getServerTransport'];
     beforeEach(async () => {
@@ -42,7 +42,7 @@ describe.each(testMatrix())(
       getClientTransport = setup.getClientTransport;
       getServerTransport = setup.getServerTransport;
       return async () => {
-        await postTestChecks();
+        await postTestCleanup();
         await setup.cleanup();
       };
     });
@@ -57,7 +57,7 @@ describe.each(testMatrix())(
         clientTransport,
         serverTransport.clientId,
       );
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -83,7 +83,7 @@ describe.each(testMatrix())(
         clientTransport,
         serverTransport.clientId,
       );
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -118,7 +118,7 @@ describe.each(testMatrix())(
         clientTransport,
         serverTransport.clientId,
       );
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -145,7 +145,7 @@ describe.each(testMatrix())(
         clientTransport,
         serverTransport.clientId,
       );
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -189,7 +189,7 @@ describe.each(testMatrix())(
         clientTransport,
         serverTransport.clientId,
       );
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -229,7 +229,7 @@ describe.each(testMatrix())(
         clientTransport,
         serverTransport.clientId,
       );
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -272,7 +272,7 @@ describe.each(testMatrix())(
         clientTransport,
         serverTransport.clientId,
       );
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -317,7 +317,7 @@ describe.each(testMatrix())(
         clientTransport,
         serverTransport.clientId,
       );
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -348,7 +348,7 @@ describe.each(testMatrix())(
         clientTransport,
         serverTransport.clientId,
       );
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -381,7 +381,7 @@ describe.each(testMatrix())(
         clientTransport,
         serverTransport.clientId,
       );
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -431,7 +431,7 @@ describe.each(testMatrix())(
         clientTransport,
         serverTransport.clientId,
       );
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -462,7 +462,7 @@ describe.each(testMatrix())(
         clientTransport,
         serverTransport.clientId,
       );
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -508,7 +508,7 @@ describe.each(testMatrix())(
         eagerlyConnect: true,
       });
 
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -532,7 +532,7 @@ describe.each(testMatrix())(
         serverTransport.clientId,
         { connectOnInvoke: true },
       );
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -578,7 +578,7 @@ describe.each(testMatrix())(
         },
       );
 
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -617,7 +617,7 @@ describe.each(testMatrix())(
         clientTransport,
         serverTransport.clientId,
       );
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -658,7 +658,7 @@ describe.each(testMatrix())(
           };
         }),
       );
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -16,6 +16,7 @@ import {
 import { Ok, UNCAUGHT_ERROR } from '../router/result';
 import {
   advanceFakeTimersBySessionGrace,
+  cleanupTransports,
   createPostTestCleanups,
   testFinishesCleanly,
   waitFor,
@@ -58,17 +59,18 @@ describe.each(testMatrix())(
         serverTransport.clientId,
       );
       addPostTestCleanup(async () => {
-        await testFinishesCleanly({
-          clientTransports: [clientTransport],
-          serverTransport,
-          server,
-        });
+        await cleanupTransports([clientTransport, serverTransport]);
       });
 
       // test
       const result = await client.test.add.rpc({ n: 3 });
       assert(result.ok);
       expect(result.payload).toStrictEqual({ result: 3 });
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+        server,
+      });
     });
 
     test('fallible rpc', async () => {
@@ -84,11 +86,7 @@ describe.each(testMatrix())(
         serverTransport.clientId,
       );
       addPostTestCleanup(async () => {
-        await testFinishesCleanly({
-          clientTransports: [clientTransport],
-          serverTransport,
-          server,
-        });
+        await cleanupTransports([clientTransport, serverTransport]);
       });
 
       // test
@@ -103,6 +101,11 @@ describe.each(testMatrix())(
         extras: {
           test: 'abc',
         },
+      });
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+        server,
       });
     });
 
@@ -119,11 +122,7 @@ describe.each(testMatrix())(
         serverTransport.clientId,
       );
       addPostTestCleanup(async () => {
-        await testFinishesCleanly({
-          clientTransports: [clientTransport],
-          serverTransport,
-          server,
-        });
+        await cleanupTransports([clientTransport, serverTransport]);
       });
 
       // test
@@ -133,6 +132,12 @@ describe.each(testMatrix())(
       expect(new TextDecoder().decode(result.payload.contents)).toStrictEqual(
         'contents for file test.py',
       );
+
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+        server,
+      });
     });
 
     test('stream', async () => {
@@ -146,11 +151,7 @@ describe.each(testMatrix())(
         serverTransport.clientId,
       );
       addPostTestCleanup(async () => {
-        await testFinishesCleanly({
-          clientTransports: [clientTransport],
-          serverTransport,
-          server,
-        });
+        await cleanupTransports([clientTransport, serverTransport]);
       });
 
       // test
@@ -177,6 +178,12 @@ describe.each(testMatrix())(
       const result4 = await output.next();
       assert(result4.done);
       close();
+
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+        server,
+      });
     });
 
     test('stream with init message', async () => {
@@ -190,11 +197,7 @@ describe.each(testMatrix())(
         serverTransport.clientId,
       );
       addPostTestCleanup(async () => {
-        await testFinishesCleanly({
-          clientTransports: [clientTransport],
-          serverTransport,
-          server,
-        });
+        await cleanupTransports([clientTransport, serverTransport]);
       });
 
       // test
@@ -213,8 +216,13 @@ describe.each(testMatrix())(
       const result2 = await iterNext(output);
       assert(result2.ok);
       expect(result2.payload).toStrictEqual({ response: 'test ghi' });
-
       close();
+
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+        server,
+      });
     });
 
     test('fallible stream', async () => {
@@ -230,11 +238,7 @@ describe.each(testMatrix())(
         serverTransport.clientId,
       );
       addPostTestCleanup(async () => {
-        await testFinishesCleanly({
-          clientTransports: [clientTransport],
-          serverTransport,
-          server,
-        });
+        await cleanupTransports([clientTransport, serverTransport]);
       });
 
       // test
@@ -258,6 +262,12 @@ describe.each(testMatrix())(
       });
 
       close();
+
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+        server,
+      });
     });
 
     test('subscription', async () => {
@@ -273,11 +283,7 @@ describe.each(testMatrix())(
         serverTransport.clientId,
       );
       addPostTestCleanup(async () => {
-        await testFinishesCleanly({
-          clientTransports: [clientTransport],
-          serverTransport,
-          server,
-        });
+        await cleanupTransports([clientTransport, serverTransport]);
       });
 
       // test
@@ -303,6 +309,12 @@ describe.each(testMatrix())(
       expect(result.payload).toStrictEqual({ result: 4 });
 
       close();
+
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+        server,
+      });
     });
 
     test('upload', async () => {
@@ -318,11 +330,7 @@ describe.each(testMatrix())(
         serverTransport.clientId,
       );
       addPostTestCleanup(async () => {
-        await testFinishesCleanly({
-          clientTransports: [clientTransport],
-          serverTransport,
-          server,
-        });
+        await cleanupTransports([clientTransport, serverTransport]);
       });
 
       // test
@@ -334,6 +342,12 @@ describe.each(testMatrix())(
       const result = await addResult;
       assert(result.ok);
       expect(result.payload).toStrictEqual({ result: 3 });
+
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+        server,
+      });
     });
 
     test('upload with init message', async () => {
@@ -349,11 +363,7 @@ describe.each(testMatrix())(
         serverTransport.clientId,
       );
       addPostTestCleanup(async () => {
-        await testFinishesCleanly({
-          clientTransports: [clientTransport],
-          serverTransport,
-          server,
-        });
+        await cleanupTransports([clientTransport, serverTransport]);
       });
 
       // test
@@ -367,6 +377,11 @@ describe.each(testMatrix())(
       const result = await addResult;
       assert(result.ok);
       expect(result.payload).toStrictEqual({ result: 'test 3' });
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+        server,
+      });
     });
 
     test('message order is preserved in the face of disconnects', async () => {
@@ -382,11 +397,7 @@ describe.each(testMatrix())(
         serverTransport.clientId,
       );
       addPostTestCleanup(async () => {
-        await testFinishesCleanly({
-          clientTransports: [clientTransport],
-          serverTransport,
-          server,
-        });
+        await cleanupTransports([clientTransport, serverTransport]);
       });
 
       // test
@@ -416,6 +427,11 @@ describe.each(testMatrix())(
       const res = await client.test.getAll.rpc({});
       assert(res.ok);
       expect(res.payload.msgs).toStrictEqual(expected);
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+        server,
+      });
     });
 
     const CONCURRENCY = 10;
@@ -432,11 +448,7 @@ describe.each(testMatrix())(
         serverTransport.clientId,
       );
       addPostTestCleanup(async () => {
-        await testFinishesCleanly({
-          clientTransports: [clientTransport],
-          serverTransport,
-          server,
-        });
+        await cleanupTransports([clientTransport, serverTransport]);
       });
 
       // test
@@ -450,6 +462,12 @@ describe.each(testMatrix())(
         assert(result.ok);
         expect(result.payload).toStrictEqual({ n: i });
       }
+
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+        server,
+      });
     });
 
     test('concurrent streams', async () => {
@@ -463,11 +481,7 @@ describe.each(testMatrix())(
         serverTransport.clientId,
       );
       addPostTestCleanup(async () => {
-        await testFinishesCleanly({
-          clientTransports: [clientTransport],
-          serverTransport,
-          server,
-        });
+        await cleanupTransports([clientTransport, serverTransport]);
       });
 
       // test
@@ -496,6 +510,12 @@ describe.each(testMatrix())(
         const [_input, _output, close] = openStreams[i];
         close();
       }
+
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+        server,
+      });
     });
 
     test('eagerlyConnect should actually eagerly connect', async () => {
@@ -509,16 +529,17 @@ describe.each(testMatrix())(
       });
 
       addPostTestCleanup(async () => {
-        await testFinishesCleanly({
-          clientTransports: [clientTransport],
-          serverTransport,
-          server,
-        });
+        await cleanupTransports([clientTransport, serverTransport]);
       });
 
       // test
       await waitFor(() => expect(serverTransport.connections.size).toEqual(1));
       await waitFor(() => expect(clientTransport.connections.size).toEqual(1));
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+        server,
+      });
     });
 
     test('client reconnects even after session grace', async () => {
@@ -533,11 +554,7 @@ describe.each(testMatrix())(
         { connectOnInvoke: true },
       );
       addPostTestCleanup(async () => {
-        await testFinishesCleanly({
-          clientTransports: [clientTransport],
-          serverTransport,
-          server,
-        });
+        await cleanupTransports([clientTransport, serverTransport]);
       });
 
       await client.test.add.rpc({ n: 3 });
@@ -545,7 +562,6 @@ describe.each(testMatrix())(
       await waitFor(() => expect(clientTransport.connections.size).toEqual(1));
 
       // kill the session
-      vi.useFakeTimers({ shouldAdvanceTime: true });
       clientTransport.reconnectOnConnectionDrop = false;
       clientTransport.connections.forEach((conn) => conn.close());
       await advanceFakeTimersBySessionGrace();
@@ -562,6 +578,11 @@ describe.each(testMatrix())(
       const result = await resultPromise;
       assert(result.ok);
       expect(result.payload).toStrictEqual({ result: 7 });
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+        server,
+      });
     });
 
     test("client doesn't reconnect after session grace if connectOnInvoke is false", async () => {
@@ -579,18 +600,13 @@ describe.each(testMatrix())(
       );
 
       addPostTestCleanup(async () => {
-        await testFinishesCleanly({
-          clientTransports: [clientTransport],
-          serverTransport,
-          server,
-        });
+        await cleanupTransports([clientTransport, serverTransport]);
       });
 
       await waitFor(() => expect(serverTransport.connections.size).toEqual(1));
       await waitFor(() => expect(clientTransport.connections.size).toEqual(1));
 
       // kill the session
-      vi.useFakeTimers({ shouldAdvanceTime: true });
       clientTransport.reconnectOnConnectionDrop = false;
       clientTransport.connections.forEach((conn) => conn.close());
       await advanceFakeTimersBySessionGrace();
@@ -600,9 +616,21 @@ describe.each(testMatrix())(
       expect(clientTransport.connections.size).toEqual(0);
 
       // client should not reconnect when making another call
-      void client.test.add.rpc({ n: 4 });
+      const resultPromise = client.test.add.rpc({ n: 4 });
       const connectMock = vi.spyOn(clientTransport, 'connect');
       expect(connectMock).not.toHaveBeenCalled();
+
+      // connect and ensure that we still get the result
+      await clientTransport.connect(serverTransport.clientId);
+      const result = await resultPromise;
+      assert(result.ok);
+      expect(result.payload).toStrictEqual({ result: 4 });
+
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+        server,
+      });
     });
 
     test('works with non-object schemas', async () => {
@@ -618,11 +646,7 @@ describe.each(testMatrix())(
         serverTransport.clientId,
       );
       addPostTestCleanup(async () => {
-        await testFinishesCleanly({
-          clientTransports: [clientTransport],
-          serverTransport,
-          server,
-        });
+        await cleanupTransports([clientTransport, serverTransport]);
       });
 
       // test
@@ -639,6 +663,11 @@ describe.each(testMatrix())(
       );
       assert(result2.ok);
       expect(result2.payload).toStrictEqual(weirdRecursivePayload);
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+        server,
+      });
     });
 
     test('procedure can use metadata', async () => {
@@ -659,11 +688,7 @@ describe.each(testMatrix())(
         }),
       );
       addPostTestCleanup(async () => {
-        await testFinishesCleanly({
-          clientTransports: [clientTransport],
-          serverTransport,
-          server,
-        });
+        await cleanupTransports([clientTransport, serverTransport]);
       });
 
       const services = {
@@ -692,6 +717,11 @@ describe.each(testMatrix())(
       const result = await client.test.getData.rpc({});
       assert(result.ok);
       expect(result.payload).toStrictEqual({ data: 'foobar', extra: 42 });
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+        server,
+      });
     });
   },
 );

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -17,6 +17,7 @@ import {
 import { Ok, UNCAUGHT_ERROR } from '../router/result';
 import {
   advanceFakeTimersBySessionGrace,
+  createPostTestChecks,
   testFinishesCleanly,
   waitFor,
 } from './fixtures/cleanup';
@@ -28,7 +29,6 @@ import {
   createServerHandshakeOptions,
 } from '../router/handshake';
 import { TestSetupHelpers } from './fixtures/transports';
-import { createPostTestChecks } from './cleanup.test';
 
 describe.each(testMatrix())(
   'client <-> server integration test ($transport.name transport, $codec.name codec)',
@@ -681,6 +681,13 @@ describe.each(testMatrix())(
           };
         }),
       );
+      onTestFinished(async () => {
+        await testFinishesCleanly({
+          clientTransports: [clientTransport],
+          serverTransport,
+          server,
+        });
+      });
 
       const services = {
         test: ServiceSchema.define({
@@ -703,13 +710,6 @@ describe.each(testMatrix())(
         clientTransport,
         serverTransport.clientId,
       );
-      onTestFinished(async () => {
-        await testFinishesCleanly({
-          clientTransports: [clientTransport],
-          serverTransport,
-          server,
-        });
-      });
 
       // test
       const result = await client.test.getData.rpc({});

--- a/__tests__/fixtures/cleanup.ts
+++ b/__tests__/fixtures/cleanup.ts
@@ -132,13 +132,13 @@ export async function testFinishesCleanly({
   vi.useRealTimers();
 }
 
-export const createPostTestChecks = () => {
+export const createPostTestCleanups = () => {
   const cleanupFns: Array<() => Promise<void>> = [];
   return {
-    onTestFinished: (fn: () => Promise<void>) => {
+    addPostTestCleanup: (fn: () => Promise<void>) => {
       cleanupFns.push(fn);
     },
-    postTestChecks: async () => {
+    postTestCleanup: async () => {
       while (cleanupFns.length > 0) {
         await cleanupFns.pop()?.();
       }

--- a/__tests__/fixtures/cleanup.ts
+++ b/__tests__/fixtures/cleanup.ts
@@ -147,3 +147,17 @@ export async function testFinishesCleanly({
 
   vi.useRealTimers();
 }
+
+export const createPostTestChecks = () => {
+  const cleanupFns: Array<() => Promise<void>> = [];
+  return {
+    onTestFinished: (fn: () => Promise<void>) => {
+      cleanupFns.push(fn);
+    },
+    postTestChecks: async () => {
+      while (cleanupFns.length > 0) {
+        await cleanupFns.pop()?.();
+      }
+    },
+  };
+};

--- a/__tests__/fixtures/cleanup.ts
+++ b/__tests__/fixtures/cleanup.ts
@@ -9,21 +9,13 @@ import {
 import { Server } from '../../router';
 import { AnyServiceSchemaMap } from '../../router/services';
 import { testingSessionOptions } from '../../util/testHelpers';
+import { Value } from '@sinclair/typebox/value';
+import { ControlMessageAckSchema } from '../../transport/message';
 
 const waitUntilOptions = {
   timeout: 500, // account for possibility of conn backoff
   interval: 5, // check every 5ms
 };
-
-export async function waitForTransportToFinish(t: Transport<Connection>) {
-  t.close();
-  await waitFor(() =>
-    expect(
-      t.connections,
-      `[post-test cleanup] transport ${t.clientId} should not have open connections after the test`,
-    ).toStrictEqual(new Map()),
-  );
-}
 
 export async function advanceFakeTimersByDisconnectGrace() {
   for (let i = 0; i < testingSessionOptions.heartbeatsUntilDead; i++) {
@@ -43,17 +35,22 @@ export async function advanceFakeTimersBySessionGrace() {
   );
 }
 
-async function ensureTransportIsClean(t: Transport<Connection>) {
-  expect(
-    t.getStatus(),
-    `[post-test cleanup] transport ${t.clientId} should be closed after the test`,
-  ).to.not.equal('open');
+export async function advanceFakeTimersByConnectionBackoff() {
+  await vi.advanceTimersByTimeAsync(500);
+}
 
-  await ensureTransportBuffersAreEventuallyEmpty(t);
+export async function ensureTransportIsClean(t: Transport<Connection>) {
+  await advanceFakeTimersBySessionGrace();
   await waitFor(() =>
     expect(
       t.sessions,
       `[post-test cleanup] transport ${t.clientId} should not have open sessions after the test`,
+    ).toStrictEqual(new Map()),
+  );
+  await waitFor(() =>
+    expect(
+      t.connections,
+      `[post-test cleanup] transport ${t.clientId} should not have open connections after the test`,
     ).toStrictEqual(new Map()),
   );
 }
@@ -65,17 +62,23 @@ export function waitFor<T>(cb: () => T | Promise<T>) {
 export async function ensureTransportBuffersAreEventuallyEmpty(
   t: Transport<Connection>,
 ) {
+  // wait for send buffers to be flushed
+  // ignore heartbeat messages
   await waitFor(() =>
     expect(
       new Map(
         [...t.sessions]
-          .map(
-            ([client, sess]) =>
-              [client, sess.inspectSendBuffer()] as [
-                string,
-                ReadonlyArray<OpaqueTransportMessage>,
-              ],
-          )
+          .map(([client, sess]) => {
+            // get all messages that are not heartbeats
+            const buff = sess.inspectSendBuffer().filter((msg) => {
+              return !Value.Check(ControlMessageAckSchema, msg.payload);
+            });
+
+            return [client, buff] as [
+              string,
+              ReadonlyArray<OpaqueTransportMessage>,
+            ];
+          })
           .filter((entry) => entry[1].length > 0),
       ),
       `[post-test cleanup] transport ${t.clientId} should not have any messages waiting to send after the test`,
@@ -92,6 +95,17 @@ export async function ensureServerIsClean(s: Server<AnyServiceSchemaMap>) {
   );
 }
 
+export async function cleanupTransports(
+  transports: Array<Transport<Connection>>,
+) {
+  for (const t of transports) {
+    if (t.getStatus() !== 'closed') {
+      t.log?.info('*** end of test cleanup ***');
+      t.close();
+    }
+  }
+}
+
 export async function testFinishesCleanly({
   clientTransports,
   serverTransport,
@@ -101,35 +115,33 @@ export async function testFinishesCleanly({
   serverTransport: ServerTransport<Connection>;
   server: Server<AnyServiceSchemaMap>;
 }>) {
-  for (const t of [...(clientTransports ?? []), serverTransport]) {
-    t?.log?.info('*** end of test cleanup ***');
+  // pre-close invariants
+  const allTransports = [
+    ...(clientTransports ?? []),
+    ...(serverTransport ? [serverTransport] : []),
+  ];
+
+  for (const t of allTransports) {
+    t.log?.info('*** end of test invariant checks ***');
+    // wait for one round of heartbeat
+    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(
+      testingSessionOptions.heartbeatIntervalMs + 1,
+    );
+    await ensureTransportBuffersAreEventuallyEmpty(t);
   }
 
-  vi.useFakeTimers({ shouldAdvanceTime: true });
-
-  if (clientTransports) {
-    for (const t of clientTransports) {
-      t.reconnectOnConnectionDrop = false;
-    }
-
-    await Promise.all(clientTransports.map(waitForTransportToFinish));
-    await advanceFakeTimersBySessionGrace();
-    await Promise.all(clientTransports.map(ensureTransportIsClean));
-  }
-
-  // server sits on top of server transport so we clean it up first
   if (server) {
-    await advanceFakeTimersBySessionGrace();
     await ensureServerIsClean(server);
   }
 
-  if (serverTransport) {
-    await waitForTransportToFinish(serverTransport);
-    await advanceFakeTimersBySessionGrace();
-    await ensureTransportIsClean(serverTransport);
-  }
+  // close all the things
+  await cleanupTransports(allTransports);
 
-  vi.useRealTimers();
+  // post-close invariants
+  for (const t of allTransports) {
+    await ensureTransportIsClean(t);
+  }
 }
 
 export const createPostTestCleanups = () => {

--- a/__tests__/fixtures/transports.ts
+++ b/__tests__/fixtures/transports.ts
@@ -34,20 +34,22 @@ export interface TestTransportOptions {
   server?: ProvidedServerTransportOptions;
 }
 
+export interface TestSetupHelpers {
+  getClientTransport: (
+    id: TransportClientId,
+    handshakeOptions?: ClientHandshakeOptions,
+  ) => ClientTransport<Connection>;
+  getServerTransport: (
+    handshakeOptions?: ServerHandshakeOptions,
+  ) => ServerTransport<Connection>;
+  simulatePhantomDisconnect: () => void;
+  restartServer: () => Promise<void>;
+  cleanup: () => Promise<void> | void;
+}
+
 export interface TransportMatrixEntry {
   name: ValidTransports;
-  setup: (opts?: TestTransportOptions) => Promise<{
-    getClientTransport: (
-      id: TransportClientId,
-      handshakeOptions?: ClientHandshakeOptions,
-    ) => ClientTransport<Connection>;
-    getServerTransport: (
-      handshakeOptions?: ServerHandshakeOptions,
-    ) => ServerTransport<Connection>;
-    simulatePhantomDisconnect: () => void;
-    restartServer: () => Promise<void>;
-    cleanup: () => Promise<void> | void;
-  }>;
+  setup: (opts?: TestTransportOptions) => Promise<TestSetupHelpers>;
 }
 
 export const transports: Array<TransportMatrixEntry> = [

--- a/__tests__/globalSetup.ts
+++ b/__tests__/globalSetup.ts
@@ -1,0 +1,3 @@
+import { vi } from 'vitest';
+
+vi.useFakeTimers({ shouldAdvanceTime: true });

--- a/__tests__/negative.test.ts
+++ b/__tests__/negative.test.ts
@@ -21,21 +21,21 @@ import { WebSocketClientTransport } from '../transport/impls/ws/client';
 import { ProtocolError } from '../transport/events';
 import { WsLike } from '../transport/impls/ws/wslike';
 import NodeWs from 'ws';
-import { createPostTestChecks } from './fixtures/cleanup';
+import { createPostTestCleanups } from './fixtures/cleanup';
 
 describe('should handle incompatabilities', async () => {
   let server: http.Server;
   let port: number;
   let wss: NodeWs.Server;
 
-  const { onTestFinished, postTestChecks } = createPostTestChecks();
+  const { addPostTestCleanup, postTestCleanup } = createPostTestCleanups();
   beforeEach(async () => {
     server = http.createServer();
     port = await onWsServerReady(server);
     wss = createWebSocketServer(server);
 
     return async () => {
-      await postTestChecks();
+      await postTestCleanup();
       wss.close();
       server.close();
     };
@@ -52,7 +52,7 @@ describe('should handle incompatabilities', async () => {
 
     const errMock = vi.fn();
     clientTransport.addEventListener('protocolError', errMock);
-    onTestFinished(async () => {
+    addPostTestCleanup(async () => {
       clientTransport.removeEventListener('protocolError', errMock);
 
       await testFinishesCleanly({
@@ -78,7 +78,7 @@ describe('should handle incompatabilities', async () => {
     const serverTransport = new WebSocketServerTransport(wss, 'SERVER');
     const errMock = vi.fn();
     clientTransport.addEventListener('protocolError', errMock);
-    onTestFinished(async () => {
+    addPostTestCleanup(async () => {
       clientTransport.removeEventListener('protocolError', errMock);
 
       await testFinishesCleanly({
@@ -122,7 +122,7 @@ describe('should handle incompatabilities', async () => {
     const errMock = vi.fn();
     clientTransport.addEventListener('protocolError', errMock);
     const promises: Array<Promise<void>> = [];
-    onTestFinished(async () => {
+    addPostTestCleanup(async () => {
       wss.off('connection', serverWsConnHandler);
       clientTransport.removeEventListener('protocolError', errMock);
       await testFinishesCleanly({
@@ -144,7 +144,7 @@ describe('should handle incompatabilities', async () => {
     const errMock = vi.fn();
     serverTransport.addEventListener('connectionStatus', spy);
     serverTransport.addEventListener('protocolError', errMock);
-    onTestFinished(async () => {
+    addPostTestCleanup(async () => {
       serverTransport.removeEventListener('connectionStatus', spy);
       serverTransport.removeEventListener('protocolError', errMock);
 
@@ -179,7 +179,7 @@ describe('should handle incompatabilities', async () => {
     const errMock = vi.fn();
     serverTransport.addEventListener('connectionStatus', spy);
     serverTransport.addEventListener('protocolError', errMock);
-    onTestFinished(async () => {
+    addPostTestCleanup(async () => {
       serverTransport.removeEventListener('connectionStatus', spy);
       serverTransport.removeEventListener('protocolError', errMock);
 
@@ -231,7 +231,7 @@ describe('should handle incompatabilities', async () => {
     const errMock = vi.fn();
     serverTransport.addEventListener('connectionStatus', spy);
     serverTransport.addEventListener('protocolError', errMock);
-    onTestFinished(async () => {
+    addPostTestCleanup(async () => {
       serverTransport.removeEventListener('protocolError', errMock);
       serverTransport.removeEventListener('connectionStatus', spy);
 

--- a/__tests__/negative.test.ts
+++ b/__tests__/negative.test.ts
@@ -21,7 +21,7 @@ import { WebSocketClientTransport } from '../transport/impls/ws/client';
 import { ProtocolError } from '../transport/events';
 import { WsLike } from '../transport/impls/ws/wslike';
 import NodeWs from 'ws';
-import { createPostTestChecks } from './cleanup.test';
+import { createPostTestChecks } from './fixtures/cleanup';
 
 describe('should handle incompatabilities', async () => {
   let server: http.Server;
@@ -119,6 +119,7 @@ describe('should handle incompatabilities', async () => {
       'client',
       { attemptBudgetCapacity: maxAttempts },
     );
+
     clientTransport.reconnectOnConnectionDrop = false;
 
     const errMock = vi.fn();
@@ -127,7 +128,9 @@ describe('should handle incompatabilities', async () => {
     onTestFinished(async () => {
       wss.off('connection', serverWsConnHandler);
       clientTransport.removeEventListener('protocolError', errMock);
-      clientTransport.close();
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+      });
     });
 
     for (let i = 0; i < maxAttempts; i++) {

--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -80,13 +80,8 @@ describe('proxy', () => {
       clientTransport,
       serverTransport.clientId,
     );
-    onTestFinished(async () => {
-      await testFinishesCleanly({
-        clientTransports: [clientTransport],
-        serverTransport,
-        server,
-      });
 
+    onTestFinished(async () => {
       udsServer.close();
       wss.close();
       proxyServer.close();
@@ -96,5 +91,11 @@ describe('proxy', () => {
     const result = await client.test.add.rpc({ n: 3 });
     assert(result.ok);
     expect(result.payload).toStrictEqual({ result: 3 });
+
+    await testFinishesCleanly({
+      clientTransports: [clientTransport],
+      serverTransport,
+      server,
+    });
   });
 });

--- a/package.json
+++ b/package.json
@@ -84,8 +84,8 @@
     "prepack": "npm run build",
     "release": "npm publish --access public",
     "test:ui": "echo \"remember to go to /__vitest__ in the webview\" && vitest --ui --api.host 0.0.0.0 --api.port 3000",
-    "test": "vitest --test-timeout=500",
-    "test:single": "vitest run --test-timeout=500 --reporter=dot",
+    "test": "vitest",
+    "test:single": "vitest run --reporter=dot",
     "test:flake": "./flake.sh",
     "bench": "vitest bench"
   },

--- a/router/diff.ts
+++ b/router/diff.ts
@@ -656,7 +656,6 @@ function getReportingType(schema: TAnySchema): string {
     return schema.type;
   }
 
-  console.error(schema);
   throw new Error(
     'Subschema not supported, probably a conditional subschema. Check logs.',
   );

--- a/tracing/tracing.test.ts
+++ b/tracing/tracing.test.ts
@@ -16,7 +16,11 @@ import tracer, {
 } from './index';
 import { OpaqueTransportMessage } from '../transport';
 import { testMatrix } from '../__tests__/fixtures/matrix';
-import { testFinishesCleanly, waitFor } from '../__tests__/fixtures/cleanup';
+import {
+  cleanupTransports,
+  testFinishesCleanly,
+  waitFor,
+} from '../__tests__/fixtures/cleanup';
 import { TestSetupHelpers } from '../__tests__/fixtures/transports';
 import { createPostTestCleanups } from '../__tests__/fixtures/cleanup';
 
@@ -89,10 +93,7 @@ describe.each(testMatrix())(
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
       addPostTestCleanup(async () => {
-        await testFinishesCleanly({
-          clientTransports: [clientTransport],
-          serverTransport,
-        });
+        await cleanupTransports([clientTransport, serverTransport]);
       });
 
       await clientTransport.connect(serverTransport.clientId);
@@ -117,6 +118,10 @@ describe.each(testMatrix())(
       // ensure server span is a child of client span
       // @ts-expect-error: hacking to get parentSpanId
       expect(serverSpan.parentSpanId).toBe(clientSpan.spanContext().spanId);
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+      });
     });
   },
 );

--- a/tracing/tracing.test.ts
+++ b/tracing/tracing.test.ts
@@ -18,7 +18,7 @@ import { OpaqueTransportMessage } from '../transport';
 import { testMatrix } from '../__tests__/fixtures/matrix';
 import { testFinishesCleanly, waitFor } from '../__tests__/fixtures/cleanup';
 import { TestSetupHelpers } from '../__tests__/fixtures/transports';
-import { createPostTestChecks } from '../__tests__/cleanup.test';
+import { createPostTestChecks } from '../__tests__/fixtures/cleanup';
 
 describe('Basic tracing tests', () => {
   const provider = new BasicTracerProvider();

--- a/tracing/tracing.test.ts
+++ b/tracing/tracing.test.ts
@@ -18,7 +18,7 @@ import { OpaqueTransportMessage } from '../transport';
 import { testMatrix } from '../__tests__/fixtures/matrix';
 import { testFinishesCleanly, waitFor } from '../__tests__/fixtures/cleanup';
 import { TestSetupHelpers } from '../__tests__/fixtures/transports';
-import { createPostTestChecks } from '../__tests__/fixtures/cleanup';
+import { createPostTestCleanups } from '../__tests__/fixtures/cleanup';
 
 describe('Basic tracing tests', () => {
   const provider = new BasicTracerProvider();
@@ -72,7 +72,7 @@ describe.each(testMatrix())(
   async ({ transport, codec }) => {
     const opts = { codec: codec.codec };
 
-    const { onTestFinished, postTestChecks } = createPostTestChecks();
+    const { addPostTestCleanup, postTestCleanup } = createPostTestCleanups();
     let getClientTransport: TestSetupHelpers['getClientTransport'];
     let getServerTransport: TestSetupHelpers['getServerTransport'];
     beforeEach(async () => {
@@ -80,7 +80,7 @@ describe.each(testMatrix())(
       getClientTransport = setup.getClientTransport;
       getServerTransport = setup.getServerTransport;
       return async () => {
-        await postTestChecks();
+        await postTestCleanup();
         await setup.cleanup();
       };
     });
@@ -88,7 +88,7 @@ describe.each(testMatrix())(
     test('Traces sessions and connections across network boundary', async () => {
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,

--- a/transport/impls/uds/uds.test.ts
+++ b/transport/impls/uds/uds.test.ts
@@ -12,20 +12,20 @@ import {
   testFinishesCleanly,
 } from '../../../__tests__/fixtures/cleanup';
 import net from 'node:net';
-import { createPostTestChecks } from '../../../__tests__/fixtures/cleanup';
+import { createPostTestCleanups } from '../../../__tests__/fixtures/cleanup';
 
 describe('sending and receiving across unix sockets works', async () => {
   let socketPath: string;
   let server: net.Server;
 
-  const { onTestFinished, postTestChecks } = createPostTestChecks();
+  const { addPostTestCleanup, postTestCleanup } = createPostTestCleanups();
   beforeEach(async () => {
     socketPath = getUnixSocketPath();
     server = net.createServer();
     await onUdsServeReady(server, socketPath);
 
     return async () => {
-      await postTestChecks();
+      await postTestCleanup();
       server.close();
     };
   });
@@ -50,7 +50,7 @@ describe('sending and receiving across unix sockets works', async () => {
         test: [1, 2, 3, 4],
       },
     ];
-    onTestFinished(async () => {
+    addPostTestCleanup(async () => {
       await testFinishesCleanly({
         clientTransports: [clientTransport],
         serverTransport,
@@ -74,7 +74,7 @@ describe('sending and receiving across unix sockets works', async () => {
       server,
       'SERVER',
     );
-    onTestFinished(async () => {
+    addPostTestCleanup(async () => {
       await testFinishesCleanly({
         clientTransports: [],
         serverTransport,

--- a/transport/impls/uds/uds.test.ts
+++ b/transport/impls/uds/uds.test.ts
@@ -12,7 +12,7 @@ import {
   testFinishesCleanly,
 } from '../../../__tests__/fixtures/cleanup';
 import net from 'node:net';
-import { createPostTestChecks } from '../../../__tests__/cleanup.test';
+import { createPostTestChecks } from '../../../__tests__/fixtures/cleanup';
 
 describe('sending and receiving across unix sockets works', async () => {
   let socketPath: string;

--- a/transport/impls/ws/client.ts
+++ b/transport/impls/ws/client.ts
@@ -59,6 +59,10 @@ export class WebSocketClientTransport extends ClientTransport<WebSocketConnectio
       ws.onclose = (evt) => {
         reject(new Error(evt.reason));
       };
+
+      ws.onerror = (err) => {
+        reject(new Error(err.message));
+      };
     });
 
     const conn = new WebSocketConnection(ws);

--- a/transport/impls/ws/ws.test.ts
+++ b/transport/impls/ws/ws.test.ts
@@ -1,5 +1,5 @@
 import http from 'node:http';
-import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { describe, test, expect, beforeEach } from 'vitest';
 import {
   createWebSocketServer,
   onWsServerReady,
@@ -12,6 +12,7 @@ import { WebSocketServerTransport } from './server';
 import { WebSocketClientTransport } from './client';
 import {
   advanceFakeTimersBySessionGrace,
+  cleanupTransports,
   testFinishesCleanly,
 } from '../../../__tests__/fixtures/cleanup';
 import { PartialTransportMessage } from '../../message';
@@ -44,10 +45,7 @@ describe('sending and receiving across websockets works', async () => {
     const serverTransport = new WebSocketServerTransport(wss, 'SERVER');
     await clientTransport.connect(serverTransport.clientId);
     addPostTestCleanup(async () => {
-      await testFinishesCleanly({
-        clientTransports: [clientTransport],
-        serverTransport,
-      });
+      await cleanupTransports([clientTransport, serverTransport]);
     });
 
     const msg = createDummyTransportMessage();
@@ -55,6 +53,11 @@ describe('sending and receiving across websockets works', async () => {
     await expect(
       waitForMessage(serverTransport, (recv) => recv.id === msgId),
     ).resolves.toStrictEqual(msg.payload);
+
+    await testFinishesCleanly({
+      clientTransports: [clientTransport],
+      serverTransport,
+    });
   });
 
   test('sending respects to/from fields', async () => {
@@ -86,10 +89,7 @@ describe('sending and receiving across websockets works', async () => {
     const client1 = await initClient(clientId1);
     const client2 = await initClient(clientId2);
     addPostTestCleanup(async () => {
-      await testFinishesCleanly({
-        clientTransports: [client1, client2],
-        serverTransport,
-      });
+      await cleanupTransports([client1, client2, serverTransport]);
     });
 
     // sending messages from server to client shouldn't leak between clients
@@ -105,18 +105,19 @@ describe('sending and receiving across websockets works', async () => {
     await expect(promises).resolves.toStrictEqual(
       expect.arrayContaining([msg1.payload, msg2.payload]),
     );
+
+    await testFinishesCleanly({
+      clientTransports: [client1, client2],
+      serverTransport,
+    });
   });
 
   test('hanging ws connection with no handshake is cleaned up after grace', async () => {
     const serverTransport = new WebSocketServerTransport(wss, 'SERVER');
     addPostTestCleanup(async () => {
-      await testFinishesCleanly({
-        clientTransports: [],
-        serverTransport,
-      });
+      await cleanupTransports([serverTransport]);
     });
 
-    vi.useFakeTimers({ shouldAdvanceTime: true });
     const ws = createLocalWebSocketClient(port);
 
     // wait for ws to be open
@@ -133,6 +134,11 @@ describe('sending and receiving across websockets works', async () => {
     expect(serverTransport.connections.size).toBe(0);
     expect(serverTransport.sessions.size).toBe(0);
     expect(ws.readyState).toBe(ws.CLOSED);
+
+    await testFinishesCleanly({
+      clientTransports: [],
+      serverTransport,
+    });
   });
 
   test('ws connection is recreated after unclean disconnect', async () => {
@@ -143,10 +149,7 @@ describe('sending and receiving across websockets works', async () => {
     const serverTransport = new WebSocketServerTransport(wss, 'SERVER');
     await clientTransport.connect(serverTransport.clientId);
     addPostTestCleanup(async () => {
-      await testFinishesCleanly({
-        clientTransports: [clientTransport],
-        serverTransport,
-      });
+      await cleanupTransports([clientTransport, serverTransport]);
     });
 
     const msg1 = createDummyTransportMessage();
@@ -167,6 +170,11 @@ describe('sending and receiving across websockets works', async () => {
     await expect(
       waitForMessage(serverTransport, (recv) => recv.id === msg2Id),
     ).resolves.toStrictEqual(msg2.payload);
+
+    await testFinishesCleanly({
+      clientTransports: [clientTransport],
+      serverTransport,
+    });
   });
 
   test('ws connection always calls the close callback', async () => {
@@ -177,10 +185,7 @@ describe('sending and receiving across websockets works', async () => {
     const serverTransport = new WebSocketServerTransport(wss, 'SERVER');
     await clientTransport.connect(serverTransport.clientId);
     addPostTestCleanup(async () => {
-      await testFinishesCleanly({
-        clientTransports: [clientTransport],
-        serverTransport,
-      });
+      await cleanupTransports([clientTransport, serverTransport]);
     });
 
     const msg1 = createDummyTransportMessage();
@@ -203,5 +208,10 @@ describe('sending and receiving across websockets works', async () => {
     await expect(
       waitForMessage(serverTransport, (recv) => recv.id === msg2Id),
     ).resolves.toStrictEqual(msg2.payload);
+
+    await testFinishesCleanly({
+      clientTransports: [clientTransport],
+      serverTransport,
+    });
   });
 });

--- a/transport/impls/ws/ws.test.ts
+++ b/transport/impls/ws/ws.test.ts
@@ -16,7 +16,7 @@ import {
 } from '../../../__tests__/fixtures/cleanup';
 import { PartialTransportMessage } from '../../message';
 import type NodeWs from 'ws';
-import { createPostTestChecks } from '../../../__tests__/cleanup.test';
+import { createPostTestChecks } from '../../../__tests__/fixtures/cleanup';
 
 describe('sending and receiving across websockets works', async () => {
   let server: http.Server;

--- a/transport/impls/ws/ws.test.ts
+++ b/transport/impls/ws/ws.test.ts
@@ -16,21 +16,21 @@ import {
 } from '../../../__tests__/fixtures/cleanup';
 import { PartialTransportMessage } from '../../message';
 import type NodeWs from 'ws';
-import { createPostTestChecks } from '../../../__tests__/fixtures/cleanup';
+import { createPostTestCleanups } from '../../../__tests__/fixtures/cleanup';
 
 describe('sending and receiving across websockets works', async () => {
   let server: http.Server;
   let port: number;
   let wss: NodeWs.Server;
 
-  const { onTestFinished, postTestChecks } = createPostTestChecks();
+  const { addPostTestCleanup, postTestCleanup } = createPostTestCleanups();
   beforeEach(async () => {
     server = http.createServer();
     port = await onWsServerReady(server);
     wss = createWebSocketServer(server);
 
     return async () => {
-      await postTestChecks();
+      await postTestCleanup();
       wss.close();
       server.close();
     };
@@ -43,7 +43,7 @@ describe('sending and receiving across websockets works', async () => {
     );
     const serverTransport = new WebSocketServerTransport(wss, 'SERVER');
     await clientTransport.connect(serverTransport.clientId);
-    onTestFinished(async () => {
+    addPostTestCleanup(async () => {
       await testFinishesCleanly({
         clientTransports: [clientTransport],
         serverTransport,
@@ -85,7 +85,7 @@ describe('sending and receiving across websockets works', async () => {
 
     const client1 = await initClient(clientId1);
     const client2 = await initClient(clientId2);
-    onTestFinished(async () => {
+    addPostTestCleanup(async () => {
       await testFinishesCleanly({
         clientTransports: [client1, client2],
         serverTransport,
@@ -109,7 +109,7 @@ describe('sending and receiving across websockets works', async () => {
 
   test('hanging ws connection with no handshake is cleaned up after grace', async () => {
     const serverTransport = new WebSocketServerTransport(wss, 'SERVER');
-    onTestFinished(async () => {
+    addPostTestCleanup(async () => {
       await testFinishesCleanly({
         clientTransports: [],
         serverTransport,
@@ -142,7 +142,7 @@ describe('sending and receiving across websockets works', async () => {
     );
     const serverTransport = new WebSocketServerTransport(wss, 'SERVER');
     await clientTransport.connect(serverTransport.clientId);
-    onTestFinished(async () => {
+    addPostTestCleanup(async () => {
       await testFinishesCleanly({
         clientTransports: [clientTransport],
         serverTransport,
@@ -176,7 +176,7 @@ describe('sending and receiving across websockets works', async () => {
     );
     const serverTransport = new WebSocketServerTransport(wss, 'SERVER');
     await clientTransport.connect(serverTransport.clientId);
-    onTestFinished(async () => {
+    addPostTestCleanup(async () => {
       await testFinishesCleanly({
         clientTransports: [clientTransport],
         serverTransport,

--- a/transport/rateLimit.test.ts
+++ b/transport/rateLimit.test.ts
@@ -35,7 +35,6 @@ describe('LeakyBucketRateLimit', () => {
   });
 
   test('keeps growing until startRestoringBudget', () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true });
     const rateLimit = new LeakyBucketRateLimit(options);
     const user = 'user1';
     rateLimit.consumeBudget(user);
@@ -53,7 +52,6 @@ describe('LeakyBucketRateLimit', () => {
   });
 
   test('stops restoring budget when we consume budget again', () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true });
     const rateLimit = new LeakyBucketRateLimit(options);
     const user = 'user1';
     rateLimit.consumeBudget(user);

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -15,7 +15,7 @@ import { testMatrix } from '../__tests__/fixtures/matrix';
 import { PartialTransportMessage } from './message';
 import { Type } from '@sinclair/typebox';
 import { TestSetupHelpers } from '../__tests__/fixtures/transports';
-import { createPostTestChecks } from '../__tests__/cleanup.test';
+import { createPostTestChecks } from '../__tests__/fixtures/cleanup';
 
 describe.each(testMatrix())(
   'transport connection behaviour tests ($transport.name transport, $codec.name codec)',

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -15,14 +15,14 @@ import { testMatrix } from '../__tests__/fixtures/matrix';
 import { PartialTransportMessage } from './message';
 import { Type } from '@sinclair/typebox';
 import { TestSetupHelpers } from '../__tests__/fixtures/transports';
-import { createPostTestChecks } from '../__tests__/fixtures/cleanup';
+import { createPostTestCleanups } from '../__tests__/fixtures/cleanup';
 
 describe.each(testMatrix())(
   'transport connection behaviour tests ($transport.name transport, $codec.name codec)',
   async ({ transport, codec }) => {
     const opts = { codec: codec.codec };
 
-    const { onTestFinished, postTestChecks } = createPostTestChecks();
+    const { addPostTestCleanup, postTestCleanup } = createPostTestCleanups();
     let getClientTransport: TestSetupHelpers['getClientTransport'];
     let getServerTransport: TestSetupHelpers['getServerTransport'];
     beforeEach(async () => {
@@ -30,7 +30,7 @@ describe.each(testMatrix())(
       getClientTransport = setup.getClientTransport;
       getServerTransport = setup.getServerTransport;
       return async () => {
-        await postTestChecks();
+        await postTestCleanup();
         await setup.cleanup();
       };
     });
@@ -38,7 +38,7 @@ describe.each(testMatrix())(
     test('connection is recreated after clean client disconnect', async () => {
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -66,7 +66,7 @@ describe.each(testMatrix())(
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
       await waitFor(() => expect(serverTransport.connections.size).toBe(1));
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -77,7 +77,7 @@ describe.each(testMatrix())(
     test('heartbeats should not interupt normal operation', async () => {
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -116,7 +116,7 @@ describe.each(testMatrix())(
       };
 
       clientTransport.addEventListener('sessionStatus', sendHandle);
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         clientTransport.removeEventListener('protocolError', protocolError);
         clientTransport.removeEventListener('sessionStatus', sendHandle);
         await testFinishesCleanly({
@@ -132,7 +132,7 @@ describe.each(testMatrix())(
     test('seq numbers should be persisted across transparent reconnects', async () => {
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -255,7 +255,7 @@ describe.each(testMatrix())(
         }
       };
 
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         // teardown
         clientTransport.removeEventListener(
           'connectionStatus',
@@ -415,7 +415,7 @@ describe.each(testMatrix())(
 
       const client1Transport = await initClient(clientId1);
       const client2Transport = await initClient(clientId2);
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [client1Transport, client2Transport],
           serverTransport,
@@ -445,11 +445,11 @@ describe.each(testMatrix())(
   ({ transport, codec }) => {
     const opts = { codec: codec.codec };
     let testHelpers: TestSetupHelpers;
-    const { onTestFinished, postTestChecks } = createPostTestChecks();
+    const { addPostTestCleanup, postTestCleanup } = createPostTestCleanups();
     beforeEach(async () => {
       testHelpers = await transport.setup({ client: opts, server: opts });
       return async () => {
-        await postTestChecks();
+        await postTestCleanup();
         await testHelpers.cleanup();
       };
     });
@@ -485,7 +485,7 @@ describe.each(testMatrix())(
 
       serverTransport.addEventListener('connectionStatus', serverConnHandler);
       serverTransport.addEventListener('sessionStatus', serverSessHandler);
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         // teardown
         serverTransport.removeEventListener(
           'connectionStatus',
@@ -572,7 +572,7 @@ describe.each(testMatrix())(
 
       clientTransport.addEventListener('connectionStatus', clientConnHandler);
       clientTransport.addEventListener('sessionStatus', clientSessHandler);
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         // teardown
         clientTransport.removeEventListener(
           'connectionStatus',
@@ -699,7 +699,7 @@ describe.each(testMatrix())(
       clientTransport.addEventListener('sessionStatus', clientSessHandler);
       serverTransport.addEventListener('connectionStatus', serverConnHandler);
       serverTransport.addEventListener('sessionStatus', serverSessHandler);
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         // teardown
         clientTransport.removeEventListener(
           'connectionStatus',
@@ -768,7 +768,7 @@ describe.each(testMatrix())(
   async ({ transport, codec }) => {
     const opts = { codec: codec.codec };
 
-    const { onTestFinished, postTestChecks } = createPostTestChecks();
+    const { addPostTestCleanup, postTestCleanup } = createPostTestCleanups();
     let getClientTransport: TestSetupHelpers['getClientTransport'];
     let getServerTransport: TestSetupHelpers['getServerTransport'];
     beforeEach(async () => {
@@ -776,7 +776,7 @@ describe.each(testMatrix())(
       getClientTransport = setup.getClientTransport;
       getServerTransport = setup.getServerTransport;
       return async () => {
-        await postTestChecks();
+        await postTestCleanup();
         await setup.cleanup();
       };
     });
@@ -801,7 +801,7 @@ describe.each(testMatrix())(
         schema,
         construct: get,
       });
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -847,7 +847,7 @@ describe.each(testMatrix())(
       const clientHandshakeFailed = vi.fn();
       clientTransport.addEventListener('protocolError', clientHandshakeFailed);
 
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         clientTransport.removeEventListener(
           'protocolError',
           clientHandshakeFailed,
@@ -905,7 +905,7 @@ describe.each(testMatrix())(
       const serverHandshakeFailed = vi.fn();
       serverTransport.addEventListener('protocolError', serverHandshakeFailed);
 
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         clientTransport.removeEventListener(
           'protocolError',
           clientHandshakeFailed,
@@ -961,7 +961,7 @@ describe.each(testMatrix())(
         construct,
       });
 
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         await testFinishesCleanly({
           clientTransports: [clientTransport],
           serverTransport,
@@ -1033,7 +1033,7 @@ describe.each(testMatrix())(
         serverRejectedConnection,
       );
 
-      onTestFinished(async () => {
+      addPostTestCleanup(async () => {
         clientTransport.removeEventListener(
           'protocolError',
           clientHandshakeFailed,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,6 @@ export default defineConfig({
     sequence: {
       hooks: 'stack',
     },
-    fileParallelism: false,
+    pool: 'forks',
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,5 +11,7 @@ export default defineConfig({
       hooks: 'stack',
     },
     pool: 'forks',
+    testTimeout: 1000,
+    setupFiles: './__tests__/globalSetup.ts',
   },
 });


### PR DESCRIPTION
## Why

We currently set up a single server that is shared among multiple test
cases. That's undesirable, since we want isolation in each test.

Supercedes #181 and #183

## What changed

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

- add missing error listener to websocket on the client
- custom onTestFinished

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
