### PR TITLE
Allow empty client-streams

### DIFF
--- a/__tests__/fixtures/services.ts
+++ b/__tests__/fixtures/services.ts
@@ -57,6 +57,7 @@ const testServiceProcedures = TestServiceScaffold.procedures({
           returnStream.end();
         }
       }
+      returnStream.end();
     },
   }),
 

--- a/__tests__/handler.test.ts
+++ b/__tests__/handler.test.ts
@@ -69,6 +69,19 @@ describe('server-side test', () => {
     expect(output.readableLength).toBe(0);
   });
 
+  test('stream empty', async () => {
+    const [input, output] = asClientStream(
+      { count: 0 },
+      service.procedures.echo,
+    );
+    input.end();
+
+    const result = await output.next();
+    expect(result).toStrictEqual({ done: true, value: undefined });
+
+    expect(output.readableLength).toBe(0);
+  });
+
   test('stream with initialization', async () => {
     const [input, output] = asClientStream(
       { count: 0 },
@@ -153,6 +166,13 @@ describe('server-side test', () => {
     input.push({ n: 2 });
     input.end();
     expect(await result).toStrictEqual({ ok: true, payload: { result: 3 } });
+  });
+
+  test('uploads empty', async () => {
+    const service = UploadableServiceSchema.instantiate({});
+    const [input, result] = asClientUpload({}, service.procedures.addMultiple);
+    input.end();
+    expect(await result).toStrictEqual({ ok: true, payload: { result: 0 } });
   });
 
   test('uploads with initialization', async () => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "type": "module",
   "exports": {
     ".": {

--- a/router/client.ts
+++ b/router/client.ts
@@ -362,9 +362,17 @@ function handleStream(
       transport.send(serverId, m);
     }
 
-    // after ending input stream, send a close message to the server
     if (!healthyClose) return;
-    transport.send(serverId, closeStreamMessage(streamId));
+    // after ending input stream, send a close message to the server
+    const m = closeStreamMessage(streamId);
+    if (firstMessage) {
+      m.serviceName = serviceName;
+      m.procedureName = procedureName;
+      m.tracing = getPropagationContext(ctx);
+      m.controlFlags |= ControlFlags.StreamOpenBit;
+      firstMessage = false;
+    }
+    transport.send(serverId, m);
   };
 
   void pipeInputToTransport();
@@ -529,9 +537,17 @@ function handleUpload(
       transport.send(serverId, m);
     }
 
-    // after ending input stream, send a close message to the server
     if (!healthyClose) return;
-    transport.send(serverId, closeStreamMessage(streamId));
+    // after ending input stream, send a close message to the server
+    const m = closeStreamMessage(streamId);
+    if (firstMessage) {
+      m.serviceName = serviceName;
+      m.procedureName = procedureName;
+      m.tracing = getPropagationContext(ctx);
+      m.controlFlags |= ControlFlags.StreamOpenBit;
+      firstMessage = false;
+    }
+    transport.send(serverId, m);
   };
 
   void pipeInputToTransport();


### PR DESCRIPTION
## Why

We currently don't force streams to have an initialization, which means that it is possible for clients to end a stream without having sent any messages. This confuses the server!

## What changed

This change now allows clients to send empty streams while the protocolv2 change lands.

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change