### PR TITLE
Also ship the handshake failure code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.26.0",
+      "version": "0.26.1",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "type": "module",
   "exports": {
     ".": {

--- a/transport/client.ts
+++ b/transport/client.ts
@@ -172,13 +172,17 @@ export abstract class ClientTransport<
           onHandshake: (msg) => {
             this.onHandshakeResponse(handshakingSession, msg);
           },
-          onInvalidHandshake: (reason) => {
+          onInvalidHandshake: (reason, code) => {
             this.log?.error(
               `invalid handshake: ${reason}`,
               handshakingSession.loggingMetadata,
             );
             this.deleteSession(session);
-            this.protocolError(ProtocolError.HandshakeFailed, reason);
+            this.protocolError({
+              type: ProtocolError.HandshakeFailed,
+              code,
+              message: reason,
+            });
           },
           onHandshakeTimeout: () => {
             this.log?.error(
@@ -246,7 +250,11 @@ export abstract class ClientTransport<
         this.tryReconnecting(session.to);
       } else {
         this.deleteSession(session);
-        this.protocolError(ProtocolError.HandshakeFailed, reason);
+        this.protocolError({
+          type: ProtocolError.HandshakeFailed,
+          code: msg.payload.status.code,
+          message: reason,
+        });
       }
 
       return;
@@ -288,7 +296,10 @@ export abstract class ClientTransport<
         onMessage: (msg) => this.handleMsg(msg),
         onInvalidMessage: (reason) => {
           this.deleteSession(connectedSession);
-          this.protocolError(ProtocolError.MessageOrderingViolated, reason);
+          this.protocolError({
+            type: ProtocolError.MessageOrderingViolated,
+            message: reason,
+          });
         },
       });
 
@@ -327,7 +338,10 @@ export abstract class ClientTransport<
       const budgetConsumed = this.retryBudget.getBudgetConsumed();
       const errMsg = `tried to connect to ${to} but retry budget exceeded (more than ${budgetConsumed} attempts in the last ${this.retryBudget.totalBudgetRestoreTime}ms)`;
       this.log?.error(errMsg, session.loggingMetadata);
-      this.protocolError(ProtocolError.RetriesExceeded, errMsg);
+      this.protocolError({
+        type: ProtocolError.RetriesExceeded,
+        message: errMsg,
+      });
       return;
     }
 

--- a/transport/events.ts
+++ b/transport/events.ts
@@ -1,5 +1,6 @@
+import { type Static } from '@sinclair/typebox';
 import { Connection } from './connection';
-import { OpaqueTransportMessage } from './message';
+import { OpaqueTransportMessage, HandshakeErrorResponseCodes } from './message';
 import { Session, SessionState } from './sessionStateMachine';
 import { TransportStatus } from './transport';
 
@@ -24,10 +25,19 @@ export interface EventMap {
     | { state: SessionState.Connecting }
     | { state: SessionState.BackingOff }
     | { state: SessionState.NoConnection };
-  protocolError: {
-    type: ProtocolErrorType;
-    message: string;
-  };
+  protocolError:
+    | {
+        type: (typeof ProtocolError)['HandshakeFailed'];
+        code: Static<typeof HandshakeErrorResponseCodes>;
+        message: string;
+      }
+    | {
+        type: Omit<
+          ProtocolErrorType,
+          (typeof ProtocolError)['HandshakeFailed']
+        >;
+        message: string;
+      };
   transportStatus: {
     status: TransportStatus;
   };

--- a/transport/server.ts
+++ b/transport/server.ts
@@ -172,13 +172,17 @@ export abstract class ServerTransport<
           receivedHandshake = true;
           void this.onHandshakeRequest(pendingSession, msg);
         },
-        onInvalidHandshake: (reason) => {
+        onInvalidHandshake: (reason, code) => {
           this.log?.error(
             `invalid handshake: ${reason}`,
             pendingSession.loggingMetadata,
           );
           this.deletePendingSession(pendingSession);
-          this.protocolError(ProtocolError.HandshakeFailed, reason);
+          this.protocolError({
+            type: ProtocolError.HandshakeFailed,
+            code,
+            message: reason,
+          });
         },
       },
       this.options,
@@ -214,7 +218,11 @@ export abstract class ServerTransport<
       }),
     );
 
-    this.protocolError(ProtocolError.HandshakeFailed, reason);
+    this.protocolError({
+      type: ProtocolError.HandshakeFailed,
+      code,
+      message: reason,
+    });
     this.deletePendingSession(session);
   }
 
@@ -434,7 +442,10 @@ export abstract class ServerTransport<
           },
           onMessage: (msg) => this.handleMsg(msg),
           onInvalidMessage: (reason) => {
-            this.protocolError(ProtocolError.MessageOrderingViolated, reason);
+            this.protocolError({
+              type: ProtocolError.MessageOrderingViolated,
+              message: reason,
+            });
             this.deleteSession(connectedSession);
           },
         },

--- a/transport/sessionStateMachine/SessionHandshaking.ts
+++ b/transport/sessionStateMachine/SessionHandshaking.ts
@@ -1,5 +1,10 @@
+import { Static } from '@sinclair/typebox';
 import { Connection } from '../connection';
-import { OpaqueTransportMessage, TransportMessage } from '../message';
+import {
+  OpaqueTransportMessage,
+  TransportMessage,
+  HandshakeErrorResponseCodes,
+} from '../message';
 import {
   IdentifiedSession,
   IdentifiedSessionProps,
@@ -10,7 +15,10 @@ export interface SessionHandshakingListeners {
   onConnectionErrored: (err: unknown) => void;
   onConnectionClosed: () => void;
   onHandshake: (msg: OpaqueTransportMessage) => void;
-  onInvalidHandshake: (reason: string) => void;
+  onInvalidHandshake: (
+    reason: string,
+    code: Static<typeof HandshakeErrorResponseCodes>,
+  ) => void;
 
   // timeout related
   onHandshakeTimeout: () => void;
@@ -52,7 +60,10 @@ export class SessionHandshaking<
   onHandshakeData = (msg: Uint8Array) => {
     const parsedMsg = this.parseMsg(msg);
     if (parsedMsg === null) {
-      this.listeners.onInvalidHandshake('could not parse message');
+      this.listeners.onInvalidHandshake(
+        'could not parse message',
+        'MALFORMED_HANDSHAKE',
+      );
       return;
     }
 

--- a/transport/sessionStateMachine/SessionWaitingForHandshake.ts
+++ b/transport/sessionStateMachine/SessionWaitingForHandshake.ts
@@ -40,7 +40,10 @@ export class SessionWaitingForHandshake<
   onHandshakeData = (msg: Uint8Array) => {
     const parsedMsg = this.parseMsg(msg);
     if (parsedMsg === null) {
-      this.listeners.onInvalidHandshake('could not parse message');
+      this.listeners.onInvalidHandshake(
+        'could not parse message',
+        'MALFORMED_HANDSHAKE',
+      );
       return;
     }
 

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -1512,12 +1512,14 @@ describe.each(testMatrix())(
         expect(clientHandshakeFailed).toHaveBeenCalledTimes(1);
         expect(clientHandshakeFailed).toHaveBeenCalledWith({
           type: ProtocolError.HandshakeFailed,
+          code: 'REJECTED_BY_CUSTOM_HANDLER',
           message: 'handshake failed: rejected by handshake handler',
         });
         expect(parse).toHaveBeenCalledTimes(1);
         expect(serverRejectedConnection).toHaveBeenCalledTimes(1);
         expect(serverRejectedConnection).toHaveBeenCalledWith({
           type: ProtocolError.HandshakeFailed,
+          code: 'REJECTED_BY_CUSTOM_HANDLER',
           message: 'rejected by handshake handler',
         });
       });

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -10,13 +10,7 @@ import {
   LoggingLevel,
   createLogProxy,
 } from '../logging/log';
-import {
-  EventDispatcher,
-  EventHandler,
-  EventMap,
-  EventTypes,
-  ProtocolErrorType,
-} from './events';
+import { EventDispatcher, EventHandler, EventMap, EventTypes } from './events';
 import {
   ProvidedTransportOptions,
   TransportOptions,
@@ -153,8 +147,8 @@ export abstract class Transport<ConnType extends Connection> {
    */
   abstract send(to: TransportClientId, msg: PartialTransportMessage): string;
 
-  protected protocolError(type: ProtocolErrorType, message: string) {
-    this.eventDispatcher.dispatchEvent('protocolError', { type, message });
+  protected protocolError(message: EventMap['protocolError']) {
+    this.eventDispatcher.dispatchEvent('protocolError', message);
   }
 
   /**


### PR DESCRIPTION
## Why

We have the handshake failure _reason_, but it would be nice to also have the code to avoid having to do string matching on the reason.

## What changed

This change now adds the `code` when the protocol error is a handshake failure.

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change