### PR TITLE
[protocolv2] Treat uncaught handler errors as abort

### DIFF
--- a/router/client.ts
+++ b/router/client.ts
@@ -357,7 +357,14 @@ function handleProc(
     }
 
     inputWriter.close();
-    transport.sendAbort(serverId, streamId);
+    transport.sendAbort(
+      serverId,
+      streamId,
+      Err({
+        code: ABORT_CODE,
+        message: 'Aborted by client',
+      }),
+    );
   }
 
   function onMessage(msg: OpaqueTransportMessage) {

--- a/router/procedures.ts
+++ b/router/procedures.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 import { Static, TNever, TSchema, TUnion, Type } from '@sinclair/typebox';
 import { ProcedureHandlerContext } from './context';
 import { BaseErrorSchemaType, Result } from './result';
@@ -37,20 +38,20 @@ export type PayloadType = TSchema;
  * UNCAUGHT_ERROR_CODE is the code that is used when an error is thrown
  * inside a procedure handler that's not required.
  */
-export const UNCAUGHT_ERROR_CODE = 'UNCAUGHT_ERROR';
+export const UNCAUGHT_ERROR_CODE = 'UNCAUGHT_ERROR' as const;
 /**
  * UNEXPECTED_DISCONNECT_CODE is the code used the stream's session
  * disconnect unexpetedly.
  */
-export const UNEXPECTED_DISCONNECT_CODE = 'UNEXPECTED_DISCONNECT';
+export const UNEXPECTED_DISCONNECT_CODE = 'UNEXPECTED_DISCONNECT' as const;
 /**
  * INVALID_REQUEST_CODE is the code used when a client's request is invalid.
  */
-export const INVALID_REQUEST_CODE = 'INVALID_REQUEST';
+export const INVALID_REQUEST_CODE = 'INVALID_REQUEST' as const;
 /**
  * ABORT_CODE is the code used when either server or client aborts the stream.
  */
-export const ABORT_CODE = 'ABORT';
+export const ABORT_CODE = 'ABORT' as const;
 
 /**
  * OutputReaderErrorSchema is the schema for all the errors that can be
@@ -72,6 +73,7 @@ export const OutputReaderErrorSchema = Type.Object({
  */
 export const InputReaderErrorSchema = Type.Object({
   code: Type.Union([
+    Type.Literal(UNCAUGHT_ERROR_CODE),
     Type.Literal(UNEXPECTED_DISCONNECT_CODE),
     Type.Literal(ABORT_CODE),
   ]),

--- a/router/server.ts
+++ b/router/server.ts
@@ -3,7 +3,6 @@ import { ServerTransport } from '../transport/transport';
 import {
   PayloadType,
   ProcedureErrorSchemaType,
-  OutputReaderErrorSchema,
   InputReaderErrorSchema,
   UNCAUGHT_ERROR_CODE,
   UNEXPECTED_DISCONNECT_CODE,
@@ -211,7 +210,7 @@ class RiverServer<Services extends AnyServiceSchemaMap>
 
     let cleanClose = true;
 
-    const onHandlerAbort = () => {
+    const onServerAbort = (errResult: Static<typeof InputErrResultSchema>) => {
       if (inputReader.isClosed() && outputWriter.isClosed()) {
         // Everything already closed, no-op.
         return;
@@ -220,17 +219,21 @@ class RiverServer<Services extends AnyServiceSchemaMap>
       cleanClose = false;
 
       if (!inputReader.isClosed()) {
-        inputReader.pushValue(
-          Err({
-            code: ABORT_CODE,
-            message: 'Aborted by server procedure handler',
-          }),
-        );
+        inputReader.pushValue(errResult);
         inputReader.triggerClose();
       }
 
       outputWriter.close();
-      this.transport.sendAbort(session.to, streamId);
+      this.transport.sendAbort(session.to, streamId, errResult);
+    };
+
+    const onHandlerAbort = () => {
+      onServerAbort(
+        Err({
+          code: ABORT_CODE,
+          message: 'Aborted by server procedure handler',
+        }),
+      );
     };
     const handlerAbortController = new AbortController();
     handlerAbortController.signal.addEventListener('abort', onHandlerAbort);
@@ -390,7 +393,7 @@ class RiverServer<Services extends AnyServiceSchemaMap>
       },
     );
 
-    const errorHandler = (err: unknown, span: Span) => {
+    const onHandlerError = (err: unknown, span: Span) => {
       const errorMsg = coerceErrorString(err);
       this.log?.error(
         `procedure ${serviceName}.${procedureName} threw an uncaught error: ${errorMsg}`,
@@ -400,15 +403,12 @@ class RiverServer<Services extends AnyServiceSchemaMap>
       span.recordException(err instanceof Error ? err : new Error(errorMsg));
       span.setStatus({ code: SpanStatusCode.ERROR });
 
-      if (!outputWriter.isClosed()) {
-        outputWriter.write(
-          Err({
-            code: UNCAUGHT_ERROR_CODE,
-            message: errorMsg,
-          } satisfies Static<typeof OutputReaderErrorSchema>),
-        );
-        outputWriter.close();
-      }
+      onServerAbort(
+        Err({
+          code: UNCAUGHT_ERROR_CODE,
+          message: errorMsg,
+        }),
+      );
     };
 
     const sessionMeta = this.transport.sessionHandshakeMetadata.get(session);
@@ -463,7 +463,7 @@ class RiverServer<Services extends AnyServiceSchemaMap>
               outputWriter.write(outputMessage);
               outputWriter.close();
             } catch (err) {
-              errorHandler(err, span);
+              onHandlerError(err, span);
             } finally {
               span.end();
             }
@@ -493,7 +493,7 @@ class RiverServer<Services extends AnyServiceSchemaMap>
                 procDispose();
               }
             } catch (err) {
-              errorHandler(err, span);
+              onHandlerError(err, span);
             } finally {
               span.end();
             }
@@ -523,7 +523,7 @@ class RiverServer<Services extends AnyServiceSchemaMap>
                 procDispose();
               }
             } catch (err) {
-              errorHandler(err, span);
+              onHandlerError(err, span);
             } finally {
               span.end();
             }
@@ -551,7 +551,7 @@ class RiverServer<Services extends AnyServiceSchemaMap>
               outputWriter.write(outputMessage);
               outputWriter.close();
             } catch (err) {
-              errorHandler(err, span);
+              onHandlerError(err, span);
             } finally {
               span.end();
             }

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -44,8 +44,11 @@ import {
   ClientHandshakeOptions,
   ServerHandshakeOptions,
 } from '../router/handshake';
-import { Err } from '../router';
-import { ABORT_CODE } from '../router/procedures';
+import { ErrResult } from '../router';
+import {
+  InputReaderErrorSchema,
+  OutputReaderErrorSchema,
+} from '../router/procedures';
 
 /**
  * Represents the possible states of a transport.
@@ -536,14 +539,17 @@ export abstract class Transport<ConnType extends Connection> {
     });
   }
 
-  sendAbort(to: TransportClientId, streamId: string) {
+  sendAbort(
+    to: TransportClientId,
+    streamId: string,
+    payload: ErrResult<
+      Static<typeof OutputReaderErrorSchema | typeof InputReaderErrorSchema>
+    >,
+  ) {
     return this.send(to, {
       streamId: streamId,
       controlFlags: ControlFlags.StreamAbortBit,
-      payload: Err({
-        code: ABORT_CODE,
-        message: 'Stream aborted',
-      }),
+      payload: payload,
     });
   }
 


### PR DESCRIPTION
## Why

Uncaught handler errors should abort the stream entirely and lead to a full close, right now they lead to a half close which is not ok.

## What changed

- `transport.sendAbort` now accepts an error result as a 3rd argument to allow us to send different payloads with the abort
- when we see a handler exception, we send an abort
- uncaught errors notify the server's input reader