### PR TITLE
[protocolv2] Allow listening for close on WriteStream

### DIFF
--- a/.replit
+++ b/.replit
@@ -12,6 +12,10 @@ channel = "stable-23_05"
 localPort = 3000
 externalPort = 80
 
+[[ports]]
+localPort = 24678
+externalPort = 3000
+
 [languages.eslint]
 pattern = "**{*.ts,*.js,*.tsx,*.jsx}"
 [languages.eslint.languageServer]

--- a/util/testHelpers.ts
+++ b/util/testHelpers.ts
@@ -236,14 +236,14 @@ function createOutputPipe<
     (v) => {
       reader.pushValue(v);
     },
-    () => {
-      // Make it async to simulate request going over the wire
-      // using promises so that we don't get affected by fake timers.
-      void Promise.resolve().then(() => {
-        reader.triggerClose();
-      });
-    },
   );
+  writer.onClose(() => {
+    // Make it async to simulate request going over the wire
+    // using promises so that we don't get affected by fake timers.
+    void Promise.resolve().then(() => {
+      reader.triggerClose();
+    });
+  });
 
   return { reader, writer };
 }
@@ -262,18 +262,16 @@ function createInputPipe<Input extends PayloadType>(): {
       writer.triggerCloseRequest();
     });
   });
-  const writer = new WriteStreamImpl<Static<Input>>(
-    (v) => {
-      reader.pushValue(Ok(v));
-    },
-    () => {
-      // Make it async to simulate request going over the wire
-      // using promises so that we don't get affected by fake timers.
-      void Promise.resolve().then(() => {
-        reader.triggerClose();
-      });
-    },
-  );
+  const writer = new WriteStreamImpl<Static<Input>>((v) => {
+    reader.pushValue(Ok(v));
+  });
+  writer.onClose(() => {
+    // Make it async to simulate request going over the wire
+    // using promises so that we don't get affected by fake timers.
+    void Promise.resolve().then(() => {
+      reader.triggerClose();
+    });
+  });
 
   return { reader, writer };
 }


### PR DESCRIPTION
## Why

I ended up needing this in river-babel, it's probably a useful API to have

## What changed

- Added `WriteStream.onClose`
- Unrelated: Made `WriteStream.close` lose reference to `onCloseRequest` listeners and unset `write` function