### PR TITLE
Make damn sure that we only send a single close

### DIFF
--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -391,7 +391,7 @@ describe.each(testMatrix())(
       });
     });
 
-    test.only('subscription idempotent close', async () => {
+    test('subscription idempotent close', async () => {
       // setup
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();

--- a/__tests__/fixtures/transports.ts
+++ b/__tests__/fixtures/transports.ts
@@ -77,6 +77,15 @@ export const transports: Array<TransportMatrixEntry> = [
             clientTransport.extendHandshake(handshakeOptions);
           }
 
+          clientTransport.bindLogger((msg, ctx, level) => {
+            if (ctx?.tags?.includes('invariant-violation')) {
+              console.error('invariant violation', { msg, ctx, level });
+              throw new Error(
+                `Invariant violation encountered: [${level}] ${msg}`,
+              );
+            }
+          }, 'debug');
+
           transports.push(clientTransport);
           return clientTransport;
         },
@@ -86,6 +95,15 @@ export const transports: Array<TransportMatrixEntry> = [
             'SERVER',
             opts?.server,
           );
+
+          serverTransport.bindLogger((msg, ctx, level) => {
+            if (ctx?.tags?.includes('invariant-violation')) {
+              console.error('invariant violation', { msg, ctx, level });
+              throw new Error(
+                `Invariant violation encountered: [${level}] ${msg}`,
+              );
+            }
+          }, 'debug');
 
           if (handshakeOptions) {
             serverTransport.extendHandshake(handshakeOptions);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.25.0",
+      "version": "0.25.1",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Why

We are still seeing places where we have client procedure calls that end up closing the stream twice.

## What changed

This change now makes _really_ sure that streams are only closed once. Also adds some machinery to detect any invariant violations during tests and fail. That way we never end up in a situation where we accidentally proceed with a test if it would have caused worsening of stuff.

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change