### PR TITLE
[protocolv2] Remove the concept of close requests

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -146,7 +146,6 @@ The `controlFlags` property is a [bit field](https://en.wikipedia.org/wiki/Bit_f
 - The `StreamOpenBit` (`0b00010`) MUST be set for the first message of a new stream.
 - The `StreamAbortBit` (`0b00100`) MUST be set when a stream is to be abruptly closed due to cancellations or an internal error condition.
 - The `StreamClosedBit` (`0b01000`) MUST be set for the last message of a stream.
-- The `StreamCloseRequestBit` (`0b10000`) MUST be set for a message that is requesting the other side to close the stream.
 
 All messages MUST have no control flags set (i.e., the `controlFlags` field is `0b00000`) unless:
 
@@ -157,8 +156,6 @@ All messages MUST have no control flags set (i.e., the `controlFlags` field is `
     - All further messages MAY omit `serviceName` and `procedureName` as they are implied by the first message and are constant throughout the lifetime of a stream.
 - It is the last message of a stream, in which case the `StreamClosedBit` MUST be set.
   - If this is sent with no payload, it is a control message the payload MUST Be a `ControlClose`.
-- It is a message requesting the other side to stop writing to the stream, in which case the `StreamCloseRequestBit` MUST be set.
-  - This is a control message and the payload MUST be a `ControlClose`.
 - It is a message aborting the stream, in which case the `StreamAbortBit` MUST be set.
   - This message MUST contain a `ProtocolError` payload.
 - It is an explicit heartbeat, so the `AckBit` MUST be the only bit set.
@@ -199,7 +196,7 @@ There are 4 `Control` payloads:
 
 ```ts
 // Used in cases where we want to send a close without
-// a payload. MUST have either a `StreamClosedBit` or `StreamCloseRequestBit` flag
+// a payload. MUST have a `StreamClosedBit`
 interface ControlClose {
   type: 'CLOSE';
 }

--- a/__tests__/disconnects.test.ts
+++ b/__tests__/disconnects.test.ts
@@ -167,8 +167,12 @@ describe.each(testMatrix())(
 
       // start procedure
       // client1 and client2 both subscribe
+      const abortController1 = new AbortController();
       const { resReader: responseReader1 } =
-        client1.subscribable.value.subscribe({});
+        client1.subscribable.value.subscribe(
+          {},
+          { signal: abortController1.signal },
+        );
       const outputIterator1 = getIteratorFromStream(responseReader1);
       let result = await iterNext(outputIterator1);
       expect(result).toStrictEqual({
@@ -239,7 +243,7 @@ describe.each(testMatrix())(
       });
 
       expect(responseReader2.isClosed()).toBe(true);
-      await responseReader1.requestClose();
+      abortController1.abort();
 
       await testFinishesCleanly({
         clientTransports: [client1Transport, client2Transport],

--- a/__tests__/fixtures/services.ts
+++ b/__tests__/fixtures/services.ts
@@ -49,16 +49,13 @@ const testServiceProcedures = TestServiceScaffold.procedures({
     requestData: EchoRequest,
     responseData: EchoResponse,
     async handler({ reqReader, resWriter }) {
-      resWriter.onCloseRequest(() => {
-        resWriter.close();
-      });
-
       for await (const input of reqReader) {
         const { ignore, msg } = unwrap(input);
         if (!ignore) {
           resWriter.write(Ok({ response: msg }));
         }
       }
+
       resWriter.close();
     },
   }),
@@ -68,16 +65,14 @@ const testServiceProcedures = TestServiceScaffold.procedures({
     requestData: EchoRequest,
     responseData: EchoResponse,
     async handler({ reqInit, reqReader, resWriter }) {
-      resWriter.onCloseRequest(() => {
-        resWriter.close();
-      });
-
       for await (const input of reqReader) {
         const { ignore, msg } = unwrap(input);
         if (!ignore) {
           resWriter.write(Ok({ response: `${reqInit.prefix} ${msg}` }));
         }
       }
+
+      resWriter.close();
     },
   }),
 
@@ -238,17 +233,11 @@ export const SubscribableServiceSchema = ServiceSchema.define(
       requestInit: Type.Object({}),
       responseData: Type.Object({ result: Type.Number() }),
       async handler({ ctx, resWriter }) {
-        const dispose1 = ctx.state.count.observe((count) => {
+        const dispose = ctx.state.count.observe((count) => {
           resWriter.write(Ok({ result: count }));
         });
 
-        ctx.onRequestFinished(dispose1);
-
-        const dispose2 = resWriter.onCloseRequest(() => {
-          resWriter.close();
-        });
-
-        ctx.onRequestFinished(dispose2);
+        ctx.onRequestFinished(dispose);
       },
     }),
   },

--- a/__tests__/handler.test.ts
+++ b/__tests__/handler.test.ts
@@ -110,7 +110,6 @@ describe('server-side test', () => {
       payload: { response: 'test ghi' },
     });
 
-    await resReader.requestClose();
     expect(await outputIterator.next()).toEqual({
       done: true,
       value: undefined,

--- a/__tests__/streams.test.ts
+++ b/__tests__/streams.test.ts
@@ -15,7 +15,7 @@ interface SomeError {
 
 describe('ReadStream unit', () => {
   it('should close the stream', async () => {
-    const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+    const stream = new ReadStreamImpl<number, SomeError>();
     stream.triggerClose();
     expect(stream.isClosed()).toEqual(true);
 
@@ -24,7 +24,7 @@ describe('ReadStream unit', () => {
   });
 
   it('should synchronously lock the stream when Symbol.asyncIterable is called', () => {
-    const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+    const stream = new ReadStreamImpl<number, SomeError>();
     stream[Symbol.asyncIterator]();
     expect(stream.isLocked()).toEqual(true);
     expect(() => stream[Symbol.asyncIterator]()).toThrowError(TypeError);
@@ -32,7 +32,7 @@ describe('ReadStream unit', () => {
   });
 
   it('should synchronously lock the stream when asArray() is called', () => {
-    const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+    const stream = new ReadStreamImpl<number, SomeError>();
     void stream.asArray();
     expect(stream.isLocked()).toEqual(true);
     expect(() => stream[Symbol.asyncIterator]()).toThrowError(TypeError);
@@ -40,7 +40,7 @@ describe('ReadStream unit', () => {
   });
 
   it('should synchronously lock the stream when unwrappedIter() is called', () => {
-    const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+    const stream = new ReadStreamImpl<number, SomeError>();
     void stream.unwrappedIter();
     expect(stream.isLocked()).toEqual(true);
     expect(() => stream[Symbol.asyncIterator]()).toThrowError(TypeError);
@@ -48,7 +48,7 @@ describe('ReadStream unit', () => {
   });
 
   it('should synchronously lock the stream when drain() is called', () => {
-    const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+    const stream = new ReadStreamImpl<number, SomeError>();
     stream.drain();
     expect(stream.isLocked()).toEqual(true);
     expect(() => stream[Symbol.asyncIterator]()).toThrowError(TypeError);
@@ -56,7 +56,7 @@ describe('ReadStream unit', () => {
   });
 
   it('should iterate over the values pushed to the stream', async () => {
-    const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+    const stream = new ReadStreamImpl<number, SomeError>();
     const iterator = stream[Symbol.asyncIterator]();
 
     stream.pushValue(Ok(1));
@@ -70,7 +70,7 @@ describe('ReadStream unit', () => {
   });
 
   it('should iterate over the values push to the stream after close', async () => {
-    const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+    const stream = new ReadStreamImpl<number, SomeError>();
     const iterator = stream[Symbol.asyncIterator]();
 
     stream.pushValue(Ok(1));
@@ -84,7 +84,7 @@ describe('ReadStream unit', () => {
   });
 
   it('should handle eager iterations gracefully', async () => {
-    const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+    const stream = new ReadStreamImpl<number, SomeError>();
     const iterator = stream[Symbol.asyncIterator]();
 
     const next1 = iterator.next();
@@ -102,7 +102,7 @@ describe('ReadStream unit', () => {
   });
 
   it('should not resolve iterator until value is pushed or stream is closed', async () => {
-    const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+    const stream = new ReadStreamImpl<number, SomeError>();
 
     const iterator = stream[Symbol.asyncIterator]();
 
@@ -140,7 +140,7 @@ describe('ReadStream unit', () => {
   });
 
   it('should return an array of the stream values when asArray is called after close', async () => {
-    const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+    const stream = new ReadStreamImpl<number, SomeError>();
     stream.pushValue(Ok(1));
     stream.pushValue(Ok(2));
     stream.pushValue(Ok(3));
@@ -151,7 +151,7 @@ describe('ReadStream unit', () => {
   });
 
   it('should not resolve asArray until the stream is closed', async () => {
-    const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+    const stream = new ReadStreamImpl<number, SomeError>();
     stream.pushValue(Ok(1));
 
     const arrayP = stream.asArray();
@@ -176,32 +176,8 @@ describe('ReadStream unit', () => {
     ).toEqual([1, 2, 3, 4].map(Ok));
   });
 
-  it('should request to close the stream when requestClose is called', () => {
-    const requestCloseCb = vi.fn();
-    const stream = new ReadStreamImpl<number, SomeError>(requestCloseCb);
-    void stream.requestClose();
-    expect(requestCloseCb).toHaveBeenCalled();
-    expect(stream.isCloseRequested()).toEqual(true);
-    stream.triggerClose();
-  });
-
-  it('should request to close once the stream when requestClose is called', () => {
-    const requestCloseCb = vi.fn();
-    const stream = new ReadStreamImpl<number, SomeError>(requestCloseCb);
-    void stream.requestClose();
-    void stream.requestClose();
-    expect(requestCloseCb).toHaveBeenCalledTimes(1);
-    stream.triggerClose();
-  });
-
-  it('should throw when requesting to close after closing', () => {
-    const stream = new ReadStreamImpl<number, SomeError>(noopCb);
-    stream.triggerClose();
-    expect(() => stream.requestClose()).toThrowError(Error);
-  });
-
   it('should call onClose callback until after close', async () => {
-    const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+    const stream = new ReadStreamImpl<number, SomeError>();
 
     const waitP = new Promise<void>((resolve) => stream.onClose(resolve));
 
@@ -222,25 +198,25 @@ describe('ReadStream unit', () => {
   });
 
   it('should error when onClose called after closing', async () => {
-    const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+    const stream = new ReadStreamImpl<number, SomeError>();
     stream.triggerClose();
     expect(() => stream.onClose(noopCb)).toThrowError(Error);
   });
 
   it('should throw when pushing to a closed stream', async () => {
-    const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+    const stream = new ReadStreamImpl<number, SomeError>();
     stream.triggerClose();
     expect(() => stream.pushValue(Ok(1))).toThrowError(Error);
   });
 
   it('shouild throw when closing multiple times', async () => {
-    const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+    const stream = new ReadStreamImpl<number, SomeError>();
     stream.triggerClose();
     expect(() => stream.triggerClose()).toThrowError(Error);
   });
 
   it('should support for-await-of', async () => {
-    const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+    const stream = new ReadStreamImpl<number, SomeError>();
 
     stream.pushValue(Ok(1));
     let i = 0;
@@ -262,7 +238,7 @@ describe('ReadStream unit', () => {
   });
 
   it('should support for-await-of with break', async () => {
-    const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+    const stream = new ReadStreamImpl<number, SomeError>();
 
     stream.pushValue(Ok(1));
     stream.pushValue(Ok(2));
@@ -279,7 +255,7 @@ describe('ReadStream unit', () => {
   });
 
   it('should support for-await-of using unwrappedIter with break', async () => {
-    const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+    const stream = new ReadStreamImpl<number, SomeError>();
 
     stream.pushValue(Ok(1));
     stream.pushValue(Ok(2));
@@ -296,7 +272,7 @@ describe('ReadStream unit', () => {
   });
 
   it('should emit error results as part of iteration', async () => {
-    const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+    const stream = new ReadStreamImpl<number, SomeError>();
 
     stream.pushValue(Ok(1));
     stream.pushValue(Ok(2));
@@ -322,7 +298,7 @@ describe('ReadStream unit', () => {
   });
 
   it('should unwrap ok results', async () => {
-    const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+    const stream = new ReadStreamImpl<number, SomeError>();
 
     stream.pushValue(Ok(1));
     stream.pushValue(Ok(2));
@@ -336,7 +312,7 @@ describe('ReadStream unit', () => {
     expect((await iterator.next()).value).toEqual(3);
     expect((await iterator.next()).done).toEqual(true);
 
-    const stream2 = new ReadStreamImpl<number, SomeError>(noopCb);
+    const stream2 = new ReadStreamImpl<number, SomeError>();
     stream2.pushValue(Ok(1));
     stream2.pushValue(Ok(2));
     stream2.pushValue(Ok(3));
@@ -358,7 +334,7 @@ describe('ReadStream unit', () => {
   });
 
   it('should throw when unwrapping an error', async () => {
-    const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+    const stream = new ReadStreamImpl<number, SomeError>();
 
     stream.pushValue(Ok(1));
     stream.pushValue(Err({ code: 'SOME_ERROR', message: 'some error' }));
@@ -372,7 +348,7 @@ describe('ReadStream unit', () => {
     );
     expect((await iterator.next()).done).toEqual(true);
 
-    const stream2 = new ReadStreamImpl<number, SomeError>(noopCb);
+    const stream2 = new ReadStreamImpl<number, SomeError>();
 
     stream2.pushValue(Ok(1));
     stream2.pushValue(Err({ code: 'SOME_ERROR', message: 'some error' }));
@@ -389,14 +365,14 @@ describe('ReadStream unit', () => {
 
   describe('drain', () => {
     it('should signal the next stream iteration', async () => {
-      const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+      const stream = new ReadStreamImpl<number, SomeError>();
       const iterator = stream[Symbol.asyncIterator]();
       stream.drain();
       expect((await iterator.next()).value).toEqual(Err(StreamDrainedError));
       stream.triggerClose();
     });
     it('should signal the pending stream iteration', async () => {
-      const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+      const stream = new ReadStreamImpl<number, SomeError>();
       const iterator = stream[Symbol.asyncIterator]();
       const pending = iterator.next();
       stream.drain();
@@ -404,7 +380,7 @@ describe('ReadStream unit', () => {
       stream.triggerClose();
     });
     it('should signal the next stream iteration wtih a queued up value', async () => {
-      const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+      const stream = new ReadStreamImpl<number, SomeError>();
       const iterator = stream[Symbol.asyncIterator]();
       stream.pushValue(Ok(1));
       expect(stream.hasValuesInQueue()).toBeTruthy();
@@ -414,7 +390,7 @@ describe('ReadStream unit', () => {
       stream.triggerClose();
     });
     it('should signal the next stream iteration with a queued up value after stream is closed', async () => {
-      const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+      const stream = new ReadStreamImpl<number, SomeError>();
       const iterator = stream[Symbol.asyncIterator]();
       stream.pushValue(Ok(1));
       stream.triggerClose();
@@ -422,14 +398,14 @@ describe('ReadStream unit', () => {
       expect((await iterator.next()).value).toEqual(Err(StreamDrainedError));
     });
     it('should not signal the next stream iteration with an empty queue after stream is closed', async () => {
-      const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+      const stream = new ReadStreamImpl<number, SomeError>();
       const iterator = stream[Symbol.asyncIterator]();
       stream.triggerClose();
       stream.drain();
       expect((await iterator.next()).done).toEqual(true);
     });
     it('should end iteration if draining mid-stream', async () => {
-      const stream = new ReadStreamImpl<number, SomeError>(noopCb);
+      const stream = new ReadStreamImpl<number, SomeError>();
       stream.pushValue(Ok(1));
       stream.pushValue(Ok(2));
       stream.pushValue(Ok(3));
@@ -493,48 +469,5 @@ describe('WriteStream unit', () => {
     const stream = new WriteStreamImpl<number>(noopCb);
     stream.close();
     expect(() => stream.write(1)).toThrowError(Error);
-  });
-
-  it('triggering a close request multiple times throws', () => {
-    // since triggering close is an internal API meant for requests coming from the client
-    // we don't expect it to be called multiple times
-    const stream = new WriteStreamImpl<number>(noopCb);
-
-    stream.triggerCloseRequest();
-    expect(() => stream.triggerCloseRequest()).toThrowError(Error);
-  });
-
-  it('should trigger a close requests', () => {
-    const stream = new WriteStreamImpl<number>(noopCb);
-
-    expect(stream.isCloseRequested()).toBeFalsy();
-    stream.triggerCloseRequest();
-    expect(stream.isCloseRequested()).toBeTruthy();
-  });
-
-  it('should notify listeners when triggering a close request', () => {
-    const stream = new WriteStreamImpl<number>(noopCb);
-
-    const cb1 = vi.fn();
-    stream.onCloseRequest(cb1);
-    const cb2 = vi.fn();
-    stream.onCloseRequest(cb2);
-
-    stream.triggerCloseRequest();
-
-    expect(cb1).toHaveBeenCalled();
-    expect(cb2).toHaveBeenCalled();
-    expect(cb1.mock.invocationCallOrder[0]).toBeLessThan(
-      cb2.mock.invocationCallOrder[0],
-    );
-  });
-
-  it('triggering a close request multiple times throws', () => {
-    // since triggering close is an internal API meant for requests coming from the client
-    // we don't expect it to be called multiple times
-    const stream = new WriteStreamImpl<number>(noopCb);
-
-    stream.triggerCloseRequest();
-    expect(() => stream.triggerCloseRequest()).toThrowError(Error);
   });
 });

--- a/router/client.ts
+++ b/router/client.ts
@@ -14,10 +14,8 @@ import {
   TransportClientId,
   isStreamClose,
   ControlMessageCloseSchema,
-  isStreamCloseRequest,
   isStreamAbort,
   closeStreamMessage,
-  requestCloseStreamMessage,
   abortMessage,
 } from '../transport/message';
 import { Static } from '@sinclair/typebox';
@@ -328,9 +326,7 @@ function handleProc(
   const resReader = new ReadStreamImpl<
     Static<PayloadType>,
     Static<BaseErrorSchemaType>
-  >(() => {
-    transport.send(serverId, requestCloseStreamMessage(streamId));
-  });
+  >();
   resReader.onClose(() => {
     span.addEvent('resReader closed');
 
@@ -387,10 +383,6 @@ function handleProc(
       });
 
       return;
-    }
-
-    if (isStreamCloseRequest(msg.controlFlags)) {
-      reqWriter.triggerCloseRequest();
     }
 
     if (isStreamAbort(msg.controlFlags)) {

--- a/router/server.ts
+++ b/router/server.ts
@@ -22,9 +22,7 @@ import {
   isStreamClose,
   isStreamOpen,
   ControlFlags,
-  isStreamCloseRequest,
   isStreamAbort,
-  requestCloseStreamMessage,
   closeStreamMessage,
   abortMessage,
 } from '../transport/message';
@@ -282,10 +280,6 @@ class RiverServer<Services extends AnyServiceSchemaMap>
         return;
       }
 
-      if (isStreamCloseRequest(msg.controlFlags)) {
-        resWriter.triggerCloseRequest();
-      }
-
       if (isStreamAbortBackwardsCompat(msg.controlFlags, protocolVersion)) {
         let abortResult: Static<typeof InputErrResultSchema>;
         if (Value.Check(InputErrResultSchema, msg.payload)) {
@@ -399,9 +393,7 @@ class RiverServer<Services extends AnyServiceSchemaMap>
     const reqReader = new ReadStreamImpl<
       Static<PayloadType>,
       Static<typeof RequestReaderErrorSchema>
-    >(() => {
-      this.transport.send(from, requestCloseStreamMessage(streamId));
-    });
+    >();
     reqReader.onClose(() => {
       // TODO remove once clients migrate to v2
       if (protocolVersion === 'v1.1') {

--- a/transport/message.ts
+++ b/transport/message.ts
@@ -24,10 +24,6 @@ export const enum ControlFlags {
    */
   StreamClosedBit = 0b01000,
   /**
-   * Used when readers no longer wish to receive messages.
-   */
-  StreamCloseRequestBit = 0b10000,
-  /**
    * Used when a stream is aborted due to cancellation or errors
    */
   StreamAbortBit = 0b00100,
@@ -264,18 +260,6 @@ export function closeStreamMessage(streamId: string): PartialTransportMessage {
   };
 }
 
-export function requestCloseStreamMessage(
-  streamId: string,
-): PartialTransportMessage {
-  return {
-    streamId,
-    controlFlags: ControlFlags.StreamCloseRequestBit,
-    payload: {
-      type: 'CLOSE' as const,
-    } satisfies Static<typeof ControlMessagePayloadSchema>,
-  };
-}
-
 export function abortMessage(
   streamId: string,
   payload: ErrResult<
@@ -328,19 +312,6 @@ export function isStreamClose(controlFlag: number): boolean {
     /* eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison */
     (controlFlag & ControlFlags.StreamClosedBit) ===
     ControlFlags.StreamClosedBit
-  );
-}
-
-/**
- * Checks if the given control flag (usually found in msg.controlFlag) is a stream close request message.
- * @param controlFlag - The control flag to check.
- * @returns True if the control flag contains the StreamCloseBit, false otherwise.
- */
-export function isStreamCloseRequest(controlFlag: number): boolean {
-  return (
-    /* eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison */
-    (controlFlag & ControlFlags.StreamCloseRequestBit) ===
-    ControlFlags.StreamCloseRequestBit
   );
 }
 

--- a/util/testHelpers.ts
+++ b/util/testHelpers.ts
@@ -232,13 +232,7 @@ function createResponsePipe<
   const reader = new ReadStreamImpl<
     Static<Output>,
     Static<Err> | Static<typeof ResponseReaderErrorSchema>
-  >(() => {
-    // Make it async to simulate request going over the wire
-    // using promises so that we don't get affected by fake timers.
-    void Promise.resolve().then(() => {
-      writer.triggerCloseRequest();
-    });
-  });
+  >();
   const writer = new WriteStreamImpl<Result<Static<Output>, Static<Err>>>(
     (v) => {
       reader.pushValue(v);
@@ -262,13 +256,7 @@ function createRequestPipe<Input extends PayloadType>(): {
   const reader = new ReadStreamImpl<
     Static<Input>,
     Static<typeof RequestReaderErrorSchema>
-  >(() => {
-    // Make it async to simulate request going over the wire
-    // using promises so that we don't get affected by fake timers.
-    void Promise.resolve().then(() => {
-      writer.triggerCloseRequest();
-    });
-  });
+  >();
   const writer = new WriteStreamImpl<Static<Input>>((v) => {
     reader.pushValue(Ok(v));
   });


### PR DESCRIPTION
## Why

Came up as part of the giga review for #127.

It's just one more concept that's unneeded. Instead of close requests, streams can listen to the closes on the other pipe and decided if they want to close then. Alternatively (for upload and stream procs), service implementers can implement a user-space close-request mechanisms. The only thing that this leaves open is in subscriptions clients have no way of signaling disinterest in the data, in which case they should just abort the stream.

FWIW this is how gRPC works.

## What changed

Remove close request, swap with aborts in tests where relevant.