### PR TITLE
Expose schema diffing function and types

### DIFF
--- a/router/index.ts
+++ b/router/index.ts
@@ -15,6 +15,13 @@ export {
   SerializedServiceSchema,
   SerializedProcedureSchema,
 } from './services';
+export {
+  diffServerSchema,
+  ServerBreakage,
+  ServiceBreakage,
+  ProcedureBreakage,
+  PayloadBreakage,
+} from './diff';
 export type {
   ValidProcType,
   PayloadType,


### PR DESCRIPTION
## Why

We added some tooling for detecting breaking changes between schemas, but we did not export them, so they couldn't be used from outside this package.

## What changed

- Expose `diffServerSchema` and related types

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
