### PR TITLE
Second attempt to clean up after reconnects

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write

--- a/transport/session.ts
+++ b/transport/session.ts
@@ -340,10 +340,16 @@ export class Session<ConnType extends Connection> {
     this.connection = undefined;
   }
 
-  replaceWithNewConnection(newConn: ConnType) {
+  replaceWithNewConnection(newConn: ConnType, isTransparentReconnect: boolean) {
     this.closeStaleConnection(newConn);
     this.cancelGrace();
-    this.sendBufferedMessages(newConn);
+    if (isTransparentReconnect) {
+      // only send the buffered messages if this is considered a transparent reconnect. there are
+      // cases where the cient reconnects but with a different session id. for those cases we should
+      // not send messages from a previous session.
+
+      this.sendBufferedMessages(newConn);
+    }
     this.connection = newConn;
 
     // we only call replaceWithNewConnection after


### PR DESCRIPTION
## Why

We had a previous attempt to clean up after reconnects. But there's still one more failure mode where _something_ happens during the reconnect handshake that makes the server believe it has never seen the client before in its life and assign a new session id. When that happens, the previous connection is never reset, and the timer eventually fires and kills the new connection accidentally.

## What changed

This change now makes the establishment of a new connection always clean up the previous data in the session, no matter what. This should cut down on some of the invariant violations we've been seeing where an old grace period timeout handler accidentally triggers after a reconnect.

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change