### PR TITLE
Stop supporting Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write


### PR DESCRIPTION
## Why

There are a few flaky tests with Unix Domain Sockets. Despite Windows officially supporting them since 2017, the tests are currently flaky and supporting Windows is not currently a priority.

## What changed

This change drops Windows support.

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change