### PR TITLE
add backing off state, add test to make sure backoff doesn't count for grace period

### DIFF
--- a/__tests__/cleanup.test.ts
+++ b/__tests__/cleanup.test.ts
@@ -380,8 +380,9 @@ describe.each(testMatrix())(
       // wait for session to disconnect
       clientTransport.reconnectOnConnectionDrop = false;
       closeAllConnections(clientTransport);
-      await advanceFakeTimersBySessionGrace();
       await waitFor(() => expect(numberOfConnections(clientTransport)).toBe(0));
+      await waitFor(() => expect(numberOfConnections(serverTransport)).toBe(0));
+      await advanceFakeTimersBySessionGrace();
 
       // reconnect
       clientTransport.reconnectOnConnectionDrop = true;

--- a/__tests__/disconnects.test.ts
+++ b/__tests__/disconnects.test.ts
@@ -60,6 +60,7 @@ describe.each(testMatrix())(
       clientTransport.reconnectOnConnectionDrop = false;
       closeAllConnections(clientTransport);
       await waitFor(() => expect(numberOfConnections(clientTransport)).toBe(0));
+      await waitFor(() => expect(numberOfConnections(serverTransport)).toBe(0));
 
       const procPromise = client.test.add.rpc({ n: 4 });
       // end procedure
@@ -108,6 +109,7 @@ describe.each(testMatrix())(
       clientTransport.reconnectOnConnectionDrop = false;
       closeAllConnections(clientTransport);
       await waitFor(() => expect(numberOfConnections(clientTransport)).toBe(0));
+      await waitFor(() => expect(numberOfConnections(serverTransport)).toBe(0));
 
       const nextResPromise = iterNext(output);
       // end procedure
@@ -268,6 +270,7 @@ describe.each(testMatrix())(
       clientTransport.reconnectOnConnectionDrop = false;
       closeAllConnections(clientTransport);
       await waitFor(() => expect(numberOfConnections(clientTransport)).toBe(0));
+      await waitFor(() => expect(numberOfConnections(serverTransport)).toBe(0));
 
       // after we've disconnected, hit end of grace period
       await advanceFakeTimersBySessionGrace();

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -708,6 +708,9 @@ describe.each(testMatrix())(
       // kill the session
       clientTransport.reconnectOnConnectionDrop = false;
       closeAllConnections(clientTransport);
+      await waitFor(() => expect(numberOfConnections(clientTransport)).toBe(0));
+      await waitFor(() => expect(numberOfConnections(serverTransport)).toBe(0));
+
       await advanceFakeTimersBySessionGrace();
       clientTransport.reconnectOnConnectionDrop = true;
 
@@ -754,6 +757,9 @@ describe.each(testMatrix())(
       // kill the session
       clientTransport.reconnectOnConnectionDrop = false;
       closeAllConnections(clientTransport);
+      await waitFor(() => expect(numberOfConnections(clientTransport)).toBe(0));
+      await waitFor(() => expect(numberOfConnections(serverTransport)).toBe(0));
+
       await advanceFakeTimersBySessionGrace();
 
       // we should have no connections

--- a/__tests__/fixtures/cleanup.ts
+++ b/__tests__/fixtures/cleanup.ts
@@ -31,7 +31,7 @@ export async function advanceFakeTimersByDisconnectGrace() {
 }
 
 export async function advanceFakeTimersBySessionGrace() {
-  await advanceFakeTimersByDisconnectGrace();
+  // await advanceFakeTimersByDisconnectGrace();
   await vi.advanceTimersByTimeAsync(
     testingSessionOptions.sessionDisconnectGraceMs,
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.25.1",
+      "version": "0.25.2",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "type": "module",
   "exports": {
     ".": {

--- a/transport/events.ts
+++ b/transport/events.ts
@@ -22,6 +22,7 @@ export interface EventMap {
     | { state: SessionState.Connected }
     | { state: SessionState.Handshaking }
     | { state: SessionState.Connecting }
+    | { state: SessionState.BackingOff }
     | { state: SessionState.NoConnection };
   protocolError: {
     type: ProtocolErrorType;

--- a/transport/options.ts
+++ b/transport/options.ts
@@ -20,7 +20,7 @@ export type ClientTransportOptions = TransportOptions & ConnectionRetryOptions;
 export type ProvidedClientTransportOptions = Partial<ClientTransportOptions>;
 
 const defaultConnectionRetryOptions: ConnectionRetryOptions = {
-  baseIntervalMs: 250,
+  baseIntervalMs: 150,
   maxJitterMs: 200,
   maxBackoffMs: 32_000,
   attemptBudgetCapacity: 5,

--- a/transport/rateLimit.test.ts
+++ b/transport/rateLimit.test.ts
@@ -15,82 +15,75 @@ describe('LeakyBucketRateLimit', () => {
 
   test('should return 0 backoff time for new user', () => {
     const rateLimit = new LeakyBucketRateLimit(options);
-    const user = 'user1';
-    const backoffMs = rateLimit.getBackoffMs(user);
+    const backoffMs = rateLimit.getBackoffMs();
     expect(backoffMs).toBe(0);
   });
 
   test('should return 0 budget consumed for new user', () => {
     const rateLimit = new LeakyBucketRateLimit(options);
-    const user = 'user1';
-    const budgetConsumed = rateLimit.getBudgetConsumed(user);
+    const budgetConsumed = rateLimit.getBudgetConsumed();
     expect(budgetConsumed).toBe(0);
   });
 
   test('should consume budget correctly', () => {
     const rateLimit = new LeakyBucketRateLimit(options);
-    const user = 'user1';
-    rateLimit.consumeBudget(user);
-    expect(rateLimit.getBudgetConsumed(user)).toBe(1);
+    rateLimit.consumeBudget();
+    expect(rateLimit.getBudgetConsumed()).toBe(1);
   });
 
   test('keeps growing until startRestoringBudget', () => {
     const rateLimit = new LeakyBucketRateLimit(options);
-    const user = 'user1';
-    rateLimit.consumeBudget(user);
-    rateLimit.consumeBudget(user);
-    expect(rateLimit.getBudgetConsumed(user)).toBe(2);
+    rateLimit.consumeBudget();
+    rateLimit.consumeBudget();
+    expect(rateLimit.getBudgetConsumed()).toBe(2);
 
     // Advanding time before startRestoringBudget should be noop
     vi.advanceTimersByTime(options.budgetRestoreIntervalMs);
-    expect(rateLimit.getBudgetConsumed(user)).toBe(2);
+    expect(rateLimit.getBudgetConsumed()).toBe(2);
 
-    rateLimit.startRestoringBudget(user);
-    expect(rateLimit.getBudgetConsumed(user)).toBe(2);
+    rateLimit.startRestoringBudget();
+    expect(rateLimit.getBudgetConsumed()).toBe(2);
     vi.advanceTimersByTime(options.budgetRestoreIntervalMs);
-    expect(rateLimit.getBudgetConsumed(user)).toBe(1);
+    expect(rateLimit.getBudgetConsumed()).toBe(1);
   });
 
   test('stops restoring budget when we consume budget again', () => {
     const rateLimit = new LeakyBucketRateLimit(options);
-    const user = 'user1';
-    rateLimit.consumeBudget(user);
-    rateLimit.consumeBudget(user);
-    expect(rateLimit.getBudgetConsumed(user)).toBe(2);
+    rateLimit.consumeBudget();
+    rateLimit.consumeBudget();
+    expect(rateLimit.getBudgetConsumed()).toBe(2);
 
-    rateLimit.startRestoringBudget(user);
-    expect(rateLimit.getBudgetConsumed(user)).toBe(2);
+    rateLimit.startRestoringBudget();
+    expect(rateLimit.getBudgetConsumed()).toBe(2);
 
-    rateLimit.consumeBudget(user);
-    expect(rateLimit.getBudgetConsumed(user)).toBe(3);
+    rateLimit.consumeBudget();
+    expect(rateLimit.getBudgetConsumed()).toBe(3);
     vi.advanceTimersByTime(options.budgetRestoreIntervalMs);
-    expect(rateLimit.getBudgetConsumed(user)).toBe(3);
+    expect(rateLimit.getBudgetConsumed()).toBe(3);
   });
 
   test('respects maximum backoff time', () => {
     const maxBackoffMs = 50;
     const rateLimit = new LeakyBucketRateLimit({ ...options, maxBackoffMs });
-    const user = 'user1';
 
-    rateLimit.consumeBudget(user);
+    rateLimit.consumeBudget();
 
-    expect(rateLimit.getBackoffMs(user)).toBeLessThanOrEqual(
+    expect(rateLimit.getBackoffMs()).toBeLessThanOrEqual(
       maxBackoffMs + options.maxJitterMs,
     );
-    expect(rateLimit.getBackoffMs(user)).toBeGreaterThanOrEqual(maxBackoffMs);
+    expect(rateLimit.getBackoffMs()).toBeGreaterThanOrEqual(maxBackoffMs);
   });
 
   test('backoff increases', () => {
     const rateLimit = new LeakyBucketRateLimit(options);
-    const user = 'user1';
 
-    rateLimit.consumeBudget(user);
-    const backoffMs1 = rateLimit.getBackoffMs(user);
-    rateLimit.consumeBudget(user);
-    const backoffMs2 = rateLimit.getBackoffMs(user);
+    rateLimit.consumeBudget();
+    const backoffMs1 = rateLimit.getBackoffMs();
+    rateLimit.consumeBudget();
+    const backoffMs2 = rateLimit.getBackoffMs();
     expect(backoffMs2).toBeGreaterThan(backoffMs1);
-    rateLimit.consumeBudget(user);
-    const backoffMs3 = rateLimit.getBackoffMs(user);
+    rateLimit.consumeBudget();
+    const backoffMs3 = rateLimit.getBackoffMs();
     expect(backoffMs3).toBeGreaterThan(backoffMs2);
   });
 
@@ -100,14 +93,13 @@ describe('LeakyBucketRateLimit', () => {
       ...options,
       attemptBudgetCapacity: maxAttempts,
     });
-    const user = 'user1';
 
     for (let i = 0; i < maxAttempts; i++) {
-      expect(rateLimit.hasBudget(user)).toBe(true);
-      rateLimit.consumeBudget(user);
+      expect(rateLimit.hasBudget()).toBe(true);
+      rateLimit.consumeBudget();
     }
 
-    expect(rateLimit.hasBudget(user)).toBe(false);
-    rateLimit.consumeBudget(user);
+    expect(rateLimit.hasBudget()).toBe(false);
+    rateLimit.consumeBudget();
   });
 });

--- a/transport/server.ts
+++ b/transport/server.ts
@@ -359,6 +359,15 @@ export abstract class ServerTransport<
           });
 
         oldSession = noConnectionSession;
+      } else if (oldSession.state === SessionState.BackingOff) {
+        const noConnectionSession =
+          SessionStateGraph.transition.BackingOffToNoConnection(oldSession, {
+            onSessionGracePeriodElapsed: () => {
+              this.onSessionGracePeriodElapsed(noConnectionSession);
+            },
+          });
+
+        oldSession = noConnectionSession;
       }
 
       this.updateSession(oldSession);

--- a/transport/sessionStateMachine/SessionBackingOff.ts
+++ b/transport/sessionStateMachine/SessionBackingOff.ts
@@ -1,0 +1,47 @@
+import {
+  IdentifiedSession,
+  IdentifiedSessionProps,
+  SessionState,
+} from './common';
+
+export interface SessionBackingOffListeners {
+  onBackoffFinished: () => void;
+}
+
+export interface SessionBackingOffProps extends IdentifiedSessionProps {
+  backoffMs: number;
+  listeners: SessionBackingOffListeners;
+}
+
+/*
+ * A session that is backing off before attempting to connect.
+ * See transitions.ts for valid transitions.
+ */
+export class SessionBackingOff extends IdentifiedSession {
+  readonly state = SessionState.BackingOff as const;
+  listeners: SessionBackingOffListeners;
+
+  backoffTimeout?: ReturnType<typeof setTimeout>;
+
+  constructor(props: SessionBackingOffProps) {
+    super(props);
+    this.listeners = props.listeners;
+
+    this.backoffTimeout = setTimeout(() => {
+      this.listeners.onBackoffFinished();
+    }, props.backoffMs);
+  }
+
+  _handleClose(): void {
+    super._handleClose();
+  }
+
+  _handleStateExit(): void {
+    super._handleStateExit();
+
+    if (this.backoffTimeout) {
+      clearTimeout(this.backoffTimeout);
+      this.backoffTimeout = undefined;
+    }
+  }
+}

--- a/transport/sessionStateMachine/SessionConnected.ts
+++ b/transport/sessionStateMachine/SessionConnected.ts
@@ -6,7 +6,11 @@ import {
   PartialTransportMessage,
   isAck,
 } from '../message';
-import { IdentifiedSession, SessionState } from './common';
+import {
+  IdentifiedSession,
+  IdentifiedSessionProps,
+  SessionState,
+} from './common';
 import { Connection } from '../connection';
 import { SpanStatusCode } from '@opentelemetry/api';
 
@@ -17,11 +21,15 @@ export interface SessionConnectedListeners {
   onInvalidMessage: (reason: string) => void;
 }
 
+export interface SessionConnectedProps<ConnType extends Connection>
+  extends IdentifiedSessionProps {
+  conn: ConnType;
+  listeners: SessionConnectedListeners;
+}
+
 /*
  * A session that is connected and can send and receive messages.
- *
- * Valid transitions:
- * - Connected -> NoConnection (on close)
+ * See transitions.ts for valid transitions.
  */
 export class SessionConnected<
   ConnType extends Connection,
@@ -52,18 +60,14 @@ export class SessionConnected<
     return constructedMsg.id;
   }
 
-  constructor(
-    conn: ConnType,
-    listeners: SessionConnectedListeners,
-    ...args: ConstructorParameters<typeof IdentifiedSession>
-  ) {
-    super(...args);
-    this.conn = conn;
-    this.listeners = listeners;
+  constructor(props: SessionConnectedProps<ConnType>) {
+    super(props);
+    this.conn = props.conn;
+    this.listeners = props.listeners;
 
     this.conn.addDataListener(this.onMessageData);
-    this.conn.addCloseListener(listeners.onConnectionClosed);
-    this.conn.addErrorListener(listeners.onConnectionErrored);
+    this.conn.addCloseListener(this.listeners.onConnectionClosed);
+    this.conn.addErrorListener(this.listeners.onConnectionErrored);
 
     // send any buffered messages
     if (this.sendBuffer.length > 0) {
@@ -74,7 +78,7 @@ export class SessionConnected<
     }
 
     for (const msg of this.sendBuffer) {
-      conn.send(this.options.codec.toBuffer(msg));
+      this.conn.send(this.options.codec.toBuffer(msg));
     }
 
     // dont explicity clear the buffer, we'll just filter out old messages
@@ -91,6 +95,7 @@ export class SessionConnected<
           this.loggingMetadata,
         );
         this.telemetry.span.addEvent('closing connection due to inactivity');
+
         this.conn.close();
         clearInterval(this.activeHeartbeatHandle);
         this.activeHeartbeatHandle = undefined;
@@ -102,7 +107,10 @@ export class SessionConnected<
     }, this.options.heartbeatIntervalMs);
   }
 
-  waitForNextHeartbeat() {
+  // kill the connection if we don't receive a heartbeat in time
+  // realistically, this only happens in a proxy scenario where the connection might
+  // be desynchronized
+  startPassiveHeartbeatCheck() {
     const duration =
       this.options.heartbeatsUntilDead * this.options.heartbeatIntervalMs;
 
@@ -117,7 +125,9 @@ export class SessionConnected<
         this.loggingMetadata,
       );
       this.telemetry.span.addEvent('closing connection due to inactivity');
+
       this.conn.close();
+      clearTimeout(this.passiveHeartbeatHandle);
       this.passiveHeartbeatHandle = undefined;
     }, duration);
   }
@@ -189,7 +199,7 @@ export class SessionConnected<
     // heartbeat mode and should send a response to the ack
     if (!this.isActivelyHeartbeating) {
       this.sendHeartbeat();
-      this.waitForNextHeartbeat();
+      this.startPassiveHeartbeatCheck();
     }
   };
 

--- a/transport/sessionStateMachine/SessionConnected.ts
+++ b/transport/sessionStateMachine/SessionConnected.ts
@@ -91,6 +91,13 @@ export class SessionConnected<
         );
         this.telemetry.span.addEvent('closing connection due to inactivity');
 
+        // it is OK to close this even on the client when we can't trust the client timer
+        // due to browser throttling or hibernation
+        // at worst, this interval will fire later than what the server expects and the server
+        // will have already closed the connection
+        // this just helps us in cases where we have a proxying setup where the server has closed
+        // the connection but the proxy hasn't synchronized the server-side close to the client so
+        // the client isn't stuck with a pseudo-dead connection forever
         this.conn.close();
         clearInterval(this.heartbeatHandle);
         this.heartbeatHandle = undefined;

--- a/transport/sessionStateMachine/SessionNoConnection.ts
+++ b/transport/sessionStateMachine/SessionNoConnection.ts
@@ -1,15 +1,21 @@
-import { IdentifiedSession, SessionState } from './common';
+import {
+  IdentifiedSession,
+  IdentifiedSessionProps,
+  SessionState,
+} from './common';
 
 export interface SessionNoConnectionListeners {
   // timeout related
   onSessionGracePeriodElapsed: () => void;
 }
 
+export interface SessionNoConnectionProps extends IdentifiedSessionProps {
+  listeners: SessionNoConnectionListeners;
+}
+
 /*
  * A session that is not connected and cannot send or receive messages.
- *
- * Valid transitions:
- * - NoConnection -> Connecting (on connect)
+ * See transitions.ts for valid transitions.
  */
 export class SessionNoConnection extends IdentifiedSession {
   readonly state = SessionState.NoConnection as const;
@@ -17,13 +23,9 @@ export class SessionNoConnection extends IdentifiedSession {
 
   gracePeriodTimeout?: ReturnType<typeof setTimeout>;
 
-  constructor(
-    listeners: SessionNoConnectionListeners,
-    ...args: ConstructorParameters<typeof IdentifiedSession>
-  ) {
-    super(...args);
-    this.listeners = listeners;
-
+  constructor(props: SessionNoConnectionProps) {
+    super(props);
+    this.listeners = props.listeners;
     this.gracePeriodTimeout = setTimeout(() => {
       this.listeners.onSessionGracePeriodElapsed();
     }, this.options.sessionDisconnectGraceMs);

--- a/transport/sessionStateMachine/SessionWaitingForHandshake.ts
+++ b/transport/sessionStateMachine/SessionWaitingForHandshake.ts
@@ -2,14 +2,17 @@ import { MessageMetadata } from '../../logging';
 import { Connection } from '../connection';
 import { TransportMessage } from '../message';
 import { SessionHandshakingListeners } from './SessionHandshaking';
-import { CommonSession, SessionState } from './common';
+import { CommonSession, CommonSessionProps, SessionState } from './common';
+
+export interface SessionWaitingForHandshakeProps<ConnType extends Connection>
+  extends CommonSessionProps {
+  conn: ConnType;
+  listeners: SessionHandshakingListeners;
+}
 
 /*
  * Server-side session that has a connection but is waiting for the client to identify itself.
- *
- * Valid transitions:
- * - WaitingForHandshake -> NoConnection (on close)
- * - WaitingForHandshake -> Connected (on handshake)
+ * See transitions.ts for valid transitions.
  */
 export class SessionWaitingForHandshake<
   ConnType extends Connection,
@@ -20,22 +23,18 @@ export class SessionWaitingForHandshake<
 
   handshakeTimeout?: ReturnType<typeof setTimeout>;
 
-  constructor(
-    conn: ConnType,
-    listeners: SessionHandshakingListeners,
-    ...args: ConstructorParameters<typeof CommonSession>
-  ) {
-    super(...args);
-    this.conn = conn;
-    this.listeners = listeners;
+  constructor(props: SessionWaitingForHandshakeProps<ConnType>) {
+    super(props);
+    this.conn = props.conn;
+    this.listeners = props.listeners;
 
     this.handshakeTimeout = setTimeout(() => {
-      listeners.onHandshakeTimeout();
+      this.listeners.onHandshakeTimeout();
     }, this.options.handshakeTimeoutMs);
 
     this.conn.addDataListener(this.onHandshakeData);
-    this.conn.addErrorListener(listeners.onConnectionErrored);
-    this.conn.addCloseListener(listeners.onConnectionClosed);
+    this.conn.addErrorListener(this.listeners.onConnectionErrored);
+    this.conn.addCloseListener(this.listeners.onConnectionClosed);
   }
 
   onHandshakeData = (msg: Uint8Array) => {

--- a/transport/sessionStateMachine/common.ts
+++ b/transport/sessionStateMachine/common.ts
@@ -8,14 +8,8 @@ import {
   TransportMessage,
 } from '../message';
 import { Value } from '@sinclair/typebox/value';
-import { SessionNoConnection } from './SessionNoConnection';
-import { SessionConnecting } from './SessionConnecting';
-import { SessionHandshaking } from './SessionHandshaking';
-import { SessionConnected } from './SessionConnected';
 import { Codec } from '../../codec';
-import { Connection } from '../connection';
 import { generateId } from '../id';
-import { SessionBackingOff } from './SessionBackingOff';
 
 export const enum SessionState {
   NoConnection = 'NoConnection',
@@ -25,13 +19,6 @@ export const enum SessionState {
   Connected = 'Connected',
   WaitingForHandshake = 'WaitingForHandshake',
 }
-
-export type Session<ConnType extends Connection> =
-  | SessionNoConnection
-  | SessionBackingOff
-  | SessionConnecting<ConnType>
-  | SessionHandshaking<ConnType>
-  | SessionConnected<ConnType>;
 
 export const ERR_CONSUMED = `session state has been consumed and is no longer valid`;
 

--- a/transport/sessionStateMachine/index.ts
+++ b/transport/sessionStateMachine/index.ts
@@ -1,7 +1,11 @@
-export { SessionState, type Session } from './common';
+export { SessionState } from './common';
 export { type SessionWaitingForHandshake } from './SessionWaitingForHandshake';
 export { type SessionConnecting } from './SessionConnecting';
 export { type SessionNoConnection } from './SessionNoConnection';
 export { type SessionHandshaking } from './SessionHandshaking';
 export { type SessionConnected } from './SessionConnected';
-export { SessionStateGraph } from './transitions';
+export {
+  ClientSessionStateGraph,
+  ServerSessionStateGraph,
+  type Session,
+} from './transitions';

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -849,10 +849,9 @@ describe.each(testMatrix())(
       const numConnKills = 3;
       for (let i = 0; i < numConnKills; i++) {
         closeAllConnections(clientTransport);
-        await waitFor(() => {
-          expect(numberOfConnections(clientTransport)).toBe(0);
-          expect(numberOfConnections(serverTransport)).toBe(0);
-        });
+        await waitFor(() =>
+          expect(numberOfConnections(clientTransport)).toBe(0),
+        );
 
         await vi.advanceTimersByTimeAsync(
           Math.ceil(

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -6,6 +6,7 @@ import {
   getTransportConnections,
   closeAllConnections,
   numberOfConnections,
+  testingClientSessionOptions,
 } from '../util/testHelpers';
 import { EventMap, ProtocolError } from '../transport/events';
 import {
@@ -795,6 +796,86 @@ describe.each(testMatrix())(
       });
     });
 
+    test('backoff should not count towards session grace period', async () => {
+      const clientTransport = testHelpers.getClientTransport('client');
+      const serverTransport = testHelpers.getServerTransport();
+      const serverConnStart = vi.fn();
+      const serverSessStart = vi.fn();
+      const serverSessStop = vi.fn();
+      const serverConnHandler = (evt: EventMap['sessionTransition']) => {
+        switch (evt.state) {
+          case SessionState.Connected:
+            serverConnStart();
+            break;
+        }
+      };
+
+      const serverSessHandler = (evt: EventMap['sessionStatus']) => {
+        switch (evt.status) {
+          case 'connect':
+            serverSessStart();
+            break;
+          case 'disconnect':
+            serverSessStop();
+            break;
+        }
+      };
+
+      serverTransport.addEventListener('sessionTransition', serverConnHandler);
+      serverTransport.addEventListener('sessionStatus', serverSessHandler);
+      clientTransport.connect(serverTransport.clientId);
+      clientTransport.reconnectOnConnectionDrop = false;
+      addPostTestCleanup(async () => {
+        serverTransport.removeEventListener(
+          'sessionTransition',
+          serverConnHandler,
+        );
+        serverTransport.removeEventListener(
+          'sessionTransition',
+          serverConnHandler,
+        );
+        await cleanupTransports([clientTransport, serverTransport]);
+      });
+
+      await waitFor(() => {
+        expect(serverConnStart).toHaveBeenCalledTimes(1);
+        expect(serverSessStart).toHaveBeenCalledTimes(1);
+        expect(serverSessStop).toHaveBeenCalledTimes(0);
+        expect(numberOfConnections(clientTransport)).toBe(1);
+        expect(numberOfConnections(serverTransport)).toBe(1);
+      });
+
+      // kill the connection
+      const numConnKills = 3;
+      for (let i = 0; i < numConnKills; i++) {
+        closeAllConnections(clientTransport);
+        await waitFor(() => {
+          expect(numberOfConnections(clientTransport)).toBe(0);
+          expect(numberOfConnections(serverTransport)).toBe(0);
+        });
+
+        await vi.advanceTimersByTimeAsync(
+          Math.ceil(
+            testingClientSessionOptions.sessionDisconnectGraceMs / numConnKills,
+          ),
+        );
+
+        clientTransport.connect(serverTransport.clientId);
+        await waitFor(() => {
+          expect(serverConnStart).toHaveBeenCalledTimes(i + 2);
+        });
+      }
+
+      expect(serverConnStart).toHaveBeenCalledTimes(numConnKills + 1);
+      expect(serverSessStart).toHaveBeenCalledTimes(1);
+      expect(serverSessStop).toHaveBeenCalledTimes(0);
+
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+      });
+    });
+
     test('messages should not be resent when the client loses all state and reconnects to the server', async () => {
       let clientTransport = testHelpers.getClientTransport('client');
       const serverTransport = testHelpers.getServerTransport();
@@ -964,7 +1045,7 @@ describe.each(testMatrix())(
 
       // eagerly reconnect client
       clientTransport.reconnectOnConnectionDrop = true;
-      clientTransport.connect('SERVER');
+      clientTransport.connect(serverTransport.clientId);
 
       await waitFor(() => expect(clientConnStart).toHaveBeenCalledTimes(2));
       await waitFor(() => expect(clientSessStart).toHaveBeenCalledTimes(2));

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -852,6 +852,9 @@ describe.each(testMatrix())(
         await waitFor(() =>
           expect(numberOfConnections(clientTransport)).toBe(0),
         );
+        await waitFor(() =>
+          expect(numberOfConnections(serverTransport)).toBe(0),
+        );
 
         await vi.advanceTimersByTimeAsync(
           Math.ceil(

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -73,6 +73,8 @@ describe.each(testMatrix())(
       expect(oldServerSessionId).toBe(oldClientSessionId);
 
       closeAllConnections(clientTransport);
+      await waitFor(() => expect(numberOfConnections(clientTransport)).toBe(0));
+      await waitFor(() => expect(numberOfConnections(serverTransport)).toBe(0));
 
       // by this point the client should have reconnected
       const msg2Id = clientTransport.send(serverTransport.clientId, msg2);
@@ -132,6 +134,7 @@ describe.each(testMatrix())(
       // disconnect and wait for reconnection
       closeAllConnections(clientTransport);
       await waitFor(() => expect(numberOfConnections(clientTransport)).toBe(0));
+      await waitFor(() => expect(numberOfConnections(serverTransport)).toBe(0));
 
       // wait a bit to let the reconnect budget restore
       await advanceFakeTimersByConnectionBackoff();
@@ -446,6 +449,8 @@ describe.each(testMatrix())(
 
       // clean disconnect + reconnect within grace period
       closeAllConnections(clientTransport);
+      await waitFor(() => expect(numberOfConnections(clientTransport)).toBe(0));
+      await waitFor(() => expect(numberOfConnections(serverTransport)).toBe(0));
 
       // wait for connection status to propagate to server
       // session    >  c------| (connected)
@@ -478,8 +483,8 @@ describe.each(testMatrix())(
       // connection >  c--x   c-----x  | (disconnected)
       clientTransport.reconnectOnConnectionDrop = false;
       closeAllConnections(clientTransport);
-      await waitFor(() => expect(clientConnStart).toHaveBeenCalledTimes(2));
-      await waitFor(() => expect(serverConnStart).toHaveBeenCalledTimes(2));
+      await waitFor(() => expect(numberOfConnections(clientTransport)).toBe(0));
+      await waitFor(() => expect(numberOfConnections(serverTransport)).toBe(0));
 
       await advanceFakeTimersBySessionGrace();
       await waitFor(() => expect(clientSessStart).toHaveBeenCalledTimes(1));
@@ -779,6 +784,9 @@ describe.each(testMatrix())(
       expect(oldServerSessionId).not.toBeUndefined();
 
       closeAllConnections(clientTransport);
+      await waitFor(() => expect(numberOfConnections(clientTransport)).toBe(0));
+      await waitFor(() => expect(numberOfConnections(serverTransport)).toBe(0));
+
       await waitFor(() => {
         expect(onConnect).toHaveBeenCalledTimes(2);
         expect(numberOfConnections(clientTransport)).toEqual(1);
@@ -932,6 +940,8 @@ describe.each(testMatrix())(
       // kill the client
       clientTransport.close();
       closeAllConnections(serverTransport);
+      await waitFor(() => expect(numberOfConnections(clientTransport)).toBe(0));
+      await waitFor(() => expect(numberOfConnections(serverTransport)).toBe(0));
 
       // queue up some messages
       serverTransport.send(
@@ -1027,6 +1037,8 @@ describe.each(testMatrix())(
       // bring client side connections down and stop trying to reconnect
       clientTransport.reconnectOnConnectionDrop = false;
       closeAllConnections(clientTransport);
+      await waitFor(() => expect(numberOfConnections(clientTransport)).toBe(0));
+      await waitFor(() => expect(numberOfConnections(serverTransport)).toBe(0));
 
       // buffer some messages
       clientTransport.send(
@@ -1074,6 +1086,9 @@ describe.each(testMatrix())(
 
       // disconnect and wait for reconnection.
       closeAllConnections(clientTransport);
+      await waitFor(() => expect(numberOfConnections(clientTransport)).toBe(0));
+      await waitFor(() => expect(numberOfConnections(serverTransport)).toBe(0));
+
       await advanceFakeTimersByConnectionBackoff();
 
       // Ensure that the session survived the reconnection. And not just that a session was not
@@ -1432,6 +1447,7 @@ describe.each(testMatrix())(
       // now, let's wait until the connection is considered dead
       closeAllConnections(clientTransport);
       await waitFor(() => expect(numberOfConnections(clientTransport)).toBe(0));
+      await waitFor(() => expect(numberOfConnections(serverTransport)).toBe(0));
 
       // should have reconnected by now
       await waitFor(() => expect(numberOfConnections(clientTransport)).toBe(1));

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -849,12 +849,10 @@ describe.each(testMatrix())(
       const numConnKills = 3;
       for (let i = 0; i < numConnKills; i++) {
         closeAllConnections(clientTransport);
-        await waitFor(() =>
-          expect(numberOfConnections(clientTransport)).toBe(0),
-        );
-        await waitFor(() =>
-          expect(numberOfConnections(serverTransport)).toBe(0),
-        );
+        await waitFor(() => {
+          expect(numberOfConnections(clientTransport)).toBe(0);
+          expect(numberOfConnections(serverTransport)).toBe(0);
+        });
 
         await vi.advanceTimersByTimeAsync(
           Math.ceil(
@@ -865,6 +863,10 @@ describe.each(testMatrix())(
         clientTransport.connect(serverTransport.clientId);
         await waitFor(() => {
           expect(serverConnStart).toHaveBeenCalledTimes(i + 2);
+        });
+        await waitFor(() => {
+          expect(numberOfConnections(clientTransport)).toBe(1);
+          expect(numberOfConnections(serverTransport)).toBe(1);
         });
       }
 

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -23,15 +23,14 @@ import {
   defaultTransportOptions,
 } from './options';
 import {
-  Session,
   SessionConnected,
   SessionConnecting,
   SessionHandshaking,
   SessionNoConnection,
   SessionState,
-  SessionStateGraph,
 } from './sessionStateMachine';
 import { Connection } from './connection';
+import { Session, SessionStateGraph } from './sessionStateMachine/transitions';
 
 /**
  * Represents the possible states of a transport.

--- a/util/testHelpers.ts
+++ b/util/testHelpers.ts
@@ -18,14 +18,13 @@ import {
 import { coerceErrorString } from './stringify';
 import { Transport } from '../transport/transport';
 import { WsLike } from '../transport/impls/ws/wslike';
-import { defaultTransportOptions } from '../transport/options';
+import {
+  defaultClientTransportOptions,
+  defaultTransportOptions,
+} from '../transport/options';
 import { generateId } from '../transport/id';
 import { Connection } from '../transport/connection';
-import {
-  Session,
-  SessionOptions,
-  SessionState,
-} from '../transport/sessionStateMachine/common';
+import { Session, SessionState } from '../transport/sessionStateMachine/common';
 import { SessionStateGraph } from '../transport/sessionStateMachine';
 
 /**
@@ -132,7 +131,8 @@ function catchProcError(err: unknown) {
   return Err({ code: UNCAUGHT_ERROR, message: errorMsg });
 }
 
-export const testingSessionOptions: SessionOptions = defaultTransportOptions;
+export const testingSessionOptions = defaultTransportOptions;
+export const testingClientSessionOptions = defaultClientTransportOptions;
 
 export function dummySession() {
   return SessionStateGraph.entrypoints.NoConnection(

--- a/util/testHelpers.ts
+++ b/util/testHelpers.ts
@@ -24,8 +24,11 @@ import {
 } from '../transport/options';
 import { generateId } from '../transport/id';
 import { Connection } from '../transport/connection';
-import { Session, SessionState } from '../transport/sessionStateMachine/common';
-import { SessionStateGraph } from '../transport/sessionStateMachine';
+import { SessionState } from '../transport/sessionStateMachine/common';
+import {
+  Session,
+  SessionStateGraph,
+} from '../transport/sessionStateMachine/transitions';
 
 /**
  * Creates a WebSocket client that connects to a local server at the specified port.


### PR DESCRIPTION
## Why

- because the Connecting state has a connection timeout, we hit cases in production where the backoff timer _exceeded_ the connection timeout which meant that after a certain point where backoff > connection timeout, we'd never successfully establish a connection


## What changed

- simplify the budget tracking now that client cannot connect to more than one server
- wake up babe, new state machine state just dropped (`SessionBackingOff` which sits between `SessionNoConnection` and `SessionConnecting`)
- add a test to make sure that backoff is not counted towards session grace period
- change session prop passing to be object based rather than long list of params

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
