### PR TITLE
Don't "fail to write" when buffering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.23.16",
+  "version": "0.23.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.23.16",
+      "version": "0.23.17",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.23.16",
+  "version": "0.23.17",
   "type": "module",
   "exports": {
     ".": {

--- a/transport/impls/uds/connection.ts
+++ b/transport/impls/uds/connection.ts
@@ -42,8 +42,11 @@ export class UdsConnection extends Connection {
   }
 
   send(payload: Uint8Array) {
-    if (this.framer.destroyed || !this.sock.writable) return false;
-    return this.sock.write(MessageFramer.write(payload));
+    if (this.framer.destroyed || !this.sock.writable || this.sock.closed) {
+      return false;
+    }
+    this.sock.write(MessageFramer.write(payload));
+    return true;
   }
 
   close() {

--- a/transport/impls/ws/connection.ts
+++ b/transport/impls/ws/connection.ts
@@ -51,12 +51,11 @@ export class WebSocketConnection extends Connection {
   }
 
   send(payload: Uint8Array) {
-    if (this.ws.readyState === this.ws.OPEN) {
-      this.ws.send(payload);
-      return true;
-    } else {
+    if (this.ws.readyState !== this.ws.OPEN) {
       return false;
     }
+    this.ws.send(payload);
+    return true;
   }
 
   close() {


### PR DESCRIPTION
## Why

Currently the `send` implementation for UDS "fails to write" (i.e. `send` returns `false`) if there is any buffering done. But that's not the intention of the code!

## What changed

This change now makes the `send` implementation of UDS consistent with the WS one: it always returns `true` _unless_ we can reliably tell that the connection was closed a priori.

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change