### PR TITLE
Bump version to 0.23.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.23.10",
+  "version": "0.23.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.23.10",
+      "version": "0.23.11",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.23.10",
+  "version": "0.23.11",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Why

Cutting a new release so we can ignore service/procedure removal when checking schemas for breakage

## What changed

```
256c02a Add options to ignore service/procedure removal during diffing (#198)
```

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
