### PR TITLE
Introduce $kind as a pivot point for uncaught errors

### DIFF
--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -333,6 +333,7 @@ describe.each(testMatrix())(
       expect(result3).toStrictEqual({
         ok: false,
         payload: {
+          $kind: 'error',
           code: UNCAUGHT_ERROR,
           message: 'some message',
         },

--- a/__tests__/handler.test.ts
+++ b/__tests__/handler.test.ts
@@ -132,6 +132,7 @@ describe('server-side test', () => {
     expect(result3).toStrictEqual({
       ok: false,
       payload: {
+        $kind: 'error',
         code: UNCAUGHT_ERROR,
         message: 'some message',
       },

--- a/router/client.ts
+++ b/router/client.ts
@@ -282,6 +282,7 @@ function handleRpc(
       cleanup();
       resolve(
         Err({
+          $kind: 'error',
           code: UNEXPECTED_DISCONNECT,
           message: `${serverId} unexpectedly disconnected`,
         }),
@@ -409,6 +410,7 @@ function handleStream(
   const onSessionStatus = createSessionDisconnectHandler(serverId, () => {
     outputStream.push(
       Err({
+        $kind: 'error',
         code: UNEXPECTED_DISCONNECT,
         message: `${serverId} unexpectedly disconnected`,
       }),
@@ -488,6 +490,7 @@ function handleSubscribe(
   const onSessionStatus = createSessionDisconnectHandler(serverId, () => {
     outputStream.push(
       Err({
+        $kind: 'error',
         code: UNEXPECTED_DISCONNECT,
         message: `${serverId} unexpectedly disconnected`,
       }),
@@ -580,6 +583,7 @@ function handleUpload(
       cleanup();
       resolve(
         Err({
+          $kind: 'error',
           code: UNEXPECTED_DISCONNECT,
           message: `${serverId} unexpectedly disconnected`,
         }),

--- a/router/result.ts
+++ b/router/result.ts
@@ -30,6 +30,7 @@ export type RiverError =
 export const UNCAUGHT_ERROR = 'UNCAUGHT_ERROR';
 export const UNEXPECTED_DISCONNECT = 'UNEXPECTED_DISCONNECT';
 export const RiverUncaughtSchema = Type.Object({
+  $kind: Type.Literal('error'),
   code: Type.Union([
     Type.Literal(UNCAUGHT_ERROR),
     Type.Literal(UNEXPECTED_DISCONNECT),

--- a/router/server.ts
+++ b/router/server.ts
@@ -302,6 +302,7 @@ class RiverServer<Services extends AnyServiceSchemaMap> {
       span.setStatus({ code: SpanStatusCode.ERROR });
       outgoing.push(
         Err({
+          $kind: 'error',
           code: UNCAUGHT_ERROR,
           message: errorMsg,
         } satisfies Static<typeof RiverUncaughtSchema>),

--- a/util/testHelpers.ts
+++ b/util/testHelpers.ts
@@ -132,7 +132,7 @@ export async function waitForMessage(
 
 function catchProcError(err: unknown) {
   const errorMsg = coerceErrorString(err);
-  return Err({ code: UNCAUGHT_ERROR, message: errorMsg });
+  return Err({ $kind: 'error', code: UNCAUGHT_ERROR, message: errorMsg });
 }
 
 export const testingSessionOptions = defaultTransportOptions;


### PR DESCRIPTION
## Why

`$kind` is emerging as a de-facto property to identify the type of a payload. Adding a literal `$kind: "error"` permits consumers to easily filter in/out error payloads.

## What changed

Add `$kind: "error"` to `RiverUncaughtSchema`, for consumers to easily identify error payloads

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
