### PR TITLE
Make the server reject misbehaving connections

### DIFF
--- a/__tests__/negative.test.ts
+++ b/__tests__/negative.test.ts
@@ -189,7 +189,15 @@ describe('should handle incompatabilities', async () => {
 
     const ws = createLocalWebSocketClient(port);
     await new Promise((resolve) => (ws.onopen = resolve));
-    const requestMsg = handshakeRequestMessage('client', 'SERVER', 'sessionId');
+    const requestMsg = handshakeRequestMessage({
+      from: 'client',
+      to: 'SERVER',
+      expectedSessionState: {
+        reconnect: false,
+        nextExpectedSeq: 0,
+      },
+      sessionId: 'sessionId',
+    });
     ws.send(NaiveJsonCodec.toBuffer(requestMsg));
 
     // wait for both sides to be happy

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.23.13",
+  "version": "0.23.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.23.13",
+      "version": "0.23.14",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.23.13",
+  "version": "0.23.14",
   "type": "module",
   "exports": {
     ".": {

--- a/transport/message.test.ts
+++ b/transport/message.test.ts
@@ -58,21 +58,41 @@ describe('message helpers', () => {
   });
 
   test('handshakeRequestMessage', () => {
-    const m = handshakeRequestMessage('a', 'b', 'sess');
+    const m = handshakeRequestMessage({
+      from: 'a',
+      to: 'b',
+      expectedSessionState: {
+        reconnect: false,
+        nextExpectedSeq: 0,
+      },
+      sessionId: 'sess',
+    });
 
-    expect(m.from).toBe('a');
-    expect(m.to).toBe('b');
-    expect(m.payload.sessionId).toBe('sess');
+    expect(m).toMatchObject({
+      from: 'a',
+      to: 'b',
+      payload: {
+        sessionId: 'sess',
+      },
+    });
   });
 
   test('handshakeResponseMessage', () => {
-    const mSuccess = handshakeResponseMessage('a', 'b', {
-      ok: true,
-      sessionId: 'sess',
+    const mSuccess = handshakeResponseMessage({
+      from: 'a',
+      to: 'b',
+      status: {
+        ok: true,
+        sessionId: 'sess',
+      },
     });
-    const mFail = handshakeResponseMessage('a', 'b', {
-      ok: false,
-      reason: 'bad',
+    const mFail = handshakeResponseMessage({
+      from: 'a',
+      to: 'b',
+      status: {
+        ok: false,
+        reason: 'bad',
+      },
     });
 
     expect(mSuccess.from).toBe('a');

--- a/transport/session.ts
+++ b/transport/session.ts
@@ -415,8 +415,17 @@ export class Session<ConnType extends Connection> {
     return this.connection !== undefined;
   }
 
+  get nextExpectedAck() {
+    return this.seq;
+  }
+
   get nextExpectedSeq() {
     return this.ack;
+  }
+
+  // This is only used in tests to make the session misbehave.
+  /* @internal */ advanceAckForTesting(by: number) {
+    this.ack += by;
   }
 
   constructMsg<Payload>(


### PR DESCRIPTION
## Why

We currently have a setup where the server just trusts whatever the client requests, and stomps over whatever was already there. That's okay in some cases, but not all! For example, if the client's timers are all wonky (like they are when the tab is hidden), we might get in a situation where the client tries to reconnect after its server-side grace period has been exceeded, and they don't agree on what the state should be. Also, if pid2 restarts for whatever reason, both parties should quickly agree that they're not agreeing upfront.

## What changed

This change now adds a new (optional) field to the handshake, `expectedState`. The client should fill this up and explicitly tell the server whether this is a reconnect attempt (currently this is done by checking if the `advertisedSessionId` is set, but that can be done by explicitly tracking whether the session has seen the server at least once when we move away from this model), and tell the server what its expected next sequence number is (so that the server can also detect drifts in this). If the clients don't fill this information up, the server will behave in a backwards-compatible fashion for safety.

## Versioning

- [ ] Breaking protocol change :massage_man: (backwards-compatible)
- [ ] Breaking ts/js API change :massage_man: 