### PR TITLE
[protocolv2] Implement server abort

### DIFF
--- a/__tests__/abort.test.ts
+++ b/__tests__/abort.test.ts
@@ -1,6 +1,11 @@
 import { Type } from '@sinclair/typebox';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { Procedure, ServiceSchema, createClient } from '../router';
+import {
+  Procedure,
+  ServiceSchema,
+  createClient,
+  createServer,
+} from '../router';
 import { testMatrix } from './fixtures/matrix';
 import {
   cleanupTransports,
@@ -8,12 +13,14 @@ import {
   waitFor,
 } from './fixtures/cleanup';
 import { EventMap } from '../transport';
-import { ABORT_CODE } from '../router/procedures';
+import { ABORT_CODE, StreamProcedure } from '../router/procedures';
 import { ControlFlags } from '../transport/message';
 import { TestSetupHelpers } from './fixtures/transports';
+import { nanoid } from 'nanoid';
+import { ProcedureHandlerContext } from '../router/context';
 
 describe.each(testMatrix())(
-  'client initiated abort, client tests ($transport.name transport, $codec.name codec)',
+  'client initiated abort ($transport.name transport, $codec.name codec)',
   async ({ transport, codec }) => {
     const opts = { codec: codec.codec };
 
@@ -30,274 +37,182 @@ describe.each(testMatrix())(
       };
     });
 
-    test('rpc', async () => {
-      const clientTransport = getClientTransport('client');
-      const serverTransport = getServerTransport();
-      const services = {
-        service: ServiceSchema.define({
-          rpc: Procedure.rpc({
-            init: Type.Object({}),
-            output: Type.Object({}),
-            async handler() {
-              throw new Error('unimplemented');
-            },
+    describe('real client, mock server', () => {
+      test('rpc', async () => {
+        const clientTransport = getClientTransport('client');
+        const serverTransport = getServerTransport();
+        const services = {
+          service: ServiceSchema.define({
+            rpc: Procedure.rpc({
+              init: Type.Object({}),
+              output: Type.Object({}),
+              async handler() {
+                throw new Error('unimplemented');
+              },
+            }),
           }),
-        }),
-      };
-      const client = createClient<typeof services>(
-        clientTransport,
-        serverTransport.clientId,
-      );
-      addPostTestCleanup(async () => {
-        await cleanupTransports([clientTransport, serverTransport]);
-      });
+        };
+        const client = createClient<typeof services>(
+          clientTransport,
+          serverTransport.clientId,
+        );
+        addPostTestCleanup(async () => {
+          await cleanupTransports([clientTransport, serverTransport]);
+        });
 
-      const serverOnMessage = vi.fn<[EventMap['message']]>();
-      serverTransport.addEventListener('message', serverOnMessage);
+        const serverOnMessage = vi.fn<[EventMap['message']]>();
+        serverTransport.addEventListener('message', serverOnMessage);
 
-      const abortController = new AbortController();
-      const signal = abortController.signal;
-      const resP = client.service.rpc.rpc({}, { signal });
+        const abortController = new AbortController();
+        const signal = abortController.signal;
+        const resP = client.service.rpc.rpc({}, { signal });
 
-      await waitFor(() => {
-        expect(serverOnMessage).toHaveBeenCalledTimes(1);
-      });
+        await waitFor(() => {
+          expect(serverOnMessage).toHaveBeenCalledTimes(1);
+        });
 
-      abortController.abort();
+        abortController.abort();
 
-      await expect(resP).resolves.toEqual({
-        ok: false,
-        payload: {
-          code: ABORT_CODE,
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          message: expect.any(String),
-        },
-      });
-
-      await waitFor(() => {
-        expect(serverOnMessage).toHaveBeenCalledTimes(2);
-      });
-
-      const initStreamId = serverOnMessage.mock.calls[0][0].streamId;
-      expect(serverOnMessage).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          controlFlags: ControlFlags.StreamAbortBit,
-          payload: {
-            ok: false,
-            payload: {
-              code: ABORT_CODE,
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              message: expect.any(String),
-            },
-          },
-          streamId: initStreamId,
-        }),
-      );
-    });
-
-    test('upload', async () => {
-      const clientTransport = getClientTransport('client');
-      const serverTransport = getServerTransport();
-      const services = {
-        service: ServiceSchema.define({
-          upload: Procedure.upload({
-            init: Type.Object({}),
-            input: Type.Object({}),
-            output: Type.Object({}),
-            async handler() {
-              throw new Error('unimplemented');
-            },
-          }),
-        }),
-      };
-      const client = createClient<typeof services>(
-        clientTransport,
-        serverTransport.clientId,
-      );
-      addPostTestCleanup(async () => {
-        await cleanupTransports([clientTransport, serverTransport]);
-      });
-
-      const serverOnMessage = vi.fn<[EventMap['message']]>();
-      serverTransport.addEventListener('message', serverOnMessage);
-
-      const abortController = new AbortController();
-      const signal = abortController.signal;
-      const [inputWriter, finalize] = client.service.upload.upload(
-        {},
-        { signal },
-      );
-
-      await waitFor(() => {
-        expect(serverOnMessage).toHaveBeenCalledTimes(1);
-      });
-
-      abortController.abort();
-
-      expect(inputWriter.isClosed());
-      await expect(finalize()).resolves.toEqual({
-        ok: false,
-        payload: {
-          code: ABORT_CODE,
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          message: expect.any(String),
-        },
-      });
-
-      await waitFor(() => {
-        expect(serverOnMessage).toHaveBeenCalledTimes(2);
-      });
-
-      const initStreamId = serverOnMessage.mock.calls[0][0].streamId;
-      expect(serverOnMessage).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          controlFlags: ControlFlags.StreamAbortBit,
-          payload: {
-            ok: false,
-            payload: {
-              code: ABORT_CODE,
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              message: expect.any(String),
-            },
-          },
-          streamId: initStreamId,
-        }),
-      );
-    });
-
-    test('subscribe', async () => {
-      const clientTransport = getClientTransport('client');
-      const serverTransport = getServerTransport();
-      const services = {
-        service: ServiceSchema.define({
-          subscribe: Procedure.subscription({
-            init: Type.Object({}),
-            output: Type.Object({}),
-            async handler() {
-              throw new Error('unimplemented');
-            },
-          }),
-        }),
-      };
-      const client = createClient<typeof services>(
-        clientTransport,
-        serverTransport.clientId,
-      );
-      addPostTestCleanup(async () => {
-        await cleanupTransports([clientTransport, serverTransport]);
-      });
-
-      const serverOnMessage = vi.fn<[EventMap['message']]>();
-      serverTransport.addEventListener('message', serverOnMessage);
-
-      const abortController = new AbortController();
-      const signal = abortController.signal;
-      const outputReader = client.service.subscribe.subscribe({}, { signal });
-
-      await waitFor(() => {
-        expect(serverOnMessage).toHaveBeenCalledTimes(1);
-      });
-
-      abortController.abort();
-
-      expect(outputReader.isClosed());
-      await expect(outputReader.asArray()).resolves.toEqual([
-        {
+        await expect(resP).resolves.toEqual({
           ok: false,
           payload: {
             code: ABORT_CODE,
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             message: expect.any(String),
           },
-        },
-      ]);
+        });
 
-      await waitFor(() => {
-        expect(serverOnMessage).toHaveBeenCalledTimes(2);
-      });
+        await waitFor(() => {
+          expect(serverOnMessage).toHaveBeenCalledTimes(2);
+        });
 
-      const initStreamId = serverOnMessage.mock.calls[0][0].streamId;
-      expect(serverOnMessage).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          controlFlags: ControlFlags.StreamAbortBit,
-          payload: {
-            ok: false,
+        const initStreamId = serverOnMessage.mock.calls[0][0].streamId;
+        expect(serverOnMessage).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({
+            controlFlags: ControlFlags.StreamAbortBit,
             payload: {
-              code: ABORT_CODE,
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              message: expect.any(String),
+              ok: false,
+              payload: {
+                code: ABORT_CODE,
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                message: expect.any(String),
+              },
             },
-          },
-          streamId: initStreamId,
-        }),
-      );
-    });
-
-    test('stream', async () => {
-      const clientTransport = getClientTransport('client');
-      const serverTransport = getServerTransport();
-      const services = {
-        service: ServiceSchema.define({
-          stream: Procedure.stream({
-            init: Type.Object({}),
-            input: Type.Object({}),
-            output: Type.Object({}),
-            async handler() {
-              throw new Error('unimplemented');
-            },
+            streamId: initStreamId,
           }),
-        }),
-      };
-      const client = createClient<typeof services>(
-        clientTransport,
-        serverTransport.clientId,
-      );
-      addPostTestCleanup(async () => {
-        await cleanupTransports([clientTransport, serverTransport]);
+        );
       });
 
-      const serverOnMessage = vi.fn<[EventMap['message']]>();
-      serverTransport.addEventListener('message', serverOnMessage);
+      test('upload', async () => {
+        const clientTransport = getClientTransport('client');
+        const serverTransport = getServerTransport();
+        const services = {
+          service: ServiceSchema.define({
+            upload: Procedure.upload({
+              init: Type.Object({}),
+              input: Type.Object({}),
+              output: Type.Object({}),
+              async handler() {
+                throw new Error('unimplemented');
+              },
+            }),
+          }),
+        };
+        const client = createClient<typeof services>(
+          clientTransport,
+          serverTransport.clientId,
+        );
+        addPostTestCleanup(async () => {
+          await cleanupTransports([clientTransport, serverTransport]);
+        });
 
-      const abortController = new AbortController();
-      const signal = abortController.signal;
-      const [inputWriter, outputReader] = client.service.stream.stream(
-        {},
-        { signal },
-      );
+        const serverOnMessage = vi.fn<[EventMap['message']]>();
+        serverTransport.addEventListener('message', serverOnMessage);
 
-      await waitFor(() => {
-        expect(serverOnMessage).toHaveBeenCalledTimes(1);
-      });
+        const abortController = new AbortController();
+        const signal = abortController.signal;
+        const [inputWriter, finalize] = client.service.upload.upload(
+          {},
+          { signal },
+        );
 
-      abortController.abort();
+        await waitFor(() => {
+          expect(serverOnMessage).toHaveBeenCalledTimes(1);
+        });
 
-      expect(outputReader.isClosed());
-      expect(inputWriter.isClosed());
-      await expect(outputReader.asArray()).resolves.toEqual([
-        {
+        abortController.abort();
+
+        expect(inputWriter.isClosed());
+        await expect(finalize()).resolves.toEqual({
           ok: false,
           payload: {
             code: ABORT_CODE,
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             message: expect.any(String),
           },
-        },
-      ]);
+        });
 
-      await waitFor(() => {
-        expect(serverOnMessage).toHaveBeenCalledTimes(2);
+        await waitFor(() => {
+          expect(serverOnMessage).toHaveBeenCalledTimes(2);
+        });
+
+        const initStreamId = serverOnMessage.mock.calls[0][0].streamId;
+        expect(serverOnMessage).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({
+            controlFlags: ControlFlags.StreamAbortBit,
+            payload: {
+              ok: false,
+              payload: {
+                code: ABORT_CODE,
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                message: expect.any(String),
+              },
+            },
+            streamId: initStreamId,
+          }),
+        );
       });
 
-      const initStreamId = serverOnMessage.mock.calls[0][0].streamId;
-      expect(serverOnMessage).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          controlFlags: ControlFlags.StreamAbortBit,
-          payload: {
+      test('subscribe', async () => {
+        const clientTransport = getClientTransport('client');
+        const serverTransport = getServerTransport();
+        const services = {
+          service: ServiceSchema.define({
+            subscribe: Procedure.subscription({
+              init: Type.Object({}),
+              output: Type.Object({}),
+              async handler() {
+                throw new Error('unimplemented');
+              },
+            }),
+          }),
+        };
+        const client = createClient<typeof services>(
+          clientTransport,
+          serverTransport.clientId,
+        );
+        addPostTestCleanup(async () => {
+          await cleanupTransports([clientTransport, serverTransport]);
+        });
+
+        const serverOnMessage = vi.fn<[EventMap['message']]>();
+        serverTransport.addEventListener('message', serverOnMessage);
+
+        const abortController = new AbortController();
+        const signal = abortController.signal;
+        const outputReader = client.service.subscribe.subscribe({}, { signal });
+
+        await waitFor(() => {
+          expect(serverOnMessage).toHaveBeenCalledTimes(1);
+        });
+
+        abortController.abort();
+
+        expect(outputReader.isClosed());
+        await expect(outputReader.asArray()).resolves.toEqual([
+          {
             ok: false,
             payload: {
               code: ABORT_CODE,
@@ -305,15 +220,270 @@ describe.each(testMatrix())(
               message: expect.any(String),
             },
           },
-          streamId: initStreamId,
-        }),
+        ]);
+
+        await waitFor(() => {
+          expect(serverOnMessage).toHaveBeenCalledTimes(2);
+        });
+
+        const initStreamId = serverOnMessage.mock.calls[0][0].streamId;
+        expect(serverOnMessage).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({
+            controlFlags: ControlFlags.StreamAbortBit,
+            payload: {
+              ok: false,
+              payload: {
+                code: ABORT_CODE,
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                message: expect.any(String),
+              },
+            },
+            streamId: initStreamId,
+          }),
+        );
+      });
+
+      test('stream', async () => {
+        const clientTransport = getClientTransport('client');
+        const serverTransport = getServerTransport();
+        const services = {
+          service: ServiceSchema.define({
+            stream: Procedure.stream({
+              init: Type.Object({}),
+              input: Type.Object({}),
+              output: Type.Object({}),
+              async handler() {
+                throw new Error('unimplemented');
+              },
+            }),
+          }),
+        };
+        const client = createClient<typeof services>(
+          clientTransport,
+          serverTransport.clientId,
+        );
+        addPostTestCleanup(async () => {
+          await cleanupTransports([clientTransport, serverTransport]);
+        });
+
+        const serverOnMessage = vi.fn<[EventMap['message']]>();
+        serverTransport.addEventListener('message', serverOnMessage);
+
+        const abortController = new AbortController();
+        const signal = abortController.signal;
+        const [inputWriter, outputReader] = client.service.stream.stream(
+          {},
+          { signal },
+        );
+
+        await waitFor(() => {
+          expect(serverOnMessage).toHaveBeenCalledTimes(1);
+        });
+
+        abortController.abort();
+
+        expect(outputReader.isClosed());
+        expect(inputWriter.isClosed());
+        await expect(outputReader.asArray()).resolves.toEqual([
+          {
+            ok: false,
+            payload: {
+              code: ABORT_CODE,
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              message: expect.any(String),
+            },
+          },
+        ]);
+
+        await waitFor(() => {
+          expect(serverOnMessage).toHaveBeenCalledTimes(2);
+        });
+
+        const initStreamId = serverOnMessage.mock.calls[0][0].streamId;
+        expect(serverOnMessage).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({
+            controlFlags: ControlFlags.StreamAbortBit,
+            payload: {
+              ok: false,
+              payload: {
+                code: ABORT_CODE,
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                message: expect.any(String),
+              },
+            },
+            streamId: initStreamId,
+          }),
+        );
+      });
+    });
+
+    describe('real server, mock client', () => {
+      test.each([
+        { procedureType: 'rpc' },
+        { procedureType: 'subscription' },
+        { procedureType: 'stream' },
+        { procedureType: 'upload' },
+      ] as const)(
+        '$procedureType: mock client, real server',
+        async ({ procedureType }) => {
+          const clientTransport = getClientTransport('client');
+          const serverTransport = getServerTransport();
+          const serverId = 'SERVER';
+          const serviceName = 'service';
+          const procedureName = procedureType;
+          const handler = vi.fn().mockImplementation(
+            () =>
+              new Promise(() => {
+                // never resolves
+              }),
+          );
+
+          const services = {
+            [serviceName]: ServiceSchema.define({
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
+              [procedureType]: (Procedure[procedureType] as any)({
+                init: Type.Object({}),
+                ...(procedureType === 'stream' || procedureType === 'upload'
+                  ? {
+                      input: Type.Object({}),
+                    }
+                  : {}),
+                output: Type.Object({}),
+                handler,
+              }),
+            }),
+          };
+
+          const server = createServer(serverTransport, services);
+
+          addPostTestCleanup(async () => {
+            await cleanupTransports([clientTransport, serverTransport]);
+          });
+
+          const streamId = nanoid();
+          clientTransport.send(serverId, {
+            streamId,
+            serviceName,
+            procedureName,
+            payload: {},
+            controlFlags:
+              ControlFlags.StreamOpenBit | ControlFlags.StreamClosedBit,
+          });
+
+          const serverOnMessage = vi.fn<[EventMap['message']]>();
+          serverTransport.addEventListener('message', serverOnMessage);
+
+          await waitFor(() => {
+            expect(serverOnMessage).toHaveBeenCalledTimes(1);
+          });
+
+          expect(server.openStreams.size).toEqual(1);
+          expect(handler).toHaveBeenCalledTimes(1);
+          const ctx =
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            handler.mock.calls[0][0] as ProcedureHandlerContext<object>;
+          const onClientAbort = vi.fn();
+          ctx.clientAbortSignal.onabort = onClientAbort;
+
+          clientTransport.sendAbort(serverId, streamId);
+
+          await waitFor(() => {
+            expect(serverOnMessage).toHaveBeenCalledTimes(2);
+          });
+
+          expect(onClientAbort).toHaveBeenCalled();
+          expect(server.openStreams.size).toEqual(0);
+        },
       );
+    });
+
+    describe('e2e', () => {
+      // testing stream only e2e as it's the most general case
+      test('stream', async () => {
+        const clientTransport = getClientTransport('client');
+        const serverTransport = getServerTransport();
+        const handler = vi
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .fn<Parameters<StreamProcedure<any, any, any, any, any>['handler']>>()
+          .mockImplementation(
+            () =>
+              new Promise(() => {
+                // never resolves
+              }),
+          );
+        const services = {
+          service: ServiceSchema.define({
+            stream: Procedure.stream({
+              init: Type.Object({}),
+              input: Type.Object({}),
+              output: Type.Object({}),
+              handler,
+            }),
+          }),
+        };
+        createServer(serverTransport, services);
+        const client = createClient<typeof services>(
+          clientTransport,
+          serverTransport.clientId,
+        );
+
+        const clientAbortController = new AbortController();
+
+        const [clientInputWriter, clientOutputReader] =
+          client.service.stream.stream(
+            {},
+            { signal: clientAbortController.signal },
+          );
+
+        await waitFor(() => {
+          expect(handler).toHaveBeenCalledTimes(1);
+        });
+
+        const [ctx, , serverInputReader, serverOutputWriter] =
+          handler.mock.calls[0];
+        const onClientAbort = vi.fn();
+        ctx.clientAbortSignal.onabort = onClientAbort;
+
+        clientAbortController.abort();
+        // this should be ignored by the client since it already aborted
+        serverOutputWriter.write({ ok: true, payload: {} });
+        expect(await clientOutputReader.asArray()).toEqual([
+          {
+            ok: false,
+            payload: {
+              code: ABORT_CODE,
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              message: expect.any(String),
+            },
+          },
+        ]);
+        expect(clientOutputReader.isClosed());
+        expect(clientInputWriter.isClosed());
+
+        await waitFor(() => {
+          expect(onClientAbort).toHaveBeenCalled();
+        });
+        expect(await serverInputReader.asArray()).toEqual([
+          {
+            ok: false,
+            payload: {
+              code: ABORT_CODE,
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              message: expect.any(String),
+            },
+          },
+        ]);
+        expect(serverInputReader.isClosed());
+        expect(serverOutputWriter.isClosed());
+      });
     });
   },
 );
 
 describe.each(testMatrix())(
-  'server initiated abort, client tests ($transport.name transport, $codec.name codec)',
+  'server explicit abort ($transport.name transport, $codec.name codec)',
   async ({ transport, codec }) => {
     const opts = { codec: codec.codec };
 
@@ -330,192 +500,356 @@ describe.each(testMatrix())(
       };
     });
 
-    test('rpc', async () => {
-      const clientTransport = getClientTransport('client');
-      const serverTransport = getServerTransport();
-      const services = {
-        service: ServiceSchema.define({
-          rpc: Procedure.rpc({
-            init: Type.Object({}),
-            output: Type.Object({}),
-            async handler() {
-              throw new Error('unimplemented');
-            },
+    describe('real client, mock server', () => {
+      test('rpc', async () => {
+        const clientTransport = getClientTransport('client');
+        const serverTransport = getServerTransport();
+        const services = {
+          service: ServiceSchema.define({
+            rpc: Procedure.rpc({
+              init: Type.Object({}),
+              output: Type.Object({}),
+              async handler() {
+                throw new Error('unimplemented');
+              },
+            }),
           }),
-        }),
-      };
-      const client = createClient<typeof services>(
-        clientTransport,
-        serverTransport.clientId,
-      );
-      addPostTestCleanup(async () => {
-        await cleanupTransports([clientTransport, serverTransport]);
-      });
+        };
+        const client = createClient<typeof services>(
+          clientTransport,
+          serverTransport.clientId,
+        );
+        addPostTestCleanup(async () => {
+          await cleanupTransports([clientTransport, serverTransport]);
+        });
 
-      const serverOnMessage = vi.fn<[EventMap['message']]>();
-      serverTransport.addEventListener('message', serverOnMessage);
+        const serverOnMessage = vi.fn<[EventMap['message']]>();
+        serverTransport.addEventListener('message', serverOnMessage);
 
-      const resP = client.service.rpc.rpc({});
+        const resP = client.service.rpc.rpc({});
 
-      await waitFor(() => {
-        expect(serverOnMessage).toHaveBeenCalledTimes(1);
-      });
+        await waitFor(() => {
+          expect(serverOnMessage).toHaveBeenCalledTimes(1);
+        });
 
-      const initStreamId = serverOnMessage.mock.calls[0][0].streamId;
+        const initStreamId = serverOnMessage.mock.calls[0][0].streamId;
 
-      serverTransport.sendAbort('client', initStreamId);
+        serverTransport.sendAbort('client', initStreamId);
 
-      await expect(resP).resolves.toEqual({
-        ok: false,
-        payload: {
-          code: ABORT_CODE,
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          message: expect.any(String),
-        },
-      });
-    });
-
-    test('upload', async () => {
-      const clientTransport = getClientTransport('client');
-      const serverTransport = getServerTransport();
-      const services = {
-        service: ServiceSchema.define({
-          upload: Procedure.upload({
-            init: Type.Object({}),
-            input: Type.Object({}),
-            output: Type.Object({}),
-            async handler() {
-              throw new Error('unimplemented');
-            },
-          }),
-        }),
-      };
-      const client = createClient<typeof services>(
-        clientTransport,
-        serverTransport.clientId,
-      );
-      addPostTestCleanup(async () => {
-        await cleanupTransports([clientTransport, serverTransport]);
-      });
-
-      const serverOnMessage = vi.fn<[EventMap['message']]>();
-      serverTransport.addEventListener('message', serverOnMessage);
-
-      const [inputWriter, finalize] = client.service.upload.upload({});
-
-      await waitFor(() => {
-        expect(serverOnMessage).toHaveBeenCalledTimes(1);
-      });
-
-      const initStreamId = serverOnMessage.mock.calls[0][0].streamId;
-
-      serverTransport.sendAbort('client', initStreamId);
-
-      await expect(finalize()).resolves.toEqual({
-        ok: false,
-        payload: {
-          code: ABORT_CODE,
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          message: expect.any(String),
-        },
-      });
-      expect(inputWriter.isClosed());
-    });
-
-    test('stream', async () => {
-      const clientTransport = getClientTransport('client');
-      const serverTransport = getServerTransport();
-      const services = {
-        service: ServiceSchema.define({
-          stream: Procedure.stream({
-            init: Type.Object({}),
-            input: Type.Object({}),
-            output: Type.Object({}),
-            async handler() {
-              throw new Error('unimplemented');
-            },
-          }),
-        }),
-      };
-      const client = createClient<typeof services>(
-        clientTransport,
-        serverTransport.clientId,
-      );
-      addPostTestCleanup(async () => {
-        await cleanupTransports([clientTransport, serverTransport]);
-      });
-
-      const serverOnMessage = vi.fn<[EventMap['message']]>();
-      serverTransport.addEventListener('message', serverOnMessage);
-
-      const [inputWriter, outputReader] = client.service.stream.stream({});
-
-      await waitFor(() => {
-        expect(serverOnMessage).toHaveBeenCalledTimes(1);
-      });
-
-      const initStreamId = serverOnMessage.mock.calls[0][0].streamId;
-
-      serverTransport.sendAbort('client', initStreamId);
-
-      await expect(outputReader.asArray()).resolves.toEqual([
-        {
+        await expect(resP).resolves.toEqual({
           ok: false,
           payload: {
             code: ABORT_CODE,
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             message: expect.any(String),
           },
-        },
-      ]);
-      expect(inputWriter.isClosed());
-    });
+        });
+      });
 
-    test('subscribe', async () => {
-      const clientTransport = getClientTransport('client');
-      const serverTransport = getServerTransport();
-      const services = {
-        service: ServiceSchema.define({
-          subscribe: Procedure.subscription({
-            init: Type.Object({}),
-            output: Type.Object({}),
-            async handler() {
-              throw new Error('unimplemented');
-            },
+      test('upload', async () => {
+        const clientTransport = getClientTransport('client');
+        const serverTransport = getServerTransport();
+        const services = {
+          service: ServiceSchema.define({
+            upload: Procedure.upload({
+              init: Type.Object({}),
+              input: Type.Object({}),
+              output: Type.Object({}),
+              async handler() {
+                throw new Error('unimplemented');
+              },
+            }),
           }),
-        }),
-      };
-      const client = createClient<typeof services>(
-        clientTransport,
-        serverTransport.clientId,
-      );
-      addPostTestCleanup(async () => {
-        await cleanupTransports([clientTransport, serverTransport]);
-      });
+        };
+        const client = createClient<typeof services>(
+          clientTransport,
+          serverTransport.clientId,
+        );
+        addPostTestCleanup(async () => {
+          await cleanupTransports([clientTransport, serverTransport]);
+        });
 
-      const serverOnMessage = vi.fn<[EventMap['message']]>();
-      serverTransport.addEventListener('message', serverOnMessage);
+        const serverOnMessage = vi.fn<[EventMap['message']]>();
+        serverTransport.addEventListener('message', serverOnMessage);
 
-      const outputReader = client.service.subscribe.subscribe({});
+        const [inputWriter, finalize] = client.service.upload.upload({});
 
-      await waitFor(() => {
-        expect(serverOnMessage).toHaveBeenCalledTimes(1);
-      });
+        await waitFor(() => {
+          expect(serverOnMessage).toHaveBeenCalledTimes(1);
+        });
 
-      const initStreamId = serverOnMessage.mock.calls[0][0].streamId;
+        const initStreamId = serverOnMessage.mock.calls[0][0].streamId;
 
-      serverTransport.sendAbort('client', initStreamId);
+        serverTransport.sendAbort('client', initStreamId);
 
-      await expect(outputReader.asArray()).resolves.toEqual([
-        {
+        await expect(finalize()).resolves.toEqual({
           ok: false,
           payload: {
             code: ABORT_CODE,
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             message: expect.any(String),
           },
-        },
-      ]);
+        });
+        expect(inputWriter.isClosed());
+      });
+
+      test('stream', async () => {
+        const clientTransport = getClientTransport('client');
+        const serverTransport = getServerTransport();
+        const services = {
+          service: ServiceSchema.define({
+            stream: Procedure.stream({
+              init: Type.Object({}),
+              input: Type.Object({}),
+              output: Type.Object({}),
+              async handler() {
+                throw new Error('unimplemented');
+              },
+            }),
+          }),
+        };
+        const client = createClient<typeof services>(
+          clientTransport,
+          serverTransport.clientId,
+        );
+        addPostTestCleanup(async () => {
+          await cleanupTransports([clientTransport, serverTransport]);
+        });
+
+        const serverOnMessage = vi.fn<[EventMap['message']]>();
+        serverTransport.addEventListener('message', serverOnMessage);
+
+        const [inputWriter, outputReader] = client.service.stream.stream({});
+
+        await waitFor(() => {
+          expect(serverOnMessage).toHaveBeenCalledTimes(1);
+        });
+
+        const initStreamId = serverOnMessage.mock.calls[0][0].streamId;
+
+        serverTransport.sendAbort('client', initStreamId);
+
+        await expect(outputReader.asArray()).resolves.toEqual([
+          {
+            ok: false,
+            payload: {
+              code: ABORT_CODE,
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              message: expect.any(String),
+            },
+          },
+        ]);
+        expect(inputWriter.isClosed());
+      });
+
+      test('subscribe', async () => {
+        const clientTransport = getClientTransport('client');
+        const serverTransport = getServerTransport();
+        const services = {
+          service: ServiceSchema.define({
+            subscribe: Procedure.subscription({
+              init: Type.Object({}),
+              output: Type.Object({}),
+              async handler() {
+                throw new Error('unimplemented');
+              },
+            }),
+          }),
+        };
+        const client = createClient<typeof services>(
+          clientTransport,
+          serverTransport.clientId,
+        );
+        addPostTestCleanup(async () => {
+          await cleanupTransports([clientTransport, serverTransport]);
+        });
+
+        const serverOnMessage = vi.fn<[EventMap['message']]>();
+        serverTransport.addEventListener('message', serverOnMessage);
+
+        const outputReader = client.service.subscribe.subscribe({});
+
+        await waitFor(() => {
+          expect(serverOnMessage).toHaveBeenCalledTimes(1);
+        });
+
+        const initStreamId = serverOnMessage.mock.calls[0][0].streamId;
+
+        serverTransport.sendAbort('client', initStreamId);
+
+        await expect(outputReader.asArray()).resolves.toEqual([
+          {
+            ok: false,
+            payload: {
+              code: ABORT_CODE,
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              message: expect.any(String),
+            },
+          },
+        ]);
+      });
+    });
+
+    describe('real server, mock client', () => {
+      test.each([
+        { procedureType: 'rpc' },
+        { procedureType: 'subscription' },
+        { procedureType: 'stream' },
+        { procedureType: 'upload' },
+      ] as const)('$procedureType', async ({ procedureType }) => {
+        const clientTransport = getClientTransport('client');
+        const serverTransport = getServerTransport();
+        const handler = vi.fn<[ProcedureHandlerContext<object>]>();
+        const serverId = 'SERVER';
+        const serviceName = 'service';
+        const procedureName = procedureType;
+
+        const services = {
+          [serviceName]: ServiceSchema.define({
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
+            [procedureType]: (Procedure[procedureType] as any)({
+              init: Type.Object({}),
+              ...(procedureType === 'stream' || procedureType === 'upload'
+                ? {
+                    input: Type.Object({}),
+                  }
+                : {}),
+              output: Type.Object({}),
+              async handler(ctx: ProcedureHandlerContext<object>) {
+                handler(ctx);
+
+                return new Promise(() => {
+                  // never resolves
+                });
+              },
+            }),
+          }),
+        };
+
+        const server = createServer(serverTransport, services);
+
+        addPostTestCleanup(async () => {
+          await cleanupTransports([clientTransport, serverTransport]);
+        });
+
+        const streamId = nanoid();
+        clientTransport.send(serverId, {
+          streamId,
+          serviceName,
+          procedureName,
+          payload: {},
+          controlFlags:
+            ControlFlags.StreamOpenBit | ControlFlags.StreamClosedBit,
+        });
+
+        const serverOnMessage = vi.fn<[EventMap['message']]>();
+        serverTransport.addEventListener('message', serverOnMessage);
+
+        const clientOnMessage = vi.fn<[EventMap['message']]>();
+        clientTransport.addEventListener('message', clientOnMessage);
+
+        await waitFor(() => {
+          expect(serverOnMessage).toHaveBeenCalledTimes(1);
+        });
+
+        expect(server.openStreams.size).toEqual(1);
+        expect(handler).toHaveBeenCalledTimes(1);
+        const [ctx] = handler.mock.calls[0];
+        ctx.abortController.abort();
+
+        await waitFor(() => {
+          expect(clientOnMessage).toHaveBeenCalledTimes(1);
+        });
+
+        expect(clientOnMessage).toHaveBeenCalledWith(
+          expect.objectContaining({
+            ack: 1,
+            controlFlags: ControlFlags.StreamAbortBit,
+            streamId,
+            payload: {
+              ok: false,
+              payload: {
+                code: ABORT_CODE,
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                message: expect.any(String),
+              },
+            },
+          }),
+        );
+
+        expect(server.openStreams.size).toEqual(0);
+      });
+    });
+
+    describe('e2e', () => {
+      // testing stream only e2e as it's the most general case
+      test('stream', async () => {
+        const clientTransport = getClientTransport('client');
+        const serverTransport = getServerTransport();
+        const handler = vi
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .fn<Parameters<StreamProcedure<any, any, any, any, any>['handler']>>()
+          .mockImplementation(
+            () =>
+              new Promise(() => {
+                // never resolves
+              }),
+          );
+        const services = {
+          service: ServiceSchema.define({
+            stream: Procedure.stream({
+              init: Type.Object({}),
+              input: Type.Object({}),
+              output: Type.Object({}),
+              handler,
+            }),
+          }),
+        };
+        createServer(serverTransport, services);
+        const client = createClient<typeof services>(
+          clientTransport,
+          serverTransport.clientId,
+        );
+
+        const [clientInputWriter, clientOutputReader] =
+          client.service.stream.stream({});
+
+        await waitFor(() => {
+          expect(handler).toHaveBeenCalledTimes(1);
+        });
+
+        const [ctx, , serverInputReader, serverOutputWriter] =
+          handler.mock.calls[0];
+
+        ctx.abortController.abort();
+        // this should be ignored by the server since it already aborted
+        clientInputWriter.write({ ok: true, payload: {} });
+        expect(await serverInputReader.asArray()).toEqual([
+          {
+            ok: false,
+            payload: {
+              code: ABORT_CODE,
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              message: expect.any(String),
+            },
+          },
+        ]);
+        expect(serverInputReader.isClosed());
+        expect(serverOutputWriter.isClosed());
+
+        expect(await clientOutputReader.asArray()).toEqual([
+          {
+            ok: false,
+            payload: {
+              code: ABORT_CODE,
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              message: expect.any(String),
+            },
+          },
+        ]);
+        expect(clientOutputReader.isClosed());
+        expect(clientInputWriter.isClosed());
+      });
     });
   },
 );

--- a/router/index.ts
+++ b/router/index.ts
@@ -40,8 +40,7 @@ export type { Server } from './server';
 export type {
   ParsedMetadata,
   ServiceContext,
-  ServiceContextWithState,
-  ServiceContextWithTransportInfo,
+  ProcedureHandlerContext,
 } from './context';
 export { Ok, Err } from './result';
 export type {

--- a/router/procedures.ts
+++ b/router/procedures.ts
@@ -1,5 +1,5 @@
 import { Static, TNever, TSchema, TUnion, Type } from '@sinclair/typebox';
-import { ServiceContextWithTransportInfo } from './context';
+import { ProcedureHandlerContext } from './context';
 import { BaseErrorSchemaType, Result } from './result';
 import { ReadStream, WriteStream } from './streams';
 
@@ -71,7 +71,10 @@ export const OutputReaderErrorSchema = Type.Object({
  * emitted in the Input ReadStream on the server.
  */
 export const InputReaderErrorSchema = Type.Object({
-  code: Type.Union([Type.Literal(UNEXPECTED_DISCONNECT_CODE)]),
+  code: Type.Union([
+    Type.Literal(UNEXPECTED_DISCONNECT_CODE),
+    Type.Literal(ABORT_CODE),
+  ]),
   message: Type.String(),
 });
 
@@ -104,7 +107,7 @@ export interface RpcProcedure<
   errors: Err;
   description?: string;
   handler(
-    context: ServiceContextWithTransportInfo<State>,
+    context: ProcedureHandlerContext<State>,
     init: Static<Init>,
   ): Promise<Result<Static<Output>, Static<Err>>>;
 }
@@ -133,7 +136,7 @@ export interface UploadProcedure<
   errors: Err;
   description?: string;
   handler(
-    context: ServiceContextWithTransportInfo<State>,
+    context: ProcedureHandlerContext<State>,
     init: Static<Init>,
     input: ReadStream<Static<Input>, Static<typeof InputReaderErrorSchema>>,
   ): Promise<Result<Static<Output>, Static<Err>>>;
@@ -159,7 +162,7 @@ export interface SubscriptionProcedure<
   errors: Err;
   description?: string;
   handler(
-    context: ServiceContextWithTransportInfo<State>,
+    context: ProcedureHandlerContext<State>,
     init: Static<Init>,
     output: WriteStream<Result<Static<Output>, Static<Err>>>,
   ): Promise<(() => void) | void>;
@@ -189,7 +192,7 @@ export interface StreamProcedure<
   errors: Err;
   description?: string;
   handler(
-    context: ServiceContextWithTransportInfo<State>,
+    context: ProcedureHandlerContext<State>,
     init: Static<Init>,
     input: ReadStream<Static<Input>, Static<typeof InputReaderErrorSchema>>,
     output: WriteStream<Result<Static<Output>, Static<Err>>>,

--- a/util/testHelpers.ts
+++ b/util/testHelpers.ts
@@ -10,7 +10,7 @@ import {
   InputReaderErrorSchema,
   OutputReaderErrorSchema,
   ServiceContext,
-  ServiceContextWithTransportInfo,
+  ProcedureHandlerContext,
   UNCAUGHT_ERROR_CODE,
 } from '../router';
 import { Static } from '@sinclair/typebox';
@@ -177,15 +177,14 @@ function dummyCtx<State>(
   state: State,
   session: Session<Connection>,
   extendedContext?: Omit<ServiceContext, 'state'>,
-): ServiceContextWithTransportInfo<State> {
+): ProcedureHandlerContext<State> {
   return {
     ...extendedContext,
     state,
-    to: session.to,
-    from: session.from,
-    streamId: nanoid(),
     session,
     metadata: {},
+    abortController: new AbortController(),
+    clientAbortSignal: new AbortController().signal,
   };
 }
 


### PR DESCRIPTION
## Why

Server-side implementation for #175

## What changed

For tests, recommend disabling whitespace diff as i nested tests in more describe blocks

Mostly abort implementation which is symmetrical with the client implementation. The handler context has mechanisms to deal with abort.

- Handler context interface renamed from `ServiceContextWithTransportInfo` is now `ProcedureHandlerContext`.
- Added doc comments to context
- Removed `from` and `to` from context, they can be retrieved from `session`
- Removed `streamId` from context as it's an internal thing
- Added `abortController` to context, this is the controller for which the handler can decide to abort the request
- Added `clientAbortSignal` to context, this is a signal that is triggered when the client sends an abort, or when the client disconnects.

I'm honestly not super happy with the interface, i think it can be confusing to have a controller and a signal that are separate, ideas welcome. One idea I had is to pass an `abort` function to the context, and an abort signal that is triggered when any of happens:
 - Abort by the client.
 - Abort by the procedure handler.
 - Request completed / normal closure.
 - Client disconnected.

with the abort reason indicating what happened. Updating the interface should be easy, but this PR gets us to a place where we can iterate on the interface.
