### PR TITLE
[protocolv2] Fix passing input as first message being backwards incompatible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.200.0-rc.4",
+  "version": "0.200.0-rc.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.200.0-rc.4",
+      "version": "0.200.0-rc.6",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.200.0-rc.4",
+  "version": "0.200.0-rc.6",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Why

In v1.1 sometimes the first message is not `init`, but instead it's the `input`. Let's handle that.

## What changed

If we get an `init` that's not matching what we expect, we'll check if the client is on v1.1 and sent us an `input` as a first message, then we'll pass the first message as `input` and treat `init` as an empty object (which is what the first pass of requiring `init` for `stream` and `upload` be).

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
