### PR TITLE
Prevent yet another bamboozle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.23.14",
+  "version": "0.23.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.23.14",
+      "version": "0.23.15",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.23.14",
+  "version": "0.23.15",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Why

Currently due to the fact that we reuse client IDs for different sessions, the server can be bamboozled into accidentally closing the wrong session!

## What changed

This change now adds more checks to prevent the server from accidentally deleting the wrong session, or accidentally replacing one session with another without our knowledge.

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change