### PR TITLE
Make the `nextExpectedSeq` test stricter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.23.15",
+  "version": "0.23.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.23.15",
+      "version": "0.23.16",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.23.15",
+  "version": "0.23.16",
   "type": "module",
   "exports": {
     ".": {

--- a/transport/session.ts
+++ b/transport/session.ts
@@ -423,6 +423,19 @@ export class Session<ConnType extends Connection> {
     return this.ack;
   }
 
+  /**
+   * Check that the peer's next expected seq number matches something that is in our send buffer
+   * _or_ matches our actual next seq.
+   */
+  nextExpectedSeqInRange(nextExpectedSeq: number) {
+    for (const msg of this.sendBuffer) {
+      if (nextExpectedSeq === msg.seq) {
+        return true;
+      }
+    }
+    return nextExpectedSeq === this.seq;
+  }
+
   // This is only used in tests to make the session misbehave.
   /* @internal */ advanceAckForTesting(by: number) {
     this.ack += by;

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -266,7 +266,7 @@ export abstract class Transport<ConnType extends Connection> {
       // reject this request if there was no previous session to replace
       session === undefined ||
       // or if both parties do not agree about the next expected sequence number
-      session.nextExpectedAck < nextExpectedSeq ||
+      !session.nextExpectedSeqInRange(nextExpectedSeq) ||
       // or if both parties do not agree on the advertised session id
       session.advertisedSessionId !== sessionId
     ) {


### PR DESCRIPTION
## Why

We used to have a loose bound of obviously wrong `nextExpectedSeq`s. But we could still get this check wrong if we got unlucky and didn't have the right entry in the buffer.

Fixes: https://linear.app/replit/issue/WS-3819/received-out-of-order-msg

## What changed

This change now checks that the `nextExpectedSeq` is either in the `sendBuffer` ready to be retransmitted _or_ exactly matches the server's next `seq`.

## Versioning

- [X] Breaking protocol change
- [X] Breaking ts/js API change