### PR TITLE
[protocolv2] Make server backwards compatible for now

### DIFF
--- a/.replit
+++ b/.replit
@@ -16,50 +16,6 @@ externalPort = 80
 localPort = 24678
 externalPort = 3000
 
-[[ports]]
-localPort = 35013
-externalPort = 8081
-
-[[ports]]
-localPort = 35587
-externalPort = 3003
-
-[[ports]]
-localPort = 37603
-externalPort = 9000
-
-[[ports]]
-localPort = 38243
-externalPort = 5173
-
-[[ports]]
-localPort = 39461
-externalPort = 3002
-
-[[ports]]
-localPort = 40401
-externalPort = 6800
-
-[[ports]]
-localPort = 40415
-externalPort = 8008
-
-[[ports]]
-localPort = 43539
-externalPort = 8099
-
-[[ports]]
-localPort = 43617
-externalPort = 8080
-
-[[ports]]
-localPort = 43661
-externalPort = 5000
-
-[[ports]]
-localPort = 44275
-externalPort = 4200
-
 [languages.eslint]
 pattern = "**{*.ts,*.js,*.tsx,*.jsx}"
 [languages.eslint.languageServer]

--- a/.replit
+++ b/.replit
@@ -16,6 +16,50 @@ externalPort = 80
 localPort = 24678
 externalPort = 3000
 
+[[ports]]
+localPort = 35013
+externalPort = 8081
+
+[[ports]]
+localPort = 35587
+externalPort = 3003
+
+[[ports]]
+localPort = 37603
+externalPort = 9000
+
+[[ports]]
+localPort = 38243
+externalPort = 5173
+
+[[ports]]
+localPort = 39461
+externalPort = 3002
+
+[[ports]]
+localPort = 40401
+externalPort = 6800
+
+[[ports]]
+localPort = 40415
+externalPort = 8008
+
+[[ports]]
+localPort = 43539
+externalPort = 8099
+
+[[ports]]
+localPort = 43617
+externalPort = 8080
+
+[[ports]]
+localPort = 43661
+externalPort = 5000
+
+[[ports]]
+localPort = 44275
+externalPort = 4200
+
 [languages.eslint]
 pattern = "**{*.ts,*.js,*.tsx,*.jsx}"
 [languages.eslint.languageServer]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.200.0-rc.3",
+  "version": "0.200.0-rc.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.200.0-rc.3",
+      "version": "0.200.0-rc.4",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.200.0-rc.3",
+  "version": "0.200.0-rc.4",
   "type": "module",
   "exports": {
     ".": {

--- a/transport/client.ts
+++ b/transport/client.ts
@@ -6,6 +6,7 @@ import {
   OpaqueTransportMessage,
   PartialTransportMessage,
   TransportClientId,
+  currentProtocolVersion,
   handshakeRequestMessage,
 } from './message';
 import {
@@ -115,6 +116,7 @@ export abstract class ClientTransport<
         },
       },
       this.options,
+      currentProtocolVersion,
       this.log,
     );
 

--- a/transport/message.ts
+++ b/transport/message.ts
@@ -76,7 +76,9 @@ export const ControlMessageCloseSchema = Type.Object({
   type: Type.Literal('CLOSE'),
 });
 
-export const PROTOCOL_VERSION = 'v1.1';
+export const currentProtocolVersion = 'v2.0';
+export const acceptedProtocolVersions = ['v1.1', currentProtocolVersion];
+
 export const ControlMessageHandshakeRequestSchema = Type.Object({
   type: Type.Literal('HANDSHAKE_REQ'),
   protocolVersion: Type.String(),
@@ -209,7 +211,7 @@ export function handshakeRequestMessage({
     tracing,
     payload: {
       type: 'HANDSHAKE_REQ',
-      protocolVersion: PROTOCOL_VERSION,
+      protocolVersion: currentProtocolVersion,
       sessionId,
       expectedSessionState,
       metadata,

--- a/transport/server.ts
+++ b/transport/server.ts
@@ -5,10 +5,11 @@ import {
   ControlMessageHandshakeRequestSchema,
   HandshakeErrorResponseCodes,
   OpaqueTransportMessage,
-  PROTOCOL_VERSION,
+  acceptedProtocolVersions,
   PartialTransportMessage,
   TransportClientId,
   handshakeResponseMessage,
+  currentProtocolVersion,
 } from './message';
 import {
   ProvidedServerTransportOptions,
@@ -56,7 +57,7 @@ export abstract class ServerTransport<
     };
     this.log?.info(`initiated server transport`, {
       clientId: this.clientId,
-      protocolVersion: PROTOCOL_VERSION,
+      protocolVersion: currentProtocolVersion,
     });
   }
 
@@ -237,11 +238,11 @@ export abstract class ServerTransport<
 
     // invariant: handshake request passes all the validation
     const gotVersion = msg.payload.protocolVersion;
-    if (gotVersion !== PROTOCOL_VERSION) {
+    if (!acceptedProtocolVersions.includes(gotVersion)) {
       this.rejectHandshakeRequest(
         session,
         msg.from,
-        `expected protocol version ${PROTOCOL_VERSION}, got ${gotVersion}`,
+        `expected protocol version oneof [${acceptedProtocolVersions.toString()}], got ${gotVersion}`,
         'PROTOCOL_VERSION_MISMATCH',
         {
           ...session.loggingMetadata,
@@ -446,6 +447,7 @@ export abstract class ServerTransport<
             this.deleteSession(connectedSession);
           },
         },
+        gotVersion,
       );
 
     this.sessionHandshakeMetadata.set(connectedSession.to, parsedMetadata);

--- a/transport/sessionStateMachine/common.ts
+++ b/transport/sessionStateMachine/common.ts
@@ -192,6 +192,7 @@ export abstract class IdentifiedSession extends CommonSession {
   readonly id: SessionId;
   readonly telemetry: TelemetryInfo;
   readonly to: TransportClientId;
+  readonly protocolVersion: string;
 
   /**
    * Index of the message we will send next (excluding handshake)
@@ -213,6 +214,7 @@ export abstract class IdentifiedSession extends CommonSession {
     sendBuffer: Array<OpaqueTransportMessage>,
     telemetry: TelemetryInfo,
     options: SessionOptions,
+    protocolVersion: string,
     log: Logger | undefined,
   ) {
     super(from, options, log);
@@ -223,6 +225,7 @@ export abstract class IdentifiedSession extends CommonSession {
     this.sendBuffer = sendBuffer;
     this.telemetry = telemetry;
     this.log = log;
+    this.protocolVersion = protocolVersion;
   }
 
   get loggingMetadata(): MessageMetadata {

--- a/transport/sessionStateMachine/stateMachine.test.ts
+++ b/transport/sessionStateMachine/stateMachine.test.ts
@@ -7,6 +7,7 @@ import { waitFor } from '../../__tests__/fixtures/cleanup';
 import {
   ControlFlags,
   ControlMessageAckSchema,
+  currentProtocolVersion,
   handshakeRequestMessage,
 } from '../message';
 import { ERR_CONSUMED, Session, SessionState } from './common';
@@ -119,6 +120,7 @@ function createSessionNoConnection() {
     'from',
     listeners,
     testingSessionOptions,
+    currentProtocolVersion,
   );
 
   return { session, ...listeners };
@@ -346,6 +348,7 @@ describe('session state machine', () => {
         'to',
         undefined,
         listeners,
+        currentProtocolVersion,
       );
 
       expect(session.state).toBe(SessionState.Connected);
@@ -399,6 +402,7 @@ describe('session state machine', () => {
         'to',
         undefined,
         listeners,
+        currentProtocolVersion,
       );
 
       session.send(payloadToTransportMessage('foo'));
@@ -765,6 +769,7 @@ describe('session state machine', () => {
         'to',
         undefined,
         listeners,
+        currentProtocolVersion,
       );
 
       // doing anything on the old session should throw

--- a/transport/sessionStateMachine/transitions.ts
+++ b/transport/sessionStateMachine/transitions.ts
@@ -34,6 +34,7 @@ function inheritSharedSession(
     session.sendBuffer,
     session.telemetry,
     session.options,
+    session.protocolVersion,
     session.log,
   ];
 }
@@ -68,6 +69,7 @@ export const SessionStateGraph = {
       from: TransportClientId,
       listeners: SessionNoConnectionListeners,
       options: SessionOptions,
+      protocolVersion: string,
       log?: Logger,
     ) {
       const id = `session-${generateId()}`;
@@ -84,6 +86,7 @@ export const SessionStateGraph = {
         sendBuffer,
         telemetry,
         options,
+        protocolVersion,
         log,
       );
 
@@ -188,6 +191,7 @@ export const SessionStateGraph = {
       to: TransportClientId,
       propagationCtx: PropagationContext | undefined,
       listeners: SessionConnectedListeners,
+      protocolVersion: string,
     ): SessionConnected<ConnType> {
       const conn = pendingSession.conn;
       const { from, options } = pendingSession;
@@ -205,6 +209,7 @@ export const SessionStateGraph = {
               [],
               createSessionTelemetryInfo(sessionId, to, from, propagationCtx),
               options,
+              protocolVersion,
               pendingSession.log,
             ];
 

--- a/util/testHelpers.ts
+++ b/util/testHelpers.ts
@@ -19,6 +19,7 @@ import net from 'node:net';
 import {
   OpaqueTransportMessage,
   PartialTransportMessage,
+  currentProtocolVersion,
 } from '../transport/message';
 import { coerceErrorString } from './stringify';
 import { Transport } from '../transport/transport';
@@ -181,6 +182,7 @@ export function dummySession() {
       },
     },
     testingSessionOptions,
+    currentProtocolVersion,
   );
 }
 


### PR DESCRIPTION
## Why

It's easier to roll out this way.

## What changed

- Added `protocolVersion` to transport
- Added allow-list for accepted protocol versions
- Use `protocolVersion` in the server router to determine how we should deal with closes and aborts