### PR TITLE
[protocolv2] Ignore follow up messages to a stream after server aborts it

### DIFF
--- a/.replit
+++ b/.replit
@@ -16,6 +16,26 @@ externalPort = 80
 localPort = 24678
 externalPort = 3000
 
+[[ports]]
+localPort = 36235
+externalPort = 3003
+
+[[ports]]
+localPort = 39589
+externalPort = 3002
+
+[[ports]]
+localPort = 44347
+externalPort = 5173
+
+[[ports]]
+localPort = 45035
+externalPort = 6800
+
+[[ports]]
+localPort = 46789
+externalPort = 5000
+
 [languages.eslint]
 pattern = "**{*.ts,*.js,*.tsx,*.jsx}"
 [languages.eslint.languageServer]


### PR DESCRIPTION
## Why

When the server aborts a stream (due to invalid request or explicit abort) the client send more messages before it gets the abort. We should make sure this doesn't lead to errors and unnecessary follow up responses.

## What changed

Keep an LRU of aborted streams, if a new message comes in for a stream in our set, we simply ignore the message.
