### PR TITLE
Fix closing readable twice sometimes on session disconnect

### DIFF
--- a/router/client.ts
+++ b/router/client.ts
@@ -443,7 +443,13 @@ function handleProc(
     if (isStreamClose(msg.controlFlags)) {
       span.addEvent('received response close');
 
-      closeReadable();
+      if (resReadable.isClosed()) {
+        transport.log?.error(
+          'received stream close but readable was already closed',
+        );
+      } else {
+        closeReadable();
+      }
     }
   }
 
@@ -464,9 +470,10 @@ function handleProc(
           message: `${serverId} unexpectedly disconnected`,
         }),
       );
+      closeReadable();
     }
+
     reqWritable.close();
-    closeReadable();
   }
 
   abortSignal?.addEventListener('abort', onClientCancel);


### PR DESCRIPTION
## Why

Seeing this case sometimes where:
1. Stream created
2. Server closes
3. Session disconnect
4. Leads to an uncaught error

There aren't any real side-effects from this AFAICT, but it's a bug

## What changed

- Fixed the issue, only close the readable if it hasn't been closed already
- Added a check elsewhere that doesn't have a guard around closeRedable


## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
