### PR TITLE
make some improvements to connecting state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.26.3",
+  "version": "0.26.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.26.3",
+      "version": "0.26.4",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.26.3",
+  "version": "0.26.4",
   "type": "module",
   "exports": {
     ".": {

--- a/transport/sessionStateMachine/stateMachine.test.ts
+++ b/transport/sessionStateMachine/stateMachine.test.ts
@@ -1535,13 +1535,13 @@ describe('session state machine', () => {
 
       connect();
 
-      await waitFor(async () => {
-        expect(connectionEstablished).toHaveBeenCalled();
-        expect(connectionEstablished).toHaveBeenCalledWith(
-          await session.connPromise,
-        );
-        expect(connectionFailed).not.toHaveBeenCalled();
-      });
+      // wait for one tick
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(connectionEstablished).toHaveBeenCalled();
+      expect(connectionEstablished).toHaveBeenCalledWith(
+        await session.connPromise,
+      );
+      expect(connectionFailed).not.toHaveBeenCalled();
 
       // should not have transitioned to the next state
       expect(session.state).toBe(SessionState.Connecting);
@@ -1558,13 +1558,10 @@ describe('session state machine', () => {
 
       error(new Error('test error'));
 
-      await waitFor(async () => {
-        expect(onConnectionFailed).toHaveBeenCalled();
-        expect(onConnectionFailed).toHaveBeenCalledWith(
-          new Error('test error'),
-        );
-        expect(onConnectionEstablished).not.toHaveBeenCalled();
-      });
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(onConnectionFailed).toHaveBeenCalled();
+      expect(onConnectionFailed).toHaveBeenCalledWith(new Error('test error'));
+      expect(onConnectionEstablished).not.toHaveBeenCalled();
 
       // should not have transitioned to the next state
       expect(session.state).toBe(SessionState.Connecting);


### PR DESCRIPTION
## Why

- missing some debug info

## What changed

- moved construction of reconnect promise into `onBackoffFinished`
- include conn logging metadata in `onConnectionEstablished` cb
- pull out logger and metadata in `bestEffortClose` so it doesn't error if we log after transition
- stricter test

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
