### PR TITLE
Add options to ignore service/procedure removal during diffing

### DIFF
--- a/__tests__/diff.test.ts
+++ b/__tests__/diff.test.ts
@@ -2674,6 +2674,65 @@ describe('schema backwards compatible changes', () => {
     const diff = diffServerSchema(oldSchema, newSchema);
     expect(diff).toBeNull();
   });
+
+  test('service removal is compatible when explicitly allowed', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({}),
+            output: Type.Object({
+              total: Type.Optional(Type.Number()),
+            }),
+            handler: async (_) => ({ ok: true, payload: { total: 0 } }),
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({});
+
+    const diff = diffServerSchema(oldSchema, newSchema, {
+      allowServiceRemoval: true,
+    });
+    expect(diff).toBeNull();
+  });
+
+  test('procedure removal is compatible when explicitly allowed', () => {
+    const oldSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {
+          add: Procedure.rpc({
+            input: Type.Object({}),
+            output: Type.Object({
+              total: Type.Optional(Type.Number()),
+            }),
+            handler: async (_) => ({ ok: true, payload: { total: 0 } }),
+          }),
+        },
+      ),
+    });
+
+    const newSchema = serializeSchema({
+      adder: ServiceSchema.define(
+        {
+          initializeState: () => ({}),
+        },
+        {},
+      ),
+    });
+
+    const diff = diffServerSchema(oldSchema, newSchema, {
+      allowProcedureRemoval: true,
+    });
+    expect(diff).toBeNull();
+  });
 });
 
 describe('unsupported schema', () => {

--- a/router/diff.ts
+++ b/router/diff.ts
@@ -48,9 +48,15 @@ export type PayloadBreakage =
       fieldBreakages: Record<string, PayloadBreakage>;
     };
 
+export interface DiffOptions {
+  allowServiceRemoval?: boolean;
+  allowProcedureRemoval?: boolean;
+}
+
 export function diffServerSchema(
   oldServer: SerializedServerSchema,
   newServer: SerializedServerSchema,
+  options?: DiffOptions,
 ): ServerBreakage | null {
   const allServices = new Set([
     ...Object.keys(oldServer.services),
@@ -62,7 +68,7 @@ export function diffServerSchema(
     const oldService = oldServer.services[serviceName];
     const newService = newServer.services[serviceName];
 
-    const breakage = diffService(oldService, newService);
+    const breakage = diffService(oldService, newService, options);
     if (breakage) {
       breakages[serviceName] = breakage;
     }
@@ -78,9 +84,10 @@ export function diffServerSchema(
 function diffService(
   oldService: SerializedServiceSchema | null,
   newService: SerializedServiceSchema | null,
+  options?: DiffOptions,
 ): ServiceBreakage | null {
   if (!newService) {
-    return { reason: 'removed' };
+    return options?.allowServiceRemoval ? null : { reason: 'removed' };
   }
   // New service, perfectly fine.
   if (!oldService) {
@@ -97,7 +104,7 @@ function diffService(
     const aProcedure = oldService.procedures[procedureName];
     const bProcedure = newService.procedures[procedureName];
 
-    const breakage = diffProcedure(aProcedure, bProcedure);
+    const breakage = diffProcedure(aProcedure, bProcedure, options);
     if (breakage) {
       breakages[procedureName] = breakage;
     }
@@ -112,9 +119,10 @@ function diffService(
 function diffProcedure(
   oldProcedure: SerializedProcedureSchema | null,
   newProcedure: SerializedProcedureSchema | null,
+  options?: DiffOptions,
 ): ProcedureBreakage | null {
   if (!newProcedure) {
-    return { reason: 'removed' };
+    return options?.allowProcedureRemoval ? null : { reason: 'removed' };
   }
   // New service, perfectly fine.
   if (!oldProcedure) {

--- a/router/index.ts
+++ b/router/index.ts
@@ -17,6 +17,7 @@ export {
 } from './services';
 export {
   diffServerSchema,
+  DiffOptions,
   ServerBreakage,
   ServiceBreakage,
   ProcedureBreakage,


### PR DESCRIPTION
## Why

Right now we have no way to mark services/procedures as deprecated, so there is no nice path for removing services/procedures.

Until we have a way to properly handle deprecation, we can skip these checks.

## What changed

- Add options to diffing to allow service and procedure removal

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
