### PR TITLE
[protocolv2] replace returned dispose function with ctx.addCleanUp

### DIFF
--- a/__tests__/fixtures/services.ts
+++ b/__tests__/fixtures/services.ts
@@ -241,14 +241,13 @@ export const SubscribableServiceSchema = ServiceSchema.define(
           returnStream.write(Ok({ result: count }));
         });
 
+        ctx.addCleanup(dispose1);
+
         const dispose2 = returnStream.onCloseRequest(() => {
           returnStream.close();
         });
 
-        return () => {
-          dispose1();
-          dispose2();
-        };
+        ctx.addCleanup(dispose2);
       },
     }),
   },

--- a/router/context.ts
+++ b/router/context.ts
@@ -89,4 +89,10 @@ export type ProcedureHandlerContext<State> = ServiceContext & {
    * the river documentation to understand the difference between the two concepts.
    */
   clientAbortSignal: AbortSignal;
+  /**
+   * Lets you add a function that will run when the stream is cleaned up due to
+   * it ending. If a cleanup is added after the stream has ended, it will
+   * run immediately.
+   */
+  addCleanup: (cleanup: () => void) => void;
 };

--- a/router/procedures.ts
+++ b/router/procedures.ts
@@ -167,7 +167,7 @@ export interface SubscriptionProcedure<
     context: ProcedureHandlerContext<State>,
     init: Static<Init>,
     output: WriteStream<Result<Static<Output>, Static<Err>>>,
-  ): Promise<(() => void) | void>;
+  ): Promise<void | undefined>;
 }
 
 /**
@@ -198,7 +198,7 @@ export interface StreamProcedure<
     init: Static<Init>,
     input: ReadStream<Static<Input>, Static<typeof InputReaderErrorSchema>>,
     output: WriteStream<Result<Static<Output>, Static<Err>>>,
-  ): Promise<(() => void) | void>;
+  ): Promise<void | undefined>;
 }
 
 /**

--- a/util/testHelpers.ts
+++ b/util/testHelpers.ts
@@ -185,6 +185,7 @@ function dummyCtx<State>(
     metadata: {},
     abortController: new AbortController(),
     clientAbortSignal: new AbortController().signal,
+    addCleanup: () => undefined,
   };
 }
 


### PR DESCRIPTION
## Why

This isn't really a protocolv2 requirement, more of an interface thing, I considered implementing it on `main` but the way things are setup outside of protocolv2 makes it a little more cumbersome. 

If a procedure throws, it has no way to cleanup, we should allow people to register cleanups regardless. In our usage, I also noticed a common pattern of putting cleanups in an array, and then returning a function that calls the cleanup function.

## What changed

Context now has a function `addCleanup` that allows people to register clean up functions. They're called after the stream ends (for any reason), or immediately if the stream already ended.