### PR TITLE
add conn extras to logging metadata

### DIFF
--- a/logging/log.ts
+++ b/logging/log.ts
@@ -51,6 +51,7 @@ export type MessageMetadata = Partial<{
     traceId: string;
     spanId: string;
   };
+  extras: unknown;
 }>;
 
 export class BaseLogger implements Logger {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.26.6",
+  "version": "0.26.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.26.6",
+      "version": "0.26.7",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.26.6",
+  "version": "0.26.7",
   "type": "module",
   "exports": {
     ".": {

--- a/transport/impls/ws/connection.ts
+++ b/transport/impls/ws/connection.ts
@@ -1,12 +1,27 @@
 import { Connection } from '../../connection';
 import { WsLike } from './wslike';
 
+interface ConnectionInfoExtras {
+  headers: Record<string, string>;
+}
+
 export class WebSocketConnection extends Connection {
   ws: WsLike;
+  extras?: ConnectionInfoExtras;
 
-  constructor(ws: WsLike) {
+  get loggingMetadata() {
+    const metadata = super.loggingMetadata;
+    if (this.extras) {
+      metadata.extras = this.extras;
+    }
+
+    return metadata;
+  }
+
+  constructor(ws: WsLike, extras?: ConnectionInfoExtras) {
     super();
     this.ws = ws;
+    this.extras = extras;
     this.ws.binaryType = 'arraybuffer';
 
     // Websockets are kinda shitty, they emit error events with no

--- a/transport/impls/ws/server.ts
+++ b/transport/impls/ws/server.ts
@@ -4,6 +4,22 @@ import { WebSocketConnection } from './connection';
 import { WsLike } from './wslike';
 import { ServerTransport } from '../../server';
 import { ProvidedServerTransportOptions } from '../../options';
+import { type IncomingMessage } from 'http';
+
+function cleanHeaders(
+  headers: IncomingMessage['headers'],
+): Record<string, string> {
+  const cleanedHeaders: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(headers)) {
+    if (!key.startsWith('sec-') && value) {
+      const cleanedValue = Array.isArray(value) ? value[0] : value;
+      cleanedHeaders[key] = cleanedValue;
+    }
+  }
+
+  return cleanedHeaders;
+}
 
 export class WebSocketServerTransport extends ServerTransport<WebSocketConnection> {
   wss: WebSocketServer;
@@ -18,8 +34,11 @@ export class WebSocketServerTransport extends ServerTransport<WebSocketConnectio
     this.wss.on('connection', this.connectionHandler);
   }
 
-  connectionHandler = (ws: WsLike) => {
-    const conn = new WebSocketConnection(ws);
+  connectionHandler = (ws: WsLike, req: IncomingMessage) => {
+    const conn = new WebSocketConnection(ws, {
+      headers: cleanHeaders(req.headersDistinct),
+    });
+
     this.handleConnection(conn);
   };
 


### PR DESCRIPTION
## Why

- we'd like visibility on the raw connection headers on the server in our logs!

## What changed

- add `extras` to logging metadata
- parse conn headers (excluding `Sec-` headers)

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
