### PR TITLE
allow session id again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.24.0",
+      "version": "0.24.1",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "type": "module",
   "exports": {
     ".": {

--- a/router/context.ts
+++ b/router/context.ts
@@ -1,4 +1,5 @@
 import { TransportClientId } from '../transport/message';
+import { SessionId } from '../transport/sessionStateMachine/common';
 
 /**
  * The context for services/procedures. This is used only on
@@ -49,6 +50,7 @@ export type ServiceContextWithState<State> = ServiceContext & { state: State };
 
 export type ServiceContextWithTransportInfo<State> = ServiceContext & {
   state: State;
+  sessionId: SessionId;
   to: TransportClientId;
   from: TransportClientId;
   streamId: string;

--- a/router/server.ts
+++ b/router/server.ts
@@ -323,6 +323,7 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
     const serviceContextWithTransportInfo: ServiceContextWithTransportInfo<object> =
       {
         ...serviceContext,
+        sessionId,
         to: message.to,
         from: message.from,
         streamId: message.streamId,

--- a/util/testHelpers.ts
+++ b/util/testHelpers.ts
@@ -166,6 +166,7 @@ function dummyCtx<State>(
   return {
     ...extendedContext,
     state,
+    sessionId: session.id,
     to: session.to,
     from: session.from,
     streamId: generateId(),


### PR DESCRIPTION
## Why

<!-- Describe what you are trying to accomplish with this pull request -->

- some handlers relied on session id before to identify session changes, etc.

## What changed

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

- expose `sessionId` to handlers again via `context`

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
