### PR TITLE
[protocolv2] Handle invalid requests and internal server errors

### DIFF
--- a/__tests__/invalid-request.test.ts
+++ b/__tests__/invalid-request.test.ts
@@ -1,0 +1,587 @@
+import { Type } from '@sinclair/typebox';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  Procedure,
+  ServiceSchema,
+  createClient,
+  createServer,
+} from '../router';
+import { testMatrix } from './fixtures/matrix';
+import {
+  cleanupTransports,
+  createPostTestCleanups,
+  waitFor,
+} from './fixtures/cleanup';
+import { EventMap } from '../transport';
+import { INVALID_REQUEST_CODE } from '../router/procedures';
+import { ControlFlags } from '../transport/message';
+import { TestSetupHelpers } from './fixtures/transports';
+import { nanoid } from 'nanoid';
+
+describe('invalid request', () => {
+  const { transport, codec } = testMatrix()[0];
+  const opts = { codec: codec.codec };
+
+  const { addPostTestCleanup, postTestCleanup } = createPostTestCleanups();
+  let getClientTransport: TestSetupHelpers['getClientTransport'];
+  let getServerTransport: TestSetupHelpers['getServerTransport'];
+  beforeEach(async () => {
+    const setup = await transport.setup({ client: opts, server: opts });
+    getClientTransport = setup.getClientTransport;
+    getServerTransport = setup.getServerTransport;
+    return async () => {
+      await postTestCleanup();
+      await setup.cleanup();
+    };
+  });
+
+  test('missing StreamOpenBit', async () => {
+    const clientTransport = getClientTransport('client');
+    const serverTransport = getServerTransport();
+    addPostTestCleanup(() =>
+      cleanupTransports([clientTransport, serverTransport]),
+    );
+    const serverId = 'SERVER';
+
+    const services = {
+      service: ServiceSchema.define({
+        stream: Procedure.stream({
+          init: Type.Object({}),
+          input: Type.Object({}),
+          output: Type.Object({}),
+          handler: async () => undefined,
+        }),
+      }),
+    };
+
+    createServer(serverTransport, services);
+
+    const streamId = nanoid();
+    clientTransport.send(serverId, {
+      streamId,
+      serviceName: 'service',
+      procedureName: 'stream',
+      payload: {},
+      controlFlags: 0,
+    });
+
+    const clientOnMessage = vi.fn<[EventMap['message']]>();
+    clientTransport.addEventListener('message', clientOnMessage);
+
+    await waitFor(() => {
+      expect(clientOnMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          controlFlags: ControlFlags.StreamAbortBit,
+          streamId,
+          payload: {
+            ok: false,
+            payload: {
+              code: INVALID_REQUEST_CODE,
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              message: expect.stringContaining('stream open bit'),
+            },
+          },
+        }),
+      );
+    });
+  });
+
+  test('missing serviceName', async () => {
+    const clientTransport = getClientTransport('client');
+    const serverTransport = getServerTransport();
+    addPostTestCleanup(() =>
+      cleanupTransports([clientTransport, serverTransport]),
+    );
+    const serverId = 'SERVER';
+
+    const services = {
+      service: ServiceSchema.define({
+        stream: Procedure.stream({
+          init: Type.Object({}),
+          input: Type.Object({}),
+          output: Type.Object({}),
+          handler: async () => undefined,
+        }),
+      }),
+    };
+
+    createServer(serverTransport, services);
+
+    const streamId = nanoid();
+    clientTransport.send(serverId, {
+      streamId,
+      procedureName: 'stream',
+      payload: {},
+      controlFlags: ControlFlags.StreamOpenBit,
+    });
+
+    const clientOnMessage = vi.fn<[EventMap['message']]>();
+    clientTransport.addEventListener('message', clientOnMessage);
+
+    await waitFor(() => {
+      expect(clientOnMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          controlFlags: ControlFlags.StreamAbortBit,
+          streamId,
+          payload: {
+            ok: false,
+            payload: {
+              code: INVALID_REQUEST_CODE,
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              message: expect.stringContaining('service name'),
+            },
+          },
+        }),
+      );
+    });
+  });
+
+  test('missing procedureName', async () => {
+    const clientTransport = getClientTransport('client');
+    const serverTransport = getServerTransport();
+    addPostTestCleanup(() =>
+      cleanupTransports([clientTransport, serverTransport]),
+    );
+    const serverId = 'SERVER';
+
+    const services = {
+      service: ServiceSchema.define({
+        stream: Procedure.stream({
+          init: Type.Object({}),
+          input: Type.Object({}),
+          output: Type.Object({}),
+          handler: async () => undefined,
+        }),
+      }),
+    };
+
+    createServer(serverTransport, services);
+
+    const streamId = nanoid();
+    clientTransport.send(serverId, {
+      streamId,
+      serviceName: 'service',
+      payload: {},
+      controlFlags: ControlFlags.StreamOpenBit,
+    });
+
+    const clientOnMessage = vi.fn<[EventMap['message']]>();
+    clientTransport.addEventListener('message', clientOnMessage);
+
+    await waitFor(() => {
+      expect(clientOnMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          controlFlags: ControlFlags.StreamAbortBit,
+          streamId,
+          payload: {
+            ok: false,
+            payload: {
+              code: INVALID_REQUEST_CODE,
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              message: expect.stringContaining('procedure name'),
+            },
+          },
+        }),
+      );
+    });
+  });
+
+  test('service does not exist', async () => {
+    const clientTransport = getClientTransport('client');
+    const serverTransport = getServerTransport();
+    addPostTestCleanup(() =>
+      cleanupTransports([clientTransport, serverTransport]),
+    );
+    const serverId = 'SERVER';
+
+    const services = {
+      service: ServiceSchema.define({
+        stream: Procedure.stream({
+          init: Type.Object({}),
+          input: Type.Object({}),
+          output: Type.Object({}),
+          handler: async () => undefined,
+        }),
+      }),
+    };
+
+    createServer(serverTransport, services);
+
+    const streamId = nanoid();
+    clientTransport.send(serverId, {
+      streamId,
+      serviceName: 'serviceDoesNotExist',
+      procedureName: 'stream',
+      payload: {},
+      controlFlags: ControlFlags.StreamOpenBit,
+    });
+
+    const clientOnMessage = vi.fn<[EventMap['message']]>();
+    clientTransport.addEventListener('message', clientOnMessage);
+
+    await waitFor(() => {
+      expect(clientOnMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          controlFlags: ControlFlags.StreamAbortBit,
+          streamId,
+          payload: {
+            ok: false,
+            payload: {
+              code: INVALID_REQUEST_CODE,
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              message: expect.stringContaining('find service'),
+            },
+          },
+        }),
+      );
+    });
+  });
+
+  test('procedure does not exist', async () => {
+    const clientTransport = getClientTransport('client');
+    const serverTransport = getServerTransport();
+    addPostTestCleanup(() =>
+      cleanupTransports([clientTransport, serverTransport]),
+    );
+    const serverId = 'SERVER';
+
+    const services = {
+      service: ServiceSchema.define({
+        stream: Procedure.stream({
+          init: Type.Object({}),
+          input: Type.Object({}),
+          output: Type.Object({}),
+          handler: async () => undefined,
+        }),
+      }),
+    };
+
+    createServer(serverTransport, services);
+
+    const streamId = nanoid();
+    clientTransport.send(serverId, {
+      streamId,
+      serviceName: 'service',
+      procedureName: 'procedureDoesNotExist',
+      payload: {},
+      controlFlags: ControlFlags.StreamOpenBit,
+    });
+
+    const clientOnMessage = vi.fn<[EventMap['message']]>();
+    clientTransport.addEventListener('message', clientOnMessage);
+
+    await waitFor(() => {
+      expect(clientOnMessage).toHaveBeenCalledTimes(1);
+    });
+
+    expect(clientOnMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        controlFlags: ControlFlags.StreamAbortBit,
+        streamId,
+        payload: {
+          ok: false,
+          payload: {
+            code: INVALID_REQUEST_CODE,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            message: expect.stringContaining('matching procedure'),
+          },
+        },
+      }),
+    );
+  });
+
+  test('bad init message', async () => {
+    const clientTransport = getClientTransport('client');
+    const serverTransport = getServerTransport();
+    addPostTestCleanup(() =>
+      cleanupTransports([clientTransport, serverTransport]),
+    );
+    const serverId = 'SERVER';
+
+    const services = {
+      service: ServiceSchema.define({
+        stream: Procedure.stream({
+          init: Type.Object({ mustSendThings: Type.String() }),
+          input: Type.Object({}),
+          output: Type.Object({}),
+          handler: async () => undefined,
+        }),
+      }),
+    };
+
+    createServer(serverTransport, services);
+
+    const streamId = nanoid();
+    clientTransport.send(serverId, {
+      streamId,
+      serviceName: 'service',
+      procedureName: 'stream',
+      payload: {},
+      controlFlags: ControlFlags.StreamOpenBit,
+    });
+
+    const clientOnMessage = vi.fn<[EventMap['message']]>();
+    clientTransport.addEventListener('message', clientOnMessage);
+
+    await waitFor(() => {
+      expect(clientOnMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          controlFlags: ControlFlags.StreamAbortBit,
+          streamId,
+          payload: {
+            ok: false,
+            payload: {
+              code: INVALID_REQUEST_CODE,
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              message: expect.stringContaining('init failed validation'),
+            },
+          },
+        }),
+      );
+    });
+  });
+
+  test('bad input message', async () => {
+    const clientTransport = getClientTransport('client');
+    const serverTransport = getServerTransport();
+    addPostTestCleanup(() =>
+      cleanupTransports([clientTransport, serverTransport]),
+    );
+    const serverId = 'SERVER';
+
+    const services = {
+      service: ServiceSchema.define({
+        stream: Procedure.stream({
+          init: Type.Object({}),
+          input: Type.Object({ mustSendThings: Type.String() }),
+          output: Type.Object({}),
+          handler: async () => undefined,
+        }),
+      }),
+    };
+
+    createServer(serverTransport, services);
+
+    const streamId = nanoid();
+    clientTransport.send(serverId, {
+      streamId,
+      serviceName: 'service',
+      procedureName: 'stream',
+      payload: {},
+      controlFlags: ControlFlags.StreamOpenBit,
+    });
+
+    clientTransport.send(serverId, {
+      streamId,
+      payload: {},
+      controlFlags: 0,
+    });
+
+    const clientOnMessage = vi.fn<[EventMap['message']]>();
+    clientTransport.addEventListener('message', clientOnMessage);
+
+    await waitFor(() => {
+      expect(clientOnMessage).toHaveBeenCalledTimes(1);
+    });
+
+    expect(clientOnMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        controlFlags: ControlFlags.StreamAbortBit,
+        streamId,
+        payload: {
+          ok: false,
+          payload: {
+            code: INVALID_REQUEST_CODE,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            message: expect.stringContaining(
+              'input payload, validation failed',
+            ),
+          },
+        },
+      }),
+    );
+  });
+
+  test('input message for non-input procedure', async () => {
+    const clientTransport = getClientTransport('client');
+    const serverTransport = getServerTransport();
+    addPostTestCleanup(() =>
+      cleanupTransports([clientTransport, serverTransport]),
+    );
+    const serverId = 'SERVER';
+
+    const services = {
+      service: ServiceSchema.define({
+        rpc: Procedure.rpc({
+          init: Type.Object({}),
+          output: Type.Object({}),
+          handler: async () => ({ ok: true, payload: {} }),
+        }),
+      }),
+    };
+
+    createServer(serverTransport, services);
+
+    const streamId = nanoid();
+    clientTransport.send(serverId, {
+      streamId,
+      serviceName: 'service',
+      procedureName: 'rpc',
+      payload: {},
+      controlFlags: ControlFlags.StreamOpenBit,
+    });
+
+    clientTransport.send(serverId, {
+      streamId,
+      payload: { wat: '1' },
+      controlFlags: 0,
+    });
+
+    const clientOnMessage = vi.fn<[EventMap['message']]>();
+    clientTransport.addEventListener('message', clientOnMessage);
+
+    await waitFor(() => {
+      expect(clientOnMessage).toHaveBeenCalledTimes(1);
+    });
+
+    expect(clientOnMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        controlFlags: ControlFlags.StreamAbortBit,
+        streamId,
+        payload: {
+          ok: false,
+          payload: {
+            code: INVALID_REQUEST_CODE,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            message: expect.stringContaining('control payload'),
+          },
+        },
+      }),
+    );
+  });
+
+  test('input after close', async () => {
+    const clientTransport = getClientTransport('client');
+    const serverTransport = getServerTransport();
+    addPostTestCleanup(() =>
+      cleanupTransports([clientTransport, serverTransport]),
+    );
+    const serverId = 'SERVER';
+
+    const services = {
+      service: ServiceSchema.define({
+        stream: Procedure.stream({
+          init: Type.Object({}),
+          input: Type.Object({}),
+          output: Type.Object({}),
+          handler: async () => undefined,
+        }),
+      }),
+    };
+
+    createServer(serverTransport, services);
+
+    const streamId = nanoid();
+    clientTransport.send(serverId, {
+      streamId,
+      serviceName: 'service',
+      procedureName: 'stream',
+      payload: {},
+      controlFlags: ControlFlags.StreamOpenBit,
+    });
+
+    clientTransport.send(serverId, {
+      streamId,
+      payload: {},
+      controlFlags: ControlFlags.StreamClosedBit,
+    });
+
+    clientTransport.send(serverId, {
+      streamId,
+      payload: {},
+      controlFlags: 0,
+    });
+
+    const clientOnMessage = vi.fn<[EventMap['message']]>();
+    clientTransport.addEventListener('message', clientOnMessage);
+
+    await waitFor(() => {
+      expect(clientOnMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          controlFlags: ControlFlags.StreamAbortBit,
+          streamId,
+          payload: {
+            ok: false,
+            payload: {
+              code: INVALID_REQUEST_CODE,
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              message: expect.stringContaining('stream is closed'),
+            },
+          },
+        }),
+      );
+    });
+  });
+
+  // things that can happen with a real client and
+  // backwards incompatible server changes
+  test('e2e', async () => {
+    const clientTransport = getClientTransport('client');
+    const serverTransport = getServerTransport();
+    addPostTestCleanup(() =>
+      cleanupTransports([clientTransport, serverTransport]),
+    );
+    const serverId = 'SERVER';
+
+    const services = {
+      service: ServiceSchema.define({
+        rpc: Procedure.rpc({
+          init: Type.Object({}),
+          output: Type.Object({}),
+          handler: async () => ({ ok: true, payload: {} }),
+        }),
+        stream: Procedure.stream({
+          init: Type.Object({}),
+          input: Type.Object({ oldField: Type.String() }),
+          output: Type.Object({}),
+          handler: async () => undefined,
+        }),
+      }),
+    };
+
+    createServer(serverTransport, services);
+
+    const client = createClient<typeof services>(clientTransport, serverId);
+
+    // @ts-expect-error monkey-patched incompatible change :D
+    delete services.service.procedures.rpc;
+
+    expect(await client.service.rpc.rpc({})).toEqual({
+      ok: false,
+      payload: {
+        code: INVALID_REQUEST_CODE,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        message: expect.stringContaining('matching procedure'),
+      },
+    });
+
+    // @ts-expect-error monkey-patched incompatible change :D
+    services.service.procedures.stream.input = Type.Object({
+      newRequiredField: Type.String(),
+    });
+
+    const [inputWriter, outputReader] = client.service.stream.stream({});
+
+    inputWriter.write({ oldField: 'heyyo' });
+    expect(await outputReader.asArray()).toEqual([
+      {
+        ok: false,
+        payload: {
+          code: INVALID_REQUEST_CODE,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          message: expect.stringContaining('input payload, validation'),
+        },
+      },
+    ]);
+  });
+});

--- a/router/context.ts
+++ b/router/context.ts
@@ -1,4 +1,4 @@
-import { Connection, Session } from '../transport/session';
+import { TransportClientId } from '../transport';
 
 /**
  * ServiceContext exist for the purpose of declaration merging
@@ -54,12 +54,9 @@ export type ProcedureHandlerContext<State> = ServiceContext & {
    */
   metadata: ParsedMetadata;
   /**
-   * The session for this stream. Can be used to identify the request
-   * sender via `session.from`, however, we recommend using the
-   * handshake metadata with some auth mechanism to identify the
-   * the request sender.
+   * The ID of the client that sent this request.
    */
-  session: Session<Connection>; // TODO: only expose a subset interface of session
+  from: TransportClientId;
   /**
    * An AbortController for this stream. This is used to abort the stream from the
    * handler and notify the client that the stream was aborted.

--- a/router/procedures.ts
+++ b/router/procedures.ts
@@ -35,6 +35,12 @@ export type ValidProcType =
 export type PayloadType = TSchema;
 
 /**
+ * INTERNAL_RIVER_ERROR_CODE is the code that is used when an internal error occurs,
+ * this means that some invariants expected by the river server implementation have
+ * been violated. When encountering this error please report this to river maintainers.
+ */
+export const INTERNAL_RIVER_ERROR_CODE = 'INTERNAL_RIVER_ERROR';
+/**
  * UNCAUGHT_ERROR_CODE is the code that is used when an error is thrown
  * inside a procedure handler that's not required.
  */
@@ -59,6 +65,7 @@ export const ABORT_CODE = 'ABORT' as const;
  */
 export const OutputReaderErrorSchema = Type.Object({
   code: Type.Union([
+    Type.Literal(INTERNAL_RIVER_ERROR_CODE),
     Type.Literal(UNCAUGHT_ERROR_CODE),
     Type.Literal(UNEXPECTED_DISCONNECT_CODE),
     Type.Literal(INVALID_REQUEST_CODE),
@@ -75,6 +82,7 @@ export const InputReaderErrorSchema = Type.Object({
   code: Type.Union([
     Type.Literal(UNCAUGHT_ERROR_CODE),
     Type.Literal(UNEXPECTED_DISCONNECT_CODE),
+    Type.Literal(INVALID_REQUEST_CODE),
     Type.Literal(ABORT_CODE),
   ]),
   message: Type.String(),

--- a/util/testHelpers.ts
+++ b/util/testHelpers.ts
@@ -180,8 +180,8 @@ function dummyCtx<State>(
 ): ProcedureHandlerContext<State> {
   return {
     ...extendedContext,
+    from: session.from,
     state,
-    session,
     metadata: {},
     abortController: new AbortController(),
     clientAbortSignal: new AbortController().signal,


### PR DESCRIPTION
## Why

Clients can send invalid requests for many reasons, most commonly due to backwards incompatible server changes, server should handle those and send back a stream abort with it.

## What changed

- Introduced `INTERNAL_RIVER_ERROR` code since some of the errors are invariant violations on the server
- Split out stream request validation from stream handling
- When we see a bad request, we send `INVALID_REQUEST` code with an abort bit
- Made tracing `createHandlerSpan` accept tracing fields explicitly instead of a transport message

some more changes that I'll note inline
