### PR TITLE
Check if the span is recording before passing along traceId

### DIFF
--- a/transport/session.ts
+++ b/transport/session.ts
@@ -38,7 +38,8 @@ export abstract class Connection {
   get loggingMetadata(): MessageMetadata {
     const metadata: MessageMetadata = { connId: this.id };
     const spanContext = this.telemetry?.span.spanContext();
-    if (spanContext) {
+    
+    if (this.telemetry?.span.isRecording() && spanContext) {
       metadata.telemetry = {
         traceId: spanContext.traceId,
         spanId: spanContext.spanId,

--- a/transport/session.ts
+++ b/transport/session.ts
@@ -38,7 +38,7 @@ export abstract class Connection {
   get loggingMetadata(): MessageMetadata {
     const metadata: MessageMetadata = { connId: this.id };
     const spanContext = this.telemetry?.span.spanContext();
-    
+
     if (this.telemetry?.span.isRecording() && spanContext) {
       metadata.telemetry = {
         traceId: spanContext.traceId,


### PR DESCRIPTION
## Why

By default we will have a non recording span (with the traceid and spanid being zeros) - this pollutes logs. Let's only include this if the span is recording (which will only be the case if they fall into the correct flag) 

## What changed

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
