### PR TITLE
[protocolv2] Implement client abort

### DIFF
--- a/__tests__/abort.test.ts
+++ b/__tests__/abort.test.ts
@@ -1,0 +1,521 @@
+import { Type } from '@sinclair/typebox';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { Procedure, ServiceSchema, createClient } from '../router';
+import { testMatrix } from './fixtures/matrix';
+import {
+  cleanupTransports,
+  createPostTestCleanups,
+  waitFor,
+} from './fixtures/cleanup';
+import { EventMap } from '../transport';
+import { ABORT_CODE } from '../router/procedures';
+import { ControlFlags } from '../transport/message';
+import { TestSetupHelpers } from './fixtures/transports';
+
+describe.each(testMatrix())(
+  'client initiated abort, client tests ($transport.name transport, $codec.name codec)',
+  async ({ transport, codec }) => {
+    const opts = { codec: codec.codec };
+
+    const { addPostTestCleanup, postTestCleanup } = createPostTestCleanups();
+    let getClientTransport: TestSetupHelpers['getClientTransport'];
+    let getServerTransport: TestSetupHelpers['getServerTransport'];
+    beforeEach(async () => {
+      const setup = await transport.setup({ client: opts, server: opts });
+      getClientTransport = setup.getClientTransport;
+      getServerTransport = setup.getServerTransport;
+      return async () => {
+        await postTestCleanup();
+        await setup.cleanup();
+      };
+    });
+
+    test('rpc', async () => {
+      const clientTransport = getClientTransport('client');
+      const serverTransport = getServerTransport();
+      const services = {
+        service: ServiceSchema.define({
+          rpc: Procedure.rpc({
+            init: Type.Object({}),
+            output: Type.Object({}),
+            async handler() {
+              throw new Error('unimplemented');
+            },
+          }),
+        }),
+      };
+      const client = createClient<typeof services>(
+        clientTransport,
+        serverTransport.clientId,
+      );
+      addPostTestCleanup(async () => {
+        await cleanupTransports([clientTransport, serverTransport]);
+      });
+
+      const serverOnMessage = vi.fn<[EventMap['message']]>();
+      serverTransport.addEventListener('message', serverOnMessage);
+
+      const abortController = new AbortController();
+      const signal = abortController.signal;
+      const resP = client.service.rpc.rpc({}, { signal });
+
+      await waitFor(() => {
+        expect(serverOnMessage).toHaveBeenCalledTimes(1);
+      });
+
+      abortController.abort();
+
+      await expect(resP).resolves.toEqual({
+        ok: false,
+        payload: {
+          code: ABORT_CODE,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          message: expect.any(String),
+        },
+      });
+
+      await waitFor(() => {
+        expect(serverOnMessage).toHaveBeenCalledTimes(2);
+      });
+
+      const initStreamId = serverOnMessage.mock.calls[0][0].streamId;
+      expect(serverOnMessage).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          controlFlags: ControlFlags.StreamAbortBit,
+          payload: {
+            ok: false,
+            payload: {
+              code: ABORT_CODE,
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              message: expect.any(String),
+            },
+          },
+          streamId: initStreamId,
+        }),
+      );
+    });
+
+    test('upload', async () => {
+      const clientTransport = getClientTransport('client');
+      const serverTransport = getServerTransport();
+      const services = {
+        service: ServiceSchema.define({
+          upload: Procedure.upload({
+            init: Type.Object({}),
+            input: Type.Object({}),
+            output: Type.Object({}),
+            async handler() {
+              throw new Error('unimplemented');
+            },
+          }),
+        }),
+      };
+      const client = createClient<typeof services>(
+        clientTransport,
+        serverTransport.clientId,
+      );
+      addPostTestCleanup(async () => {
+        await cleanupTransports([clientTransport, serverTransport]);
+      });
+
+      const serverOnMessage = vi.fn<[EventMap['message']]>();
+      serverTransport.addEventListener('message', serverOnMessage);
+
+      const abortController = new AbortController();
+      const signal = abortController.signal;
+      const [inputWriter, finalize] = client.service.upload.upload(
+        {},
+        { signal },
+      );
+
+      await waitFor(() => {
+        expect(serverOnMessage).toHaveBeenCalledTimes(1);
+      });
+
+      abortController.abort();
+
+      expect(inputWriter.isClosed());
+      await expect(finalize()).resolves.toEqual({
+        ok: false,
+        payload: {
+          code: ABORT_CODE,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          message: expect.any(String),
+        },
+      });
+
+      await waitFor(() => {
+        expect(serverOnMessage).toHaveBeenCalledTimes(2);
+      });
+
+      const initStreamId = serverOnMessage.mock.calls[0][0].streamId;
+      expect(serverOnMessage).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          controlFlags: ControlFlags.StreamAbortBit,
+          payload: {
+            ok: false,
+            payload: {
+              code: ABORT_CODE,
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              message: expect.any(String),
+            },
+          },
+          streamId: initStreamId,
+        }),
+      );
+    });
+
+    test('subscribe', async () => {
+      const clientTransport = getClientTransport('client');
+      const serverTransport = getServerTransport();
+      const services = {
+        service: ServiceSchema.define({
+          subscribe: Procedure.subscription({
+            init: Type.Object({}),
+            output: Type.Object({}),
+            async handler() {
+              throw new Error('unimplemented');
+            },
+          }),
+        }),
+      };
+      const client = createClient<typeof services>(
+        clientTransport,
+        serverTransport.clientId,
+      );
+      addPostTestCleanup(async () => {
+        await cleanupTransports([clientTransport, serverTransport]);
+      });
+
+      const serverOnMessage = vi.fn<[EventMap['message']]>();
+      serverTransport.addEventListener('message', serverOnMessage);
+
+      const abortController = new AbortController();
+      const signal = abortController.signal;
+      const outputReader = client.service.subscribe.subscribe({}, { signal });
+
+      await waitFor(() => {
+        expect(serverOnMessage).toHaveBeenCalledTimes(1);
+      });
+
+      abortController.abort();
+
+      expect(outputReader.isClosed());
+      await expect(outputReader.asArray()).resolves.toEqual([
+        {
+          ok: false,
+          payload: {
+            code: ABORT_CODE,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            message: expect.any(String),
+          },
+        },
+      ]);
+
+      await waitFor(() => {
+        expect(serverOnMessage).toHaveBeenCalledTimes(2);
+      });
+
+      const initStreamId = serverOnMessage.mock.calls[0][0].streamId;
+      expect(serverOnMessage).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          controlFlags: ControlFlags.StreamAbortBit,
+          payload: {
+            ok: false,
+            payload: {
+              code: ABORT_CODE,
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              message: expect.any(String),
+            },
+          },
+          streamId: initStreamId,
+        }),
+      );
+    });
+
+    test('stream', async () => {
+      const clientTransport = getClientTransport('client');
+      const serverTransport = getServerTransport();
+      const services = {
+        service: ServiceSchema.define({
+          stream: Procedure.stream({
+            init: Type.Object({}),
+            input: Type.Object({}),
+            output: Type.Object({}),
+            async handler() {
+              throw new Error('unimplemented');
+            },
+          }),
+        }),
+      };
+      const client = createClient<typeof services>(
+        clientTransport,
+        serverTransport.clientId,
+      );
+      addPostTestCleanup(async () => {
+        await cleanupTransports([clientTransport, serverTransport]);
+      });
+
+      const serverOnMessage = vi.fn<[EventMap['message']]>();
+      serverTransport.addEventListener('message', serverOnMessage);
+
+      const abortController = new AbortController();
+      const signal = abortController.signal;
+      const [inputWriter, outputReader] = client.service.stream.stream(
+        {},
+        { signal },
+      );
+
+      await waitFor(() => {
+        expect(serverOnMessage).toHaveBeenCalledTimes(1);
+      });
+
+      abortController.abort();
+
+      expect(outputReader.isClosed());
+      expect(inputWriter.isClosed());
+      await expect(outputReader.asArray()).resolves.toEqual([
+        {
+          ok: false,
+          payload: {
+            code: ABORT_CODE,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            message: expect.any(String),
+          },
+        },
+      ]);
+
+      await waitFor(() => {
+        expect(serverOnMessage).toHaveBeenCalledTimes(2);
+      });
+
+      const initStreamId = serverOnMessage.mock.calls[0][0].streamId;
+      expect(serverOnMessage).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          controlFlags: ControlFlags.StreamAbortBit,
+          payload: {
+            ok: false,
+            payload: {
+              code: ABORT_CODE,
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              message: expect.any(String),
+            },
+          },
+          streamId: initStreamId,
+        }),
+      );
+    });
+  },
+);
+
+describe.each(testMatrix())(
+  'server initiated abort, client tests ($transport.name transport, $codec.name codec)',
+  async ({ transport, codec }) => {
+    const opts = { codec: codec.codec };
+
+    const { addPostTestCleanup, postTestCleanup } = createPostTestCleanups();
+    let getClientTransport: TestSetupHelpers['getClientTransport'];
+    let getServerTransport: TestSetupHelpers['getServerTransport'];
+    beforeEach(async () => {
+      const setup = await transport.setup({ client: opts, server: opts });
+      getClientTransport = setup.getClientTransport;
+      getServerTransport = setup.getServerTransport;
+      return async () => {
+        await postTestCleanup();
+        await setup.cleanup();
+      };
+    });
+
+    test('rpc', async () => {
+      const clientTransport = getClientTransport('client');
+      const serverTransport = getServerTransport();
+      const services = {
+        service: ServiceSchema.define({
+          rpc: Procedure.rpc({
+            init: Type.Object({}),
+            output: Type.Object({}),
+            async handler() {
+              throw new Error('unimplemented');
+            },
+          }),
+        }),
+      };
+      const client = createClient<typeof services>(
+        clientTransport,
+        serverTransport.clientId,
+      );
+      addPostTestCleanup(async () => {
+        await cleanupTransports([clientTransport, serverTransport]);
+      });
+
+      const serverOnMessage = vi.fn<[EventMap['message']]>();
+      serverTransport.addEventListener('message', serverOnMessage);
+
+      const resP = client.service.rpc.rpc({});
+
+      await waitFor(() => {
+        expect(serverOnMessage).toHaveBeenCalledTimes(1);
+      });
+
+      const initStreamId = serverOnMessage.mock.calls[0][0].streamId;
+
+      serverTransport.sendAbort('client', initStreamId);
+
+      await expect(resP).resolves.toEqual({
+        ok: false,
+        payload: {
+          code: ABORT_CODE,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          message: expect.any(String),
+        },
+      });
+    });
+
+    test('upload', async () => {
+      const clientTransport = getClientTransport('client');
+      const serverTransport = getServerTransport();
+      const services = {
+        service: ServiceSchema.define({
+          upload: Procedure.upload({
+            init: Type.Object({}),
+            input: Type.Object({}),
+            output: Type.Object({}),
+            async handler() {
+              throw new Error('unimplemented');
+            },
+          }),
+        }),
+      };
+      const client = createClient<typeof services>(
+        clientTransport,
+        serverTransport.clientId,
+      );
+      addPostTestCleanup(async () => {
+        await cleanupTransports([clientTransport, serverTransport]);
+      });
+
+      const serverOnMessage = vi.fn<[EventMap['message']]>();
+      serverTransport.addEventListener('message', serverOnMessage);
+
+      const [inputWriter, finalize] = client.service.upload.upload({});
+
+      await waitFor(() => {
+        expect(serverOnMessage).toHaveBeenCalledTimes(1);
+      });
+
+      const initStreamId = serverOnMessage.mock.calls[0][0].streamId;
+
+      serverTransport.sendAbort('client', initStreamId);
+
+      await expect(finalize()).resolves.toEqual({
+        ok: false,
+        payload: {
+          code: ABORT_CODE,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          message: expect.any(String),
+        },
+      });
+      expect(inputWriter.isClosed());
+    });
+
+    test('stream', async () => {
+      const clientTransport = getClientTransport('client');
+      const serverTransport = getServerTransport();
+      const services = {
+        service: ServiceSchema.define({
+          stream: Procedure.stream({
+            init: Type.Object({}),
+            input: Type.Object({}),
+            output: Type.Object({}),
+            async handler() {
+              throw new Error('unimplemented');
+            },
+          }),
+        }),
+      };
+      const client = createClient<typeof services>(
+        clientTransport,
+        serverTransport.clientId,
+      );
+      addPostTestCleanup(async () => {
+        await cleanupTransports([clientTransport, serverTransport]);
+      });
+
+      const serverOnMessage = vi.fn<[EventMap['message']]>();
+      serverTransport.addEventListener('message', serverOnMessage);
+
+      const [inputWriter, outputReader] = client.service.stream.stream({});
+
+      await waitFor(() => {
+        expect(serverOnMessage).toHaveBeenCalledTimes(1);
+      });
+
+      const initStreamId = serverOnMessage.mock.calls[0][0].streamId;
+
+      serverTransport.sendAbort('client', initStreamId);
+
+      await expect(outputReader.asArray()).resolves.toEqual([
+        {
+          ok: false,
+          payload: {
+            code: ABORT_CODE,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            message: expect.any(String),
+          },
+        },
+      ]);
+      expect(inputWriter.isClosed());
+    });
+
+    test('subscribe', async () => {
+      const clientTransport = getClientTransport('client');
+      const serverTransport = getServerTransport();
+      const services = {
+        service: ServiceSchema.define({
+          subscribe: Procedure.subscription({
+            init: Type.Object({}),
+            output: Type.Object({}),
+            async handler() {
+              throw new Error('unimplemented');
+            },
+          }),
+        }),
+      };
+      const client = createClient<typeof services>(
+        clientTransport,
+        serverTransport.clientId,
+      );
+      addPostTestCleanup(async () => {
+        await cleanupTransports([clientTransport, serverTransport]);
+      });
+
+      const serverOnMessage = vi.fn<[EventMap['message']]>();
+      serverTransport.addEventListener('message', serverOnMessage);
+
+      const outputReader = client.service.subscribe.subscribe({});
+
+      await waitFor(() => {
+        expect(serverOnMessage).toHaveBeenCalledTimes(1);
+      });
+
+      const initStreamId = serverOnMessage.mock.calls[0][0].streamId;
+
+      serverTransport.sendAbort('client', initStreamId);
+
+      await expect(outputReader.asArray()).resolves.toEqual([
+        {
+          ok: false,
+          payload: {
+            code: ABORT_CODE,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            message: expect.any(String),
+          },
+        },
+      ]);
+    });
+  },
+);

--- a/router/procedures.ts
+++ b/router/procedures.ts
@@ -47,6 +47,10 @@ export const UNEXPECTED_DISCONNECT_CODE = 'UNEXPECTED_DISCONNECT';
  * INVALID_REQUEST_CODE is the code used when a client's request is invalid.
  */
 export const INVALID_REQUEST_CODE = 'INVALID_REQUEST';
+/**
+ * ABORT_CODE is the code used when either server or client aborts the stream.
+ */
+export const ABORT_CODE = 'ABORT';
 
 /**
  * OutputReaderErrorSchema is the schema for all the errors that can be
@@ -57,6 +61,7 @@ export const OutputReaderErrorSchema = Type.Object({
     Type.Literal(UNCAUGHT_ERROR_CODE),
     Type.Literal(UNEXPECTED_DISCONNECT_CODE),
     Type.Literal(INVALID_REQUEST_CODE),
+    Type.Literal(ABORT_CODE),
   ]),
   message: Type.String(),
 });

--- a/transport/message.ts
+++ b/transport/message.ts
@@ -23,9 +23,9 @@ export const enum ControlFlags {
    */
   StreamCloseRequestBit = 0b10000,
   /**
-   * Used when an abort happens due to cancellation or errors
+   * Used when a stream is aborted due to cancellation or errors
    */
-  AbortBit = 0b00100,
+  StreamAbortBit = 0b00100,
 }
 
 /**
@@ -126,8 +126,8 @@ export const OpaqueTransportMessageSchema = TransportMessageSchema(
  */
 export interface TransportMessage<Payload = unknown> {
   id: string;
-  from: string;
-  to: string;
+  from: TransportClientId;
+  to: TransportClientId;
   seq: number;
   ack: number;
   serviceName?: string;
@@ -240,5 +240,17 @@ export function isStreamCloseRequest(controlFlag: number): boolean {
     /* eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison */
     (controlFlag & ControlFlags.StreamCloseRequestBit) ===
     ControlFlags.StreamCloseRequestBit
+  );
+}
+
+/**
+ * Checks if the given control flag (usually found in msg.controlFlag) is an abort message.
+ * @param controlFlag - The control flag to check.
+ * @returns True if the control flag contains the AbortBit, false otherwise
+ */
+export function isStreamAbort(controlFlag: number): boolean {
+  return (
+    /* eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison */
+    (controlFlag & ControlFlags.StreamAbortBit) === ControlFlags.StreamAbortBit
   );
 }

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -44,6 +44,8 @@ import {
   ClientHandshakeOptions,
   ServerHandshakeOptions,
 } from '../router/handshake';
+import { Err } from '../router';
+import { ABORT_CODE } from '../router/procedures';
 
 /**
  * Represents the possible states of a transport.
@@ -531,6 +533,17 @@ export abstract class Transport<ConnType extends Connection> {
       payload: {
         type: 'CLOSE' as const,
       } satisfies Static<typeof ControlMessagePayloadSchema>,
+    });
+  }
+
+  sendAbort(to: TransportClientId, streamId: string) {
+    return this.send(to, {
+      streamId: streamId,
+      controlFlags: ControlFlags.StreamAbortBit,
+      payload: Err({
+        code: ABORT_CODE,
+        message: 'Stream aborted',
+      }),
     });
   }
 


### PR DESCRIPTION
## Why

Client-side implementation for #175 

## What changed

Client calls now accept an `options` parameter (in addition to `init`), the only option is `signal` which is an abort signal so that the caller can abort the stream. Internally nothing crazy, mostly adding code.
