### PR TITLE
Supply context to initializeState

### DIFF
--- a/__tests__/context.test.ts
+++ b/__tests__/context.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import { cleanupTransports, createPostTestCleanups } from './fixtures/cleanup';
+import { testMatrix } from './fixtures/matrix';
+import { TestSetupHelpers } from './fixtures/transports';
+import {
+  Ok,
+  Procedure,
+  ServiceSchema,
+  createClient,
+  createServer,
+} from '../router';
+import { Type } from '@sinclair/typebox';
+
+describe('should handle incompatabilities', async () => {
+  const { addPostTestCleanup, postTestCleanup } = createPostTestCleanups();
+  let getClientTransport: TestSetupHelpers['getClientTransport'];
+  let getServerTransport: TestSetupHelpers['getServerTransport'];
+  beforeEach(async () => {
+    const {
+      codec: { codec },
+      transport,
+    } = testMatrix()[0];
+    const setup = await transport.setup({
+      client: { codec },
+      server: { codec },
+    });
+    getClientTransport = setup.getClientTransport;
+    getServerTransport = setup.getServerTransport;
+    return async () => {
+      await postTestCleanup();
+      await setup.cleanup();
+    };
+  });
+
+  test('should pass extended context to procedure', async () => {
+    // setup
+    const clientTransport = getClientTransport('client');
+    const serverTransport = getServerTransport();
+    const services = {
+      testservice: ServiceSchema.define({
+        testrpc: Procedure.rpc({
+          input: Type.Object({}),
+          output: Type.String(),
+          handler: async (ctx) => {
+            return Ok((ctx as unknown as typeof extendedContext).testctx);
+          },
+        }),
+      }),
+    };
+
+    const extendedContext = { testctx: Math.random().toString() };
+    createServer(serverTransport, services, {
+      extendedContext,
+    });
+    const client = createClient<typeof services>(
+      clientTransport,
+      serverTransport.clientId,
+    );
+    addPostTestCleanup(async () => {
+      await cleanupTransports([clientTransport, serverTransport]);
+    });
+
+    const res = await client.testservice.testrpc.rpc({});
+
+    expect(res).toEqual({ ok: true, payload: extendedContext.testctx });
+  });
+
+  test('should pass extended context to initializeState', async () => {
+    // setup
+    const clientTransport = getClientTransport('client');
+    const serverTransport = getServerTransport();
+
+    const TestServiceScaffold = ServiceSchema.scaffold({
+      initializeState: (ctx) => ({
+        fromctx: (ctx as unknown as typeof extendedContext).testctx,
+      }),
+    });
+    const services = {
+      testservice: TestServiceScaffold.finalize({
+        ...TestServiceScaffold.procedures({
+          testrpc: Procedure.rpc({
+            input: Type.Object({}),
+            output: Type.String(),
+            handler: async (ctx) => {
+              return Ok(ctx.state.fromctx);
+            },
+          }),
+        }),
+      }),
+    };
+
+    const extendedContext = { testctx: Math.random().toString() };
+    createServer(serverTransport, services, {
+      extendedContext,
+    });
+    const client = createClient<typeof services>(
+      clientTransport,
+      serverTransport.clientId,
+    );
+    addPostTestCleanup(async () => {
+      await cleanupTransports([clientTransport, serverTransport]);
+    });
+
+    const res = await client.testservice.testrpc.rpc({});
+
+    expect(res).toEqual({ ok: true, payload: extendedContext.testctx });
+  });
+});

--- a/__tests__/handler.test.ts
+++ b/__tests__/handler.test.ts
@@ -18,7 +18,7 @@ import { UNCAUGHT_ERROR } from '../router/result';
 import { Observable } from './fixtures/observable';
 
 describe('server-side test', () => {
-  const service = TestServiceSchema.instantiate();
+  const service = TestServiceSchema.instantiate({});
 
   test('rpc basic', async () => {
     const add = asClientRpc({ count: 0 }, service.procedures.add);
@@ -35,7 +35,7 @@ describe('server-side test', () => {
   });
 
   test('fallible rpc', async () => {
-    const service = FallibleServiceSchema.instantiate();
+    const service = FallibleServiceSchema.instantiate({});
     const divide = asClientRpc({}, service.procedures.divide);
     const result = await divide({ a: 10, b: 2 });
     assert(result.ok);
@@ -98,7 +98,7 @@ describe('server-side test', () => {
   });
 
   test('fallible stream', async () => {
-    const service = FallibleServiceSchema.instantiate();
+    const service = FallibleServiceSchema.instantiate({});
     const [input, output] = asClientStream({}, service.procedures.echo);
 
     input.push({ msg: 'abc', throwResult: false, throwError: false });
@@ -124,7 +124,7 @@ describe('server-side test', () => {
   });
 
   test('subscriptions', async () => {
-    const service = SubscribableServiceSchema.instantiate();
+    const service = SubscribableServiceSchema.instantiate({});
     const state = { count: new Observable(0) };
     const add = asClientRpc(state, service.procedures.add);
     const subscribe = asClientSubscription(state, service.procedures.value);
@@ -144,7 +144,7 @@ describe('server-side test', () => {
   });
 
   test('uploads', async () => {
-    const service = UploadableServiceSchema.instantiate();
+    const service = UploadableServiceSchema.instantiate({});
     const [input, result] = asClientUpload({}, service.procedures.addMultiple);
 
     input.push({ n: 1 });
@@ -154,7 +154,7 @@ describe('server-side test', () => {
   });
 
   test('uploads with initialization', async () => {
-    const service = UploadableServiceSchema.instantiate();
+    const service = UploadableServiceSchema.instantiate({});
     const [input, result] = asClientUpload(
       {},
       service.procedures.addMultipleWithPrefix,

--- a/router/server.ts
+++ b/router/server.ts
@@ -81,7 +81,7 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
     this.contextMap = new Map();
 
     for (const [name, service] of Object.entries(services)) {
-      const instance = service.instantiate();
+      const instance = service.instantiate(extendedContext ?? {});
       instances[name] = instance;
 
       this.contextMap.set(instance, {

--- a/router/services.ts
+++ b/router/services.ts
@@ -7,6 +7,7 @@ import {
   AnyProcedure,
   PayloadType,
 } from './procedures';
+import { ServiceContext } from './context';
 
 /**
  * An instantiated service, probably from a {@link ServiceSchema}.
@@ -134,7 +135,7 @@ export interface ServiceConfiguration<State extends object> {
   /**
    * A factory function for creating a fresh state.
    */
-  initializeState: () => State;
+  initializeState: (extendedContext: ServiceContext) => State;
 }
 
 export interface SerializedProcedureSchema {
@@ -201,7 +202,9 @@ export class ServiceSchema<
   /**
    * Factory function for creating a fresh state.
    */
-  protected readonly initializeState: () => State;
+  protected readonly initializeState: (
+    extendedContext: ServiceContext,
+  ) => State;
 
   /**
    * The procedures for this service.
@@ -412,9 +415,9 @@ export class ServiceSchema<
    * You probably don't need this, usually the River server will handle this
    * for you.
    */
-  instantiate(): Service<State, Procedures> {
+  instantiate(extendedContext: ServiceContext): Service<State, Procedures> {
     return Object.freeze({
-      state: this.initializeState(),
+      state: this.initializeState(extendedContext),
       procedures: this.procedures,
     });
   }


### PR DESCRIPTION
## Why

We want to use shared instances across services in their state, specifically `ToolChainWatcher` in our codebase, we're having to create a new one for each service when we should be re-using the same one and instantiating it in the extended context.

## What changed

`initializeState` is now passed `ServiceContext`

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change 

backwards compatible