### PR TITLE
add `onSessionGracePeriodElapsed` to `SessionBackingOff`, `SessionConnecting`, and `SessionHandshaking`

### DIFF
--- a/__tests__/fixtures/cleanup.ts
+++ b/__tests__/fixtures/cleanup.ts
@@ -31,7 +31,6 @@ export async function advanceFakeTimersByDisconnectGrace() {
 }
 
 export async function advanceFakeTimersBySessionGrace() {
-  // await advanceFakeTimersByDisconnectGrace();
   await vi.advanceTimersByTimeAsync(
     testingSessionOptions.sessionDisconnectGraceMs,
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.26.1",
+      "version": "0.26.2",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "type": "module",
   "exports": {
     ".": {

--- a/router/context.ts
+++ b/router/context.ts
@@ -41,7 +41,7 @@ export interface ServiceContext {}
  * ```
  */
 /* eslint-disable-next-line @typescript-eslint/no-empty-interface */
-export interface ParsedMetadata {}
+export interface ParsedMetadata extends Record<string, unknown> {}
 
 /**
  * The {@link ServiceContext} with state. This is what is passed to procedures.

--- a/transport/client.ts
+++ b/transport/client.ts
@@ -76,8 +76,6 @@ export abstract class ClientTransport<
 
   /**
    * Abstract method that creates a new {@link Connection} object.
-   * This should call {@link handleConnection} when the connection is created.
-   * The downstream client implementation needs to implement this.
    *
    * @param to The client ID of the node to connect to.
    * @returns The new connection object.
@@ -86,7 +84,12 @@ export abstract class ClientTransport<
     to: TransportClientId,
   ): Promise<ConnType>;
 
-  private tryReconnecting(to: string) {
+  private tryReconnecting(to: TransportClientId) {
+    const oldSession = this.sessions.get(to);
+    if (!this.options.enableTransparentSessionReconnects && oldSession) {
+      this.deleteSession(oldSession);
+    }
+
     if (this.reconnectOnConnectionDrop && this.getStatus() === 'open') {
       this.connect(to);
     }

--- a/transport/client.ts
+++ b/transport/client.ts
@@ -187,6 +187,9 @@ export abstract class ClientTransport<
             );
             this.onConnClosed(handshakingSession);
           },
+          onSessionGracePeriodElapsed: () => {
+            this.onSessionGracePeriodElapsed(handshakingSession);
+          },
         },
       );
 
@@ -365,6 +368,9 @@ export abstract class ClientTransport<
 
             this.onBackoffFinished(backingOffSession, reconnectPromise);
           },
+          onSessionGracePeriodElapsed: () => {
+            this.onSessionGracePeriodElapsed(backingOffSession);
+          },
         },
       );
 
@@ -405,6 +411,9 @@ export abstract class ClientTransport<
               connectingSession.loggingMetadata,
             );
             this.onConnectingFailed(connectingSession);
+          },
+          onSessionGracePeriodElapsed: () => {
+            this.onSessionGracePeriodElapsed(connectingSession);
           },
         },
       );

--- a/transport/options.ts
+++ b/transport/options.ts
@@ -12,6 +12,7 @@ export const defaultTransportOptions: TransportOptions = {
   sessionDisconnectGraceMs: 5_000,
   connectionTimeoutMs: 2_000,
   handshakeTimeoutMs: 1_000,
+  enableTransparentSessionReconnects: true,
   codec: NaiveJsonCodec,
 };
 

--- a/transport/server.ts
+++ b/transport/server.ts
@@ -501,20 +501,23 @@ export abstract class ServerTransport<
       ? this.sessionHandshakeMetadata.get(existingSession.to)
       : undefined;
 
-    const parsedMetadata = await this.handshakeExtensions.validate(
+    const parsedMetadataOrFailureCode = await this.handshakeExtensions.validate(
       rawMetadata,
       previousParsedMetadata,
     );
 
     // handler rejected the connection
     if (
-      Value.Check(HandshakeErrorCustomHandlerFatalResponseCodes, parsedMetadata)
+      Value.Check(
+        HandshakeErrorCustomHandlerFatalResponseCodes,
+        parsedMetadataOrFailureCode,
+      )
     ) {
       this.rejectHandshakeRequest(
         handshakingSession,
         from,
         'rejected by handshake handler',
-        parsedMetadata,
+        parsedMetadataOrFailureCode,
         {
           ...handshakingSession.loggingMetadata,
           connectedTo: from,
@@ -525,6 +528,6 @@ export abstract class ServerTransport<
       return false;
     }
 
-    return parsedMetadata;
+    return parsedMetadataOrFailureCode;
   }
 }

--- a/transport/server.ts
+++ b/transport/server.ts
@@ -301,7 +301,11 @@ export abstract class ServerTransport<
       msg.payload.expectedSessionState.nextExpectedSeq;
     const clientNextSentSeq = msg.payload.expectedSessionState.nextSentSeq ?? 0;
 
-    if (oldSession && oldSession.id === msg.payload.sessionId) {
+    if (
+      this.options.enableTransparentSessionReconnects &&
+      oldSession &&
+      oldSession.id === msg.payload.sessionId
+    ) {
       connectCase = 'transparent reconnection';
 
       // invariant: ordering must be correct
@@ -382,10 +386,15 @@ export abstract class ServerTransport<
       // we don't have a session, but the client is trying to reconnect
       // to an old session. we can't do anything about this, so we reject
       connectCase = 'unknown session';
+
+      const rejectionMessage = this.options.enableTransparentSessionReconnects
+        ? `client is trying to reconnect to a session the server don't know about: ${msg.payload.sessionId}`
+        : `client is attempting a transparent reconnect to a session but the server does not support it: ${msg.payload.sessionId}`;
+
       this.rejectHandshakeRequest(
         session,
         msg.from,
-        `client is trying to reconnect to a session the server don't know about: ${msg.payload.sessionId}`,
+        rejectionMessage,
         'SESSION_STATE_MISMATCH',
         {
           ...session.loggingMetadata,

--- a/transport/sessionStateMachine/SessionBackingOff.ts
+++ b/transport/sessionStateMachine/SessionBackingOff.ts
@@ -1,14 +1,17 @@
 import {
-  IdentifiedSession,
-  IdentifiedSessionProps,
+  IdentifiedSessionWithGracePeriod,
+  IdentifiedSessionWithGracePeriodListeners,
+  IdentifiedSessionWithGracePeriodProps,
   SessionState,
 } from './common';
 
-export interface SessionBackingOffListeners {
+export interface SessionBackingOffListeners
+  extends IdentifiedSessionWithGracePeriodListeners {
   onBackoffFinished: () => void;
 }
 
-export interface SessionBackingOffProps extends IdentifiedSessionProps {
+export interface SessionBackingOffProps
+  extends IdentifiedSessionWithGracePeriodProps {
   backoffMs: number;
   listeners: SessionBackingOffListeners;
 }
@@ -17,7 +20,7 @@ export interface SessionBackingOffProps extends IdentifiedSessionProps {
  * A session that is backing off before attempting to connect.
  * See transitions.ts for valid transitions.
  */
-export class SessionBackingOff extends IdentifiedSession {
+export class SessionBackingOff extends IdentifiedSessionWithGracePeriod {
   readonly state = SessionState.BackingOff as const;
   listeners: SessionBackingOffListeners;
 

--- a/transport/sessionStateMachine/SessionConnected.ts
+++ b/transport/sessionStateMachine/SessionConnected.ts
@@ -129,7 +129,10 @@ export class SessionConnected<
 
   onMessageData = (msg: Uint8Array) => {
     const parsedMsg = this.parseMsg(msg);
-    if (parsedMsg === null) return;
+    if (parsedMsg === null) {
+      this.listeners.onInvalidMessage('could not parse message');
+      return;
+    }
 
     // check message ordering here
     if (parsedMsg.seq !== this.ack) {

--- a/transport/sessionStateMachine/SessionConnecting.ts
+++ b/transport/sessionStateMachine/SessionConnecting.ts
@@ -1,11 +1,13 @@
 import { Connection } from '../connection';
 import {
-  IdentifiedSession,
-  IdentifiedSessionProps,
+  IdentifiedSessionWithGracePeriod,
+  IdentifiedSessionWithGracePeriodListeners,
+  IdentifiedSessionWithGracePeriodProps,
   SessionState,
 } from './common';
 
-export interface SessionConnectingListeners {
+export interface SessionConnectingListeners
+  extends IdentifiedSessionWithGracePeriodListeners {
   onConnectionEstablished: (conn: Connection) => void;
   onConnectionFailed: (err: unknown) => void;
 
@@ -14,7 +16,7 @@ export interface SessionConnectingListeners {
 }
 
 export interface SessionConnectingProps<ConnType extends Connection>
-  extends IdentifiedSessionProps {
+  extends IdentifiedSessionWithGracePeriodProps {
   connPromise: Promise<ConnType>;
   listeners: SessionConnectingListeners;
 }
@@ -25,7 +27,7 @@ export interface SessionConnectingProps<ConnType extends Connection>
  */
 export class SessionConnecting<
   ConnType extends Connection,
-> extends IdentifiedSession {
+> extends IdentifiedSessionWithGracePeriod {
   readonly state = SessionState.Connecting as const;
   connPromise: Promise<ConnType>;
   listeners: SessionConnectingListeners;
@@ -65,8 +67,11 @@ export class SessionConnecting<
 
   _handleStateExit(): void {
     super._handleStateExit();
-    clearTimeout(this.connectionTimeout);
-    this.connectionTimeout = undefined;
+
+    if (this.connectionTimeout) {
+      clearTimeout(this.connectionTimeout);
+      this.connectionTimeout = undefined;
+    }
   }
 
   _handleClose(): void {

--- a/transport/sessionStateMachine/SessionNoConnection.ts
+++ b/transport/sessionStateMachine/SessionNoConnection.ts
@@ -1,35 +1,21 @@
 import {
-  IdentifiedSession,
-  IdentifiedSessionProps,
+  IdentifiedSessionWithGracePeriod,
+  IdentifiedSessionWithGracePeriodListeners,
+  IdentifiedSessionWithGracePeriodProps,
   SessionState,
 } from './common';
 
-export interface SessionNoConnectionListeners {
-  // timeout related
-  onSessionGracePeriodElapsed: () => void;
-}
+export type SessionNoConnectionListeners =
+  IdentifiedSessionWithGracePeriodListeners;
 
-export interface SessionNoConnectionProps extends IdentifiedSessionProps {
-  listeners: SessionNoConnectionListeners;
-}
+export type SessionNoConnectionProps = IdentifiedSessionWithGracePeriodProps;
 
 /*
  * A session that is not connected and cannot send or receive messages.
  * See transitions.ts for valid transitions.
  */
-export class SessionNoConnection extends IdentifiedSession {
+export class SessionNoConnection extends IdentifiedSessionWithGracePeriod {
   readonly state = SessionState.NoConnection as const;
-  listeners: SessionNoConnectionListeners;
-
-  gracePeriodTimeout?: ReturnType<typeof setTimeout>;
-
-  constructor(props: SessionNoConnectionProps) {
-    super(props);
-    this.listeners = props.listeners;
-    this.gracePeriodTimeout = setTimeout(() => {
-      this.listeners.onSessionGracePeriodElapsed();
-    }, this.options.sessionDisconnectGraceMs);
-  }
 
   _handleClose(): void {
     super._handleClose();
@@ -37,10 +23,5 @@ export class SessionNoConnection extends IdentifiedSession {
 
   _handleStateExit(): void {
     super._handleStateExit();
-
-    if (this.gracePeriodTimeout) {
-      clearTimeout(this.gracePeriodTimeout);
-      this.gracePeriodTimeout = undefined;
-    }
   }
 }

--- a/transport/sessionStateMachine/SessionWaitingForHandshake.ts
+++ b/transport/sessionStateMachine/SessionWaitingForHandshake.ts
@@ -1,13 +1,21 @@
+import { Static } from '@sinclair/typebox';
 import { MessageMetadata } from '../../logging';
 import { Connection } from '../connection';
-import { OpaqueTransportMessage, TransportMessage } from '../message';
+import {
+  HandshakeErrorResponseCodes,
+  OpaqueTransportMessage,
+  TransportMessage,
+} from '../message';
 import { CommonSession, CommonSessionProps, SessionState } from './common';
 
 export interface SessionWaitingForHandshakeListeners {
   onConnectionErrored: (err: unknown) => void;
   onConnectionClosed: () => void;
   onHandshake: (msg: OpaqueTransportMessage) => void;
-  onInvalidHandshake: (reason: string) => void;
+  onInvalidHandshake: (
+    reason: string,
+    code: Static<typeof HandshakeErrorResponseCodes>,
+  ) => void;
 
   // timeout related
   onHandshakeTimeout: () => void;

--- a/transport/sessionStateMachine/SessionWaitingForHandshake.ts
+++ b/transport/sessionStateMachine/SessionWaitingForHandshake.ts
@@ -1,13 +1,22 @@
 import { MessageMetadata } from '../../logging';
 import { Connection } from '../connection';
-import { TransportMessage } from '../message';
-import { SessionHandshakingListeners } from './SessionHandshaking';
+import { OpaqueTransportMessage, TransportMessage } from '../message';
 import { CommonSession, CommonSessionProps, SessionState } from './common';
+
+export interface SessionWaitingForHandshakeListeners {
+  onConnectionErrored: (err: unknown) => void;
+  onConnectionClosed: () => void;
+  onHandshake: (msg: OpaqueTransportMessage) => void;
+  onInvalidHandshake: (reason: string) => void;
+
+  // timeout related
+  onHandshakeTimeout: () => void;
+}
 
 export interface SessionWaitingForHandshakeProps<ConnType extends Connection>
   extends CommonSessionProps {
   conn: ConnType;
-  listeners: SessionHandshakingListeners;
+  listeners: SessionWaitingForHandshakeListeners;
 }
 
 /*
@@ -19,7 +28,7 @@ export class SessionWaitingForHandshake<
 > extends CommonSession {
   readonly state = SessionState.WaitingForHandshake as const;
   conn: ConnType;
-  listeners: SessionHandshakingListeners;
+  listeners: SessionWaitingForHandshakeListeners;
 
   handshakeTimeout?: ReturnType<typeof setTimeout>;
 

--- a/transport/sessionStateMachine/common.ts
+++ b/transport/sessionStateMachine/common.ts
@@ -108,13 +108,12 @@ export interface SessionOptions {
   heartbeatsUntilDead: number;
   /**
    * Max duration that a session can be without a connection before we consider
-   * it dead.
+   * it dead. This deadline is carried between states and is used to determine
+   * when to consider the session a lost cause and delete it entirely.
+   * Generally, this should be strictly greater than the sum of
+   * {@link connectionTimeoutMs} and {@link handshakeTimeoutMs}.
    */
   sessionDisconnectGraceMs: number;
-  /**
-   * Whether to enable transparent session reconnects
-   */
-  enableTransparentSessionReconnects: boolean;
   /**
    * Connection timeout in milliseconds
    */
@@ -123,6 +122,10 @@ export interface SessionOptions {
    * Handshake timeout in milliseconds
    */
   handshakeTimeoutMs: number;
+  /**
+   * Whether to enable transparent session reconnects
+   */
+  enableTransparentSessionReconnects: boolean;
   /**
    * The codec to use for encoding/decoding messages over the wire
    */

--- a/transport/sessionStateMachine/common.ts
+++ b/transport/sessionStateMachine/common.ts
@@ -107,9 +107,14 @@ export interface SessionOptions {
    */
   heartbeatsUntilDead: number;
   /**
-   * Duration to wait between connection disconnect and actual session disconnect
+   * Max duration that a session can be without a connection before we consider
+   * it dead.
    */
   sessionDisconnectGraceMs: number;
+  /**
+   * Whether to enable transparent session reconnects
+   */
+  enableTransparentSessionReconnects: boolean;
   /**
    * Connection timeout in milliseconds
    */

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -28,6 +28,8 @@ import {
   ProvidedClientTransportOptions,
   ProvidedTransportOptions,
 } from './options';
+import { coloredStringLogger } from '../logging';
+import { ParsedMetadata } from '../router';
 
 describe.each(testMatrix())(
   'transport connection behaviour tests ($transport.name transport, $codec.name codec)',
@@ -339,46 +341,6 @@ describe.each(testMatrix())(
       await expect(
         Promise.all([...first90Promises, ...last10Promises]),
       ).resolves.toStrictEqual(clientMsgs.map((msg) => msg.payload));
-
-      await testFinishesCleanly({
-        clientTransports: [clientTransport],
-        serverTransport,
-      });
-    });
-
-    test('session grace elapses during long reconnect loop', async () => {
-      const clientTransport = getClientTransport('client');
-      const serverTransport = getServerTransport();
-      clientTransport.reconnectOnConnectionDrop = true;
-      clientTransport.connect(serverTransport.clientId);
-
-      addPostTestCleanup(async () => {
-        await cleanupTransports([clientTransport, serverTransport]);
-      });
-
-      await waitFor(() => expect(numberOfConnections(serverTransport)).toBe(1));
-      await waitFor(() => expect(numberOfConnections(clientTransport)).toBe(1));
-
-      // disconnect the client
-      closeAllConnections(clientTransport);
-      await waitFor(() => expect(numberOfConnections(clientTransport)).toBe(0));
-      await waitFor(() => expect(numberOfConnections(serverTransport)).toBe(0));
-
-      // should still have a session
-      expect(serverTransport.sessions.size).toBe(1);
-      expect(clientTransport.sessions.size).toBe(1);
-
-      for (
-        let i = 0;
-        i < testingClientSessionOptions.sessionDisconnectGraceMs / 1000;
-        i++
-      ) {
-        await vi.advanceTimersByTimeAsync(1000);
-      }
-
-      // grace is elapsed, should have no sessions
-      expect(serverTransport.sessions.size).toBe(0);
-      expect(clientTransport.sessions.size).toBe(0);
 
       await testFinishesCleanly({
         clientTransports: [clientTransport],
@@ -723,9 +685,10 @@ describe.each(testMatrix())(
       const get = vi.fn();
 
       const parse = vi.fn(() => {
-        const promise = new Promise(() => {
+        const promise = new Promise<ParsedMetadata>(() => {
           // noop we never want this to return
         });
+
         return promise;
       });
 
@@ -843,88 +806,85 @@ describe.each(testMatrix())(
       });
     });
 
-    test('backoff should not count towards session grace period', async () => {
-      const clientTransport = testHelpers.getClientTransport('client');
-      const serverTransport = testHelpers.getServerTransport();
-      const serverConnStart = vi.fn();
-      const serverSessStart = vi.fn();
-      const serverSessStop = vi.fn();
-      const serverConnHandler = (evt: EventMap['sessionTransition']) => {
-        switch (evt.state) {
-          case SessionState.Connected:
-            serverConnStart();
-            break;
+    // make a custom auth thing that rejects all connections
+    // session grace should elapse at some point despite retry loop
+    test('session grace elapses during long reconnect loop', async () => {
+      let attemptNumber = 0;
+      let connsReachedServer = 0;
+      const schema = Type.Object({
+        attemptNumber: Type.Number(),
+      });
+      const clientTransport = testHelpers.getClientTransport('client', {
+        schema,
+        construct() {
+          return { attemptNumber: attemptNumber++ };
+        },
+      });
+      const serverTransport = testHelpers.getServerTransport({
+        schema,
+        async validate(_metadata, _previousParsedMetadata) {
+          connsReachedServer++;
+          await new Promise((resolve) =>
+            setTimeout(resolve, testingClientSessionOptions.handshakeTimeoutMs),
+          );
+          return {};
+        },
+      });
+
+      const onSessionDisconnect = vi.fn();
+      const sessionStatusListener = (evt: EventMap['sessionStatus']) => {
+        if (evt.status === 'disconnect') {
+          onSessionDisconnect();
         }
       };
 
-      const serverSessHandler = (evt: EventMap['sessionStatus']) => {
-        switch (evt.status) {
-          case 'connect':
-            serverSessStart();
-            break;
-          case 'disconnect':
-            serverSessStop();
-            break;
-        }
-      };
-
-      serverTransport.addEventListener('sessionTransition', serverConnHandler);
-      serverTransport.addEventListener('sessionStatus', serverSessHandler);
-      clientTransport.connect(serverTransport.clientId);
-      clientTransport.reconnectOnConnectionDrop = false;
+      clientTransport.addEventListener('sessionStatus', sessionStatusListener);
       addPostTestCleanup(async () => {
-        serverTransport.removeEventListener(
-          'sessionTransition',
-          serverConnHandler,
-        );
-        serverTransport.removeEventListener(
-          'sessionTransition',
-          serverConnHandler,
+        clientTransport.removeEventListener(
+          'sessionStatus',
+          sessionStatusListener,
         );
         await cleanupTransports([clientTransport, serverTransport]);
       });
 
-      await waitFor(() => {
-        expect(serverConnStart).toHaveBeenCalledTimes(1);
-        expect(serverSessStart).toHaveBeenCalledTimes(1);
-        expect(serverSessStop).toHaveBeenCalledTimes(0);
-        expect(numberOfConnections(clientTransport)).toBe(1);
-        expect(numberOfConnections(serverTransport)).toBe(1);
-      });
-
-      // kill the connection
-      const numConnKills = 3;
-      for (let i = 0; i < numConnKills; i++) {
-        closeAllConnections(clientTransport);
-        await waitFor(() => {
-          expect(numberOfConnections(clientTransport)).toBe(0);
-          expect(numberOfConnections(serverTransport)).toBe(0);
-        });
-
-        await vi.advanceTimersByTimeAsync(
-          Math.ceil(
-            testingClientSessionOptions.sessionDisconnectGraceMs / numConnKills,
-          ),
-        );
+      // enter the retry loop
+      let timeAdvanced = 0;
+      for (
+        let i = 0;
+        i < testingClientSessionOptions.attemptBudgetCapacity;
+        i++
+      ) {
+        const backoff =
+          clientTransport.retryBudget.getBackoffMs() +
+          testingClientSessionOptions.maxJitterMs;
 
         clientTransport.connect(serverTransport.clientId);
+
+        await vi.advanceTimersByTimeAsync(backoff);
+        timeAdvanced += backoff;
+
+        if (
+          timeAdvanced > testingClientSessionOptions.sessionDisconnectGraceMs
+        ) {
+          // ok we should have hit session disconnect grace by now
+          break;
+        }
+
+        // wait for the conn attempt to reach the server
         await waitFor(() => {
-          expect(serverConnStart).toHaveBeenCalledTimes(i + 2);
+          expect(connsReachedServer).toBe(i + 1);
+          expect(attemptNumber).toBe(i + 1);
         });
-        await waitFor(() => {
-          expect(numberOfConnections(clientTransport)).toBe(1);
-          expect(numberOfConnections(serverTransport)).toBe(1);
-        });
+
+        // wait for the artificially long handshake to finish
+        await vi.advanceTimersByTimeAsync(
+          testingClientSessionOptions.handshakeTimeoutMs,
+        );
+        timeAdvanced += testingClientSessionOptions.handshakeTimeoutMs;
       }
 
-      expect(serverConnStart).toHaveBeenCalledTimes(numConnKills + 1);
-      expect(serverSessStart).toHaveBeenCalledTimes(1);
-      expect(serverSessStop).toHaveBeenCalledTimes(0);
-
-      await testFinishesCleanly({
-        clientTransports: [clientTransport],
-        serverTransport,
-      });
+      expect(attemptNumber).toBeGreaterThan(1);
+      expect(onSessionDisconnect).toHaveBeenCalledTimes(1);
     });
 
     test('messages should not be resent when the client loses all state and reconnects to the server', async () => {
@@ -1515,7 +1475,7 @@ describe.each(testMatrix())(
       });
 
       const get = vi.fn(async () => ({ foo: 'foo' }));
-      const parse = vi.fn(async () => 'REJECTED_BY_CUSTOM_HANDLER');
+      const parse = vi.fn(async () => 'REJECTED_BY_CUSTOM_HANDLER' as const);
       const serverTransport = getServerTransport({
         schema,
         validate: parse,

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -28,7 +28,6 @@ import {
   ProvidedClientTransportOptions,
   ProvidedTransportOptions,
 } from './options';
-import { coloredStringLogger } from '../logging';
 import { ParsedMetadata } from '../router';
 
 describe.each(testMatrix())(

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -588,8 +588,7 @@ describe.each(testMatrix())(
   async ({ transport, codec }) => {
     const opts: ProvidedTransportOptions = {
       codec: codec.codec,
-      // set the session disconnect grace to 0 to force a hard reconnect
-      sessionDisconnectGraceMs: 0,
+      enableTransparentSessionReconnects: false,
     };
 
     let testHelpers: TestSetupHelpers;

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -220,7 +220,7 @@ export abstract class Transport<ConnType extends Connection> {
   }
 
   // common listeners
-  protected onSessionGracePeriodElapsed(session: SessionNoConnection) {
+  protected onSessionGracePeriodElapsed(session: Session<ConnType>) {
     this.log?.warn(
       `session to ${session.to} grace period elapsed, closing`,
       session.loggingMetadata,


### PR DESCRIPTION
## Why

- session should track its grace period even as it transitions between various non-connected states
- otherwise, we end up in scenarios where the reconnect loop will prevent the session grace from kicking in until the retry budget is exhausted

<!-- Describe what you are trying to accomplish with this pull request -->

## What changed

- add `onSessionGracePeriodElapsed` to intermediate states
- add many many tests for behavior of session grace between states

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
