### PR TITLE
make out of order non fatal + various fixes

### DIFF
--- a/__tests__/negative.test.ts
+++ b/__tests__/negative.test.ts
@@ -173,7 +173,7 @@ describe('should handle incompatabilities', async () => {
     });
   });
 
-  test('seq number in the future should raise protocol error', async () => {
+  test('seq number in the future should close connection', async () => {
     const serverTransport = new WebSocketServerTransport(wss, 'SERVER');
 
     // add listeners
@@ -222,12 +222,8 @@ describe('should handle incompatabilities', async () => {
     };
     ws.send(NaiveJsonCodec.toBuffer(msg));
 
-    await waitFor(() => expect(errMock).toHaveBeenCalledTimes(1));
-    expect(errMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: ProtocolError.MessageOrderingViolated,
-      }),
-    );
+    await waitFor(() => ws.readyState === ws.CLOSED);
+    expect(serverTransport.sessions.size).toBe(1);
 
     await testFinishesCleanly({
       clientTransports: [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.26.5",
+  "version": "0.26.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.26.5",
+      "version": "0.26.6",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.26.5",
+  "version": "0.26.6",
   "type": "module",
   "exports": {
     ".": {

--- a/transport/client.ts
+++ b/transport/client.ts
@@ -300,7 +300,7 @@ export abstract class ClientTransport<
         onInvalidMessage: (reason) => {
           this.deleteSession(connectedSession);
           this.protocolError({
-            type: ProtocolError.MessageOrderingViolated,
+            type: ProtocolError.InvalidMessage,
             message: reason,
           });
         },
@@ -436,6 +436,12 @@ export abstract class ClientTransport<
 
     if (this.handshakeExtensions) {
       metadata = await this.handshakeExtensions.construct();
+    }
+
+    // double-check to make sure we haven't transitioned the session yet
+    if (session._isConsumed) {
+      // bail out, don't need to do anything
+      return;
     }
 
     const requestMsg = handshakeRequestMessage({

--- a/transport/events.ts
+++ b/transport/events.ts
@@ -8,6 +8,7 @@ export const ProtocolError = {
   RetriesExceeded: 'conn_retry_exceeded',
   HandshakeFailed: 'handshake_failed',
   MessageOrderingViolated: 'message_ordering_violated',
+  InvalidMessage: 'invalid_message',
 } as const;
 
 export type ProtocolErrorType =

--- a/transport/server.ts
+++ b/transport/server.ts
@@ -508,7 +508,7 @@ export abstract class ServerTransport<
           onMessage: (msg) => this.handleMsg(msg),
           onInvalidMessage: (reason) => {
             this.protocolError({
-              type: ProtocolError.MessageOrderingViolated,
+              type: ProtocolError.InvalidMessage,
               message: reason,
             });
             this.deleteSession(connectedSession);


### PR DESCRIPTION
## Why

<!-- Describe what you are trying to accomplish with this pull request -->

- we see out-of-order messages in production but only from user agents `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36` and AS name of Menlo Security who seem like they run a proxy of some sort for security
- it is likely that their proxy drops websocket messages which sucks for us

## What changed

- no longer raise protocol error on out of order and instead close the connection
  - the reasoning is that the client will attempt to re-establish the connection and re-agree on the right seq number and resend the send buffer
  - if theres a disagreement at this stage, we will kill the session but otherwise we can actually transparently recover!
- also downgrade it to a warn
- extra check for session consumed during the async wait point when constructing the handshake

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
