### PR TITLE
[protocolv2] Refactor server proc streams to look like client implementation

### DIFF
--- a/__tests__/cleanup.test.ts
+++ b/__tests__/cleanup.test.ts
@@ -177,10 +177,10 @@ describe.each(testMatrix())(
 
       // ensure we only have one stream despite pushing multiple messages.
       inputWriter.close();
-      await waitFor(() => expect(server.streams.size).toEqual(1));
+      await waitFor(() => expect(server.openStreams.size).toEqual(1));
       await outputReader.requestClose();
-      // ensure we no longer have any streams since the input was closed.
-      await waitFor(() => expect(server.streams.size).toEqual(0));
+      // ensure we no longer have any open streams since the input was closed.
+      await waitFor(() => expect(server.openStreams.size).toEqual(0));
 
       const result2 = await iterNext(outputIterator);
       assert(result2.ok);

--- a/__tests__/fixtures/cleanup.ts
+++ b/__tests__/fixtures/cleanup.ts
@@ -89,9 +89,9 @@ export async function ensureTransportBuffersAreEventuallyEmpty(
 export async function ensureServerIsClean(s: Server<AnyServiceSchemaMap>) {
   return waitFor(() =>
     expect(
-      s.streams,
+      s.openStreams,
       `[post-test cleanup] server should not have any open streams after the test`,
-    ).toStrictEqual(new Map()),
+    ).toStrictEqual(new Set()),
   );
 }
 


### PR DESCRIPTION
## Why

I was running into issues with server cleanup when I was implementing abort on the server due to all the different places that can close the stream and such. The implementation was straight forward on the client, so I decided to mimic the client's implementation of "procStream" which is easy to read and extend, as it has less indirection and is self-contained.

## What changed

- `createProcStream` now registers its own listeners for `sessionStatus` and `message` and handles events coming from there internally.
- Listen to `message` events within the server's constructor only to call `createProcStream`

A lot of the code between the frontend and backend stream handling is completely duplicated, we can probably extract it out and re-use it. I'll revisit this later.
