### PR TITLE
Release new version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.23.9",
+  "version": "0.23.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.23.9",
+      "version": "0.23.10",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.23.9",
+  "version": "0.23.10",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Why

Time for a new version!

## What changed

```
d213eaf Expose schema diffing function and types (#194) [GitHub]
09803c8 Check if the span is recording before passing along traceId (#192) [GitHub]
07ae7f5 build(deps-dev): bump braces from 3.0.2 to 3.0.3 (#191) [GitHub]
f70e710 Don't share servers among tests (#189) [GitHub]
2ae4c58 Remove all transport listeners on destroy [Faris Masad]
bf63f80 Tie server lifetime to transport [Faris Masad]
a2a3345 Remove disposable state feature [Faris Masad]
feb3271 Remove destroy state from transport, close is now destroy [Faris Masad]
c1fb454 Emit status events when transport status changes [Faris Masad]
4c8f702 Fix adding and removing listeners during a notification changing list of handlers to notify (#182) [GitHub]
534b7d0 [dev] Deflake the tests (#177) [GitHub]
f9a51ba [dev] Do not log that the handshake timed out when it didn't (#180) [GitHub]
```

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

