### PR TITLE
Allow the custom handler to return more error codes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.25.2",
+  "version": "0.26.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.25.2",
+      "version": "0.26.0",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.25.2",
+  "version": "0.26.0",
   "type": "module",
   "exports": {
     ".": {

--- a/router/handshake.ts
+++ b/router/handshake.ts
@@ -1,5 +1,6 @@
 import { Static, TSchema } from '@sinclair/typebox';
 import { ParsedMetadata } from './context';
+import { HandshakeErrorCustomHandlerFatalResponseCodes } from '../transport/message';
 
 type ConstructHandshake<T extends TSchema> = () =>
   | Static<T>
@@ -8,7 +9,13 @@ type ConstructHandshake<T extends TSchema> = () =>
 type ValidateHandshake<T extends TSchema> = (
   metadata: Static<T>,
   previousParsedMetadata?: ParsedMetadata,
-) => false | ParsedMetadata | Promise<false | ParsedMetadata>;
+) =>
+  | Static<typeof HandshakeErrorCustomHandlerFatalResponseCodes>
+  | ParsedMetadata
+  | Promise<
+      | Static<typeof HandshakeErrorCustomHandlerFatalResponseCodes>
+      | ParsedMetadata
+    >;
 
 export interface ClientHandshakeOptions<
   MetadataSchema extends TSchema = TSchema,

--- a/transport/message.ts
+++ b/transport/message.ts
@@ -84,11 +84,21 @@ export const HandshakeErrorRetriableResponseCodes = Type.Union([
   Type.Literal('SESSION_STATE_MISMATCH'),
 ]);
 
-export const HandshakeErrorFatalResponseCodes = Type.Union([
-  Type.Literal('MALFORMED_HANDSHAKE_META'),
-  Type.Literal('MALFORMED_HANDSHAKE'),
-  Type.Literal('PROTOCOL_VERSION_MISMATCH'),
+export const HandshakeErrorCustomHandlerFatalResponseCodes = Type.Union([
+  // The custom validation handler rejected the handler because the client is unsupported.
+  Type.Literal('REJECTED_UNSUPPORTED_CLIENT'),
+  // The custom validation handler rejected the handshake.
   Type.Literal('REJECTED_BY_CUSTOM_HANDLER'),
+]);
+
+export const HandshakeErrorFatalResponseCodes = Type.Union([
+  HandshakeErrorCustomHandlerFatalResponseCodes,
+  // The ciient sent a handshake that doesn't comply with the extended handshake metadata.
+  Type.Literal('MALFORMED_HANDSHAKE_META'),
+  // The ciient sent a handshake that doesn't comply with ControlMessageHandshakeRequestSchema.
+  Type.Literal('MALFORMED_HANDSHAKE'),
+  // The client's protocol version does not match the server's.
+  Type.Literal('PROTOCOL_VERSION_MISMATCH'),
 ]);
 
 export const HandshakeErrorResponseCodes = Type.Union([

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -1476,7 +1476,7 @@ describe.each(testMatrix())(
       });
 
       const get = vi.fn(async () => ({ foo: 'foo' }));
-      const parse = vi.fn(async () => false);
+      const parse = vi.fn(async () => 'REJECTED_BY_CUSTOM_HANDLER');
       const serverTransport = getServerTransport({
         schema,
         validate: parse,


### PR DESCRIPTION
## Why

Previously the only allowed error in a custom handler is `false` (which doesn't say a lot). But we want to be able to return something more expressive.

## What changed

This change now adds a new type for this, and allows the custom handler to return more responses. This allows us to have different behavior for different rejection kinds (some more permanent than others).

## Versioning

- [ ] Breaking protocol change
- [X] Breaking ts/js API change (return type from the validator changed)