### PR TITLE
Avoid races when setting the grace period

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.23.12",
+  "version": "0.23.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.23.12",
+      "version": "0.23.13",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.23.12",
+  "version": "0.23.13",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Why

We currently have a race where the `onDisconnect` callback can be invoked arbitrarily late. This means that when replacing a new connection, we can legally get the `onDisconnect` callback invoked after we had already established the new connection, causing a) the grace period to be installed after the reconnection was set and b) the grace period could be invoked with a connection already in place!

## What changed

This change tries _even harder_ to avoid races with the session <-> connection mapping. Now whenever `onDisconnect` is called with the wrong parameters (a mismatched connection), or the grace period elapses with a connection already installed, we just bail out and avoid making more damage.

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change