### PR TITLE
uds: clear received buffer on _flush

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "type": "module",
   "exports": {
     ".": {

--- a/transport/impls/uds/connection.ts
+++ b/transport/impls/uds/connection.ts
@@ -38,10 +38,6 @@ export class UdsConnection extends Connection {
         cb(msg);
       }
     });
-
-    this.sock.on('end', () => {
-      this.sock.destroy();
-    });
   }
 
   send(payload: Uint8Array) {
@@ -53,7 +49,7 @@ export class UdsConnection extends Connection {
   }
 
   close() {
-    this.sock.end();
-    this.framer.end();
+    this.sock.destroy();
+    this.framer.destroy();
   }
 }

--- a/transport/transforms/messageFraming.test.ts
+++ b/transport/transforms/messageFraming.test.ts
@@ -102,7 +102,7 @@ describe('MessageFramer', () => {
 
     parser.end();
     expect(spy).toHaveBeenCalledTimes(0);
-    expect(err).toHaveBeenCalledTimes(1);
+    expect(err).toHaveBeenCalledTimes(0);
   });
 
   test('consistent byte length calculation with emojis and unicode', () => {

--- a/transport/transforms/messageFraming.ts
+++ b/transport/transforms/messageFraming.ts
@@ -55,11 +55,6 @@ export class Uint32LengthPrefixFraming extends Transform {
   }
 
   _flush(cb: TransformCallback) {
-    // if there's any leftover data that doesn't form a complete message
-    if (this.receivedBuffer.length) {
-      this.emit('error', new Error('got incomplete message while flushing'));
-    }
-
     this.receivedBuffer = Buffer.alloc(0);
     cb();
   }


### PR DESCRIPTION
## Why

- it is safe to lose data here

<!-- Describe what you are trying to accomplish with this pull request -->

## What changed

- make it so `receivedBuffer` gets yoinked on flush and no longer errors if theres outstanding data

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
