### PR TITLE
label unhealthy sessions

### DIFF
--- a/__tests__/negative.test.ts
+++ b/__tests__/negative.test.ts
@@ -173,7 +173,7 @@ describe('should handle incompatabilities', async () => {
     });
   });
 
-  test('seq number in the future should raise protocol error', async () => {
+  test('seq number in the future should close connection', async () => {
     const serverTransport = new WebSocketServerTransport(wss, 'SERVER');
 
     // add listeners
@@ -222,12 +222,8 @@ describe('should handle incompatabilities', async () => {
     };
     ws.send(NaiveJsonCodec.toBuffer(msg));
 
-    await waitFor(() => expect(errMock).toHaveBeenCalledTimes(1));
-    expect(errMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: ProtocolError.MessageOrderingViolated,
-      }),
-    );
+    await waitFor(() => ws.readyState === ws.CLOSED);
+    expect(serverTransport.sessions.size).toBe(1);
 
     await testFinishesCleanly({
       clientTransports: [],

--- a/logging/log.ts
+++ b/logging/log.ts
@@ -18,7 +18,10 @@ export type Logger = {
   [key in LoggingLevel]: (msg: string, metadata?: MessageMetadata) => void;
 };
 
-export type Tags = 'invariant-violation' | 'state-transition';
+export type Tags =
+  | 'invariant-violation'
+  | 'state-transition'
+  | 'unhealthy-session';
 
 const cleanedLogFn = (log: LogFn) => {
   return (msg: string, metadata?: MessageMetadata) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.26.5",
+  "version": "0.26.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.26.5",
+      "version": "0.26.6",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.26.5",
+  "version": "0.26.6",
   "type": "module",
   "exports": {
     ".": {

--- a/transport/client.ts
+++ b/transport/client.ts
@@ -300,7 +300,7 @@ export abstract class ClientTransport<
         onInvalidMessage: (reason) => {
           this.deleteSession(connectedSession);
           this.protocolError({
-            type: ProtocolError.MessageOrderingViolated,
+            type: ProtocolError.InvalidMessage,
             message: reason,
           });
         },
@@ -436,6 +436,12 @@ export abstract class ClientTransport<
 
     if (this.handshakeExtensions) {
       metadata = await this.handshakeExtensions.construct();
+    }
+
+    // double-check to make sure we haven't transitioned the session yet
+    if (session._isConsumed) {
+      // bail out, don't need to do anything
+      return;
     }
 
     const requestMsg = handshakeRequestMessage({

--- a/transport/client.ts
+++ b/transport/client.ts
@@ -180,7 +180,7 @@ export abstract class ClientTransport<
               `invalid handshake: ${reason}`,
               handshakingSession.loggingMetadata,
             );
-            this.deleteSession(session, true);
+            this.deleteSession(session, { unhealthy: true });
             this.protocolError({
               type: ProtocolError.HandshakeFailed,
               code,
@@ -216,7 +216,7 @@ export abstract class ClientTransport<
     });
 
     this.log?.warn(reason, metadata);
-    this.deleteSession(session, true);
+    this.deleteSession(session, { unhealthy: true });
   }
 
   protected onHandshakeResponse(
@@ -298,7 +298,7 @@ export abstract class ClientTransport<
         },
         onMessage: (msg) => this.handleMsg(msg),
         onInvalidMessage: (reason) => {
-          this.deleteSession(connectedSession, true);
+          this.deleteSession(connectedSession, { unhealthy: true });
           this.protocolError({
             type: ProtocolError.InvalidMessage,
             message: reason,

--- a/transport/client.ts
+++ b/transport/client.ts
@@ -180,7 +180,7 @@ export abstract class ClientTransport<
               `invalid handshake: ${reason}`,
               handshakingSession.loggingMetadata,
             );
-            this.deleteSession(session);
+            this.deleteSession(session, true);
             this.protocolError({
               type: ProtocolError.HandshakeFailed,
               code,
@@ -216,7 +216,7 @@ export abstract class ClientTransport<
     });
 
     this.log?.warn(reason, metadata);
-    this.deleteSession(session);
+    this.deleteSession(session, true);
   }
 
   protected onHandshakeResponse(
@@ -298,7 +298,7 @@ export abstract class ClientTransport<
         },
         onMessage: (msg) => this.handleMsg(msg),
         onInvalidMessage: (reason) => {
-          this.deleteSession(connectedSession);
+          this.deleteSession(connectedSession, true);
           this.protocolError({
             type: ProtocolError.InvalidMessage,
             message: reason,

--- a/transport/events.ts
+++ b/transport/events.ts
@@ -8,6 +8,7 @@ export const ProtocolError = {
   RetriesExceeded: 'conn_retry_exceeded',
   HandshakeFailed: 'handshake_failed',
   MessageOrderingViolated: 'message_ordering_violated',
+  InvalidMessage: 'invalid_message',
 } as const;
 
 export type ProtocolErrorType =

--- a/transport/server.ts
+++ b/transport/server.ts
@@ -508,7 +508,7 @@ export abstract class ServerTransport<
           onMessage: (msg) => this.handleMsg(msg),
           onInvalidMessage: (reason) => {
             this.protocolError({
-              type: ProtocolError.MessageOrderingViolated,
+              type: ProtocolError.InvalidMessage,
               message: reason,
             });
             this.deleteSession(connectedSession);

--- a/transport/server.ts
+++ b/transport/server.ts
@@ -16,7 +16,7 @@ import {
   ServerTransportOptions,
   defaultServerTransportOptions,
 } from './options';
-import { Transport } from './transport';
+import { DeleteSessionOptions, Transport } from './transport';
 import { coerceErrorString } from '../util/stringify';
 import { Static } from '@sinclair/typebox';
 import { Value } from '@sinclair/typebox/value';
@@ -110,10 +110,10 @@ export abstract class ServerTransport<
 
   protected deleteSession(
     session: ServerSession<ConnType>,
-    unhealthy = false,
+    options?: DeleteSessionOptions,
   ): void {
     this.sessionHandshakeMetadata.delete(session.to);
-    super.deleteSession(session, unhealthy);
+    super.deleteSession(session, options);
   }
 
   protected handleConnection(conn: ConnType) {
@@ -514,7 +514,7 @@ export abstract class ServerTransport<
               type: ProtocolError.InvalidMessage,
               message: reason,
             });
-            this.deleteSession(connectedSession, true);
+            this.deleteSession(connectedSession, { unhealthy: true });
           },
         },
       );

--- a/transport/server.ts
+++ b/transport/server.ts
@@ -108,9 +108,12 @@ export abstract class ServerTransport<
     this.pendingSessions.delete(pendingSession);
   }
 
-  protected deleteSession(session: ServerSession<ConnType>): void {
+  protected deleteSession(
+    session: ServerSession<ConnType>,
+    unhealthy = false,
+  ): void {
     this.sessionHandshakeMetadata.delete(session.to);
-    super.deleteSession(session);
+    super.deleteSession(session, unhealthy);
   }
 
   protected handleConnection(conn: ConnType) {
@@ -511,7 +514,7 @@ export abstract class ServerTransport<
               type: ProtocolError.InvalidMessage,
               message: reason,
             });
-            this.deleteSession(connectedSession);
+            this.deleteSession(connectedSession, true);
           },
         },
       );

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -201,8 +201,11 @@ export abstract class Transport<ConnType extends Connection> {
   }
 
   // state transitions
-  protected deleteSession(session: Session<ConnType>) {
-    session.log?.info(`closing session ${session.id}`, session.loggingMetadata);
+  protected deleteSession(session: Session<ConnType>, unhealthy = false) {
+    session.log?.info(`closing session ${session.id}`, {
+      ...session.loggingMetadata,
+      tags: unhealthy ? ['unhealthy-session'] : [],
+    });
 
     this.eventDispatcher.dispatchEvent('sessionStatus', {
       status: 'disconnect',

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -33,6 +33,10 @@ import { Session, SessionStateGraph } from './sessionStateMachine/transitions';
  */
 export type TransportStatus = 'open' | 'closed';
 
+export interface DeleteSessionOptions {
+  unhealthy: boolean;
+}
+
 /**
  * Transports manage the lifecycle (creation/deletion) of sessions
  *
@@ -201,12 +205,16 @@ export abstract class Transport<ConnType extends Connection> {
   }
 
   // state transitions
-  protected deleteSession(session: Session<ConnType>, unhealthy = false) {
-    session.log?.info(`closing session ${session.id}`, {
-      ...session.loggingMetadata,
-      tags: unhealthy ? ['unhealthy-session'] : [],
-    });
+  protected deleteSession(
+    session: Session<ConnType>,
+    options?: DeleteSessionOptions,
+  ) {
+    const loggingMetadata = session.loggingMetadata;
+    if (loggingMetadata.tags && options?.unhealthy) {
+      loggingMetadata.tags.push('unhealthy-session');
+    }
 
+    session.log?.info(`closing session ${session.id}`, loggingMetadata);
     this.eventDispatcher.dispatchEvent('sessionStatus', {
       status: 'disconnect',
       session: session,


### PR DESCRIPTION
## Why

- we'd like an easy way to filter session close events by whether the session ended up being a healthy or unhealthy session to get some baseline SLAs

<!-- Describe what you are trying to accomplish with this pull request -->

## What changed

- add `unhealthy-session` tags to all the places where it makes sense

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
