### PR TITLE
v2 Patches

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -560,7 +560,7 @@ The handshake request payload schema is the following:
 ```ts
 type HandshakeRequest = {
   type: 'HANDSHAKE_REQ';
-  protocolVersion: string;
+  protocolVersion: 'v0' | 'v1' | 'v1.1' | 'v2.0';
   sessionId: string;
   expectedSessionState: {
     nextExpectedSeq: number;

--- a/__tests__/bandwidth.bench.ts
+++ b/__tests__/bandwidth.bench.ts
@@ -1,5 +1,5 @@
 import { afterAll, assert, bench, describe } from 'vitest';
-import { waitForMessage } from '../util/testHelpers';
+import { getClientSendFn, waitForMessage } from '../util/testHelpers';
 import { TestServiceSchema } from './fixtures/services';
 import { createServer } from '../router/server';
 import { createClient } from '../router/client';
@@ -34,11 +34,12 @@ describe('bandwidth', async () => {
       serverTransport.clientId,
     );
 
+    const sendClosure = getClientSendFn(clientTransport, serverTransport);
     bench(
       `${name} -- raw transport send and recv`,
       async () => {
         const msg = dummyPayloadSmall();
-        const id = clientTransport.send(serverTransport.clientId, msg);
+        const id = sendClosure(msg);
         await waitForMessage(serverTransport, (msg) => msg.id === id);
         return;
       },

--- a/__tests__/cancellation.test.ts
+++ b/__tests__/cancellation.test.ts
@@ -16,7 +16,7 @@ import {
   testFinishesCleanly,
   waitFor,
 } from './fixtures/cleanup';
-import { CANCEL_CODE, UNCAUGHT_ERROR_CODE } from '../router/procedures';
+import { CANCEL_CODE, UNCAUGHT_ERROR_CODE } from '../router/errors';
 import { TestSetupHelpers } from './fixtures/transports';
 
 function makeMockHandler<T extends ValidProcType>(

--- a/__tests__/cleanup.test.ts
+++ b/__tests__/cleanup.test.ts
@@ -12,6 +12,7 @@ import {
   UploadableServiceSchema,
 } from './fixtures/services';
 import {
+  Ok,
   Procedure,
   ProcedureHandlerContext,
   ServiceSchema,
@@ -160,7 +161,7 @@ describe.each(testMatrix())(
 
       // start procedure
       const res = await client.test.add.rpc({ n: 3 });
-      expect(res).toStrictEqual({ ok: true, payload: { result: 3 } });
+      expect(res).toStrictEqual(Ok({ result: 3 }));
       // end procedure
 
       // number of message handlers shouldn't increase after rpc
@@ -207,10 +208,7 @@ describe.each(testMatrix())(
       reqWritable.write({ msg: '2', ignore: false });
 
       const result1 = await readNextResult(resReadable);
-      expect(result1).toStrictEqual({
-        ok: true,
-        payload: { response: '1' },
-      });
+      expect(result1).toStrictEqual(Ok({ response: '1' }));
 
       // ensure we only have one stream despite pushing multiple messages.
       expect(server.streams.size);
@@ -220,10 +218,7 @@ describe.each(testMatrix())(
       await waitFor(() => expect(server.streams.size).toEqual(0));
 
       const result2 = await readNextResult(resReadable);
-      expect(result2).toStrictEqual({
-        ok: true,
-        payload: { response: '2' },
-      });
+      expect(result2).toStrictEqual(Ok({ response: '2' }));
 
       expect(await isReadableDone(resReadable)).toEqual(true);
       // end procedure

--- a/__tests__/cleanup.test.ts
+++ b/__tests__/cleanup.test.ts
@@ -4,6 +4,7 @@ import {
   readNextResult,
   isReadableDone,
   numberOfConnections,
+  getClientSendFn,
 } from '../util/testHelpers';
 import {
   SubscribableServiceSchema,
@@ -212,10 +213,11 @@ describe.each(testMatrix())(
       });
 
       // ensure we only have one stream despite pushing multiple messages.
+      expect(server.streams.size);
+
       reqWritable.close();
-      await waitFor(() => expect(server.openStreams.size).toEqual(1));
       // ensure we no longer have any open streams since the request was closed.
-      await waitFor(() => expect(server.openStreams.size).toEqual(0));
+      await waitFor(() => expect(server.streams.size).toEqual(0));
 
       const result2 = await readNextResult(resReadable);
       expect(result2).toStrictEqual({
@@ -237,6 +239,66 @@ describe.each(testMatrix())(
       // check number of connections
       expect(numberOfConnections(clientTransport)).toEqual(1);
       expect(numberOfConnections(serverTransport)).toEqual(1);
+
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+        server,
+      });
+    });
+
+    test('cancellation after transport close', async () => {
+      // setup
+      const clientTransport = getClientTransport('client');
+      const serverTransport = getServerTransport();
+      const services = { test: TestServiceSchema };
+      const server = createServer(serverTransport, services);
+      const client = createClient<typeof services>(
+        clientTransport,
+        serverTransport.clientId,
+      );
+      addPostTestCleanup(async () => {
+        await cleanupTransports([clientTransport, serverTransport]);
+      });
+
+      // start procedure
+      const abortController = new AbortController();
+      const { reqWritable, resReadable } = client.test.echo.stream(
+        {},
+        { signal: abortController.signal },
+      );
+      reqWritable.write({ msg: '1', ignore: false });
+
+      const result1 = await readNextResult(resReadable);
+      expect(result1).toStrictEqual({
+        ok: true,
+        payload: { response: '1' },
+      });
+
+      // close the transport
+      clientTransport.close();
+      await waitFor(() => {
+        expect(numberOfConnections(clientTransport)).toEqual(0);
+        expect(numberOfConnections(serverTransport)).toEqual(0);
+      });
+
+      // wait for session timer to elapse and make sure there are not more sessions
+      await advanceFakeTimersBySessionGrace();
+      await waitFor(() => {
+        expect(serverTransport.sessions.size).toEqual(0);
+        expect(clientTransport.sessions.size).toEqual(0);
+      });
+
+      // close the req writable after the transport is closed
+      // should not send message nor start a new session
+      reqWritable.close();
+      expect(serverTransport.sessions.size).toEqual(0);
+      expect(clientTransport.sessions.size).toEqual(0);
+
+      // same with abort
+      abortController.abort();
+      expect(serverTransport.sessions.size).toEqual(0);
+      expect(clientTransport.sessions.size).toEqual(0);
 
       await testFinishesCleanly({
         clientTransports: [clientTransport],
@@ -478,7 +540,8 @@ describe('request finishing triggers signal onabort', async () => {
       await cleanupTransports([clientTransport, serverTransport]);
     });
 
-    clientTransport.send(serverId, {
+    const clientSendFn = getClientSendFn(clientTransport, serverTransport);
+    clientSendFn({
       streamId: nanoid(),
       serviceName,
       procedureName,

--- a/__tests__/disconnects.test.ts
+++ b/__tests__/disconnects.test.ts
@@ -129,8 +129,8 @@ describe.each(testMatrix())(
         payload: expect.objectContaining({ code: UNEXPECTED_DISCONNECT_CODE }),
       });
 
-      // further writes should error
-      expect(() => reqWritable.write({ msg: 'def', ignore: false })).toThrow();
+      // req writable should be closed
+      expect(reqWritable.isWritable()).toBe(false);
 
       await waitFor(() => expect(numberOfConnections(clientTransport)).toBe(0));
       await waitFor(() => expect(numberOfConnections(serverTransport)).toBe(0));
@@ -298,8 +298,8 @@ describe.each(testMatrix())(
         payload: expect.objectContaining({ code: UNEXPECTED_DISCONNECT_CODE }),
       });
 
-      // further writes should error
-      expect(() => reqWritable.write({ n: 3 })).toThrow();
+      // req writable should be closed
+      expect(reqWritable.isWritable()).toBe(false);
 
       await waitFor(() => expect(numberOfConnections(clientTransport)).toBe(0));
       await waitFor(() => expect(numberOfConnections(serverTransport)).toBe(0));

--- a/__tests__/disconnects.test.ts
+++ b/__tests__/disconnects.test.ts
@@ -129,6 +129,9 @@ describe.each(testMatrix())(
         payload: expect.objectContaining({ code: UNEXPECTED_DISCONNECT_CODE }),
       });
 
+      // further writes should error
+      expect(() => reqWritable.write({ msg: 'def', ignore: false })).toThrow();
+
       await waitFor(() => expect(numberOfConnections(clientTransport)).toBe(0));
       await waitFor(() => expect(numberOfConnections(serverTransport)).toBe(0));
       await testFinishesCleanly({
@@ -233,6 +236,9 @@ describe.each(testMatrix())(
         payload: expect.objectContaining({ code: UNEXPECTED_DISCONNECT_CODE }),
       });
 
+      // wait for client1 to restablish connection
+      // (elapsing by session grace on client2 will inadvertedly trigger a phantom disconnect
+      // on client1 because mocked timers are shared, which will cause it to reconnect)
       // at this point, only client1 is connected
       await waitFor(() => {
         expect(numberOfConnections(client1Transport)).toEqual(1);
@@ -292,8 +298,12 @@ describe.each(testMatrix())(
         payload: expect.objectContaining({ code: UNEXPECTED_DISCONNECT_CODE }),
       });
 
+      // further writes should error
+      expect(() => reqWritable.write({ n: 3 })).toThrow();
+
       await waitFor(() => expect(numberOfConnections(clientTransport)).toBe(0));
       await waitFor(() => expect(numberOfConnections(serverTransport)).toBe(0));
+
       await testFinishesCleanly({
         clientTransports: [clientTransport],
         serverTransport,

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -40,8 +40,6 @@ import {
 } from '../router/handshake';
 import { TestSetupHelpers } from './fixtures/transports';
 
-// TODO: various rpc types across session disconnect scenarios
-
 describe.each(testMatrix())(
   'client <-> server integration test ($transport.name transport, $codec.name codec)',
   async ({ transport, codec }) => {

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -100,6 +100,7 @@ describe.each(testMatrix())(
 
       // test
       const result = await client.fallible.divide.rpc({ a: 10, b: 2 });
+
       expect(result).toStrictEqual({ ok: true, payload: { result: 5 } });
       const result2 = await client.fallible.divide.rpc({ a: 10, b: 0 });
       expect(result2).toStrictEqual({

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -40,6 +40,8 @@ import {
 } from '../router/handshake';
 import { TestSetupHelpers } from './fixtures/transports';
 
+// TODO: various rpc types across session disconnect scenarios
+
 describe.each(testMatrix())(
   'client <-> server integration test ($transport.name transport, $codec.name codec)',
   async ({ transport, codec }) => {

--- a/__tests__/fixtures/cleanup.ts
+++ b/__tests__/fixtures/cleanup.ts
@@ -90,9 +90,9 @@ export async function ensureTransportBuffersAreEventuallyEmpty(
 export async function ensureServerIsClean(s: Server<AnyServiceSchemaMap>) {
   return waitFor(() =>
     expect(
-      s.openStreams,
+      s.streams,
       `[post-test cleanup] server should not have any open streams after the test`,
-    ).toStrictEqual(new Set()),
+    ).toStrictEqual(new Map()),
   );
 }
 

--- a/__tests__/fixtures/services.ts
+++ b/__tests__/fixtures/services.ts
@@ -171,6 +171,12 @@ export const FallibleServiceSchema = ServiceSchema.define({
         message: Type.String(),
         extras: Type.Object({ test: Type.String() }),
       }),
+      Type.Union([
+        Type.Object({
+          code: Type.Literal('INFINITY'),
+          message: Type.String(),
+        }),
+      ]),
     ]),
     async handler({ reqInit: { a, b } }) {
       if (b === 0) {
@@ -178,6 +184,11 @@ export const FallibleServiceSchema = ServiceSchema.define({
           code: DIV_BY_ZERO,
           message: 'Cannot divide by zero',
           extras: { test: 'abc' },
+        });
+      } else if (a === Infinity || b === Infinity) {
+        return Err({
+          code: 'INFINITY',
+          message: 'Result is infinity',
         });
       } else {
         return Ok({ result: a / b });

--- a/__tests__/invalid-request.test.ts
+++ b/__tests__/invalid-request.test.ts
@@ -16,7 +16,7 @@ import {
   waitFor,
 } from './fixtures/cleanup';
 import { EventMap } from '../transport';
-import { INVALID_REQUEST_CODE } from '../router/procedures';
+import { INVALID_REQUEST_CODE } from '../router/errors';
 import { ControlFlags } from '../transport/message';
 import { TestSetupHelpers } from './fixtures/transports';
 import { nanoid } from 'nanoid';

--- a/__tests__/invalid-request.test.ts
+++ b/__tests__/invalid-request.test.ts
@@ -1,6 +1,8 @@
 import { Type } from '@sinclair/typebox';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import {
+  Err,
+  Ok,
   Procedure,
   ServiceSchema,
   createClient,
@@ -76,14 +78,11 @@ describe('cancels invalid request', () => {
         expect.objectContaining({
           controlFlags: ControlFlags.StreamCancelBit,
           streamId,
-          payload: {
-            ok: false,
-            payload: {
-              code: INVALID_REQUEST_CODE,
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              message: expect.stringContaining('stream open bit'),
-            },
-          },
+          payload: Err({
+            code: INVALID_REQUEST_CODE,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            message: expect.stringContaining('stream open bit'),
+          }),
         }),
       );
     });
@@ -128,14 +127,11 @@ describe('cancels invalid request', () => {
         expect.objectContaining({
           controlFlags: ControlFlags.StreamCancelBit,
           streamId,
-          payload: {
-            ok: false,
-            payload: {
-              code: INVALID_REQUEST_CODE,
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              message: expect.stringContaining('service name'),
-            },
-          },
+          payload: Err({
+            code: INVALID_REQUEST_CODE,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            message: expect.stringContaining('service name'),
+          }),
         }),
       );
     });
@@ -180,14 +176,11 @@ describe('cancels invalid request', () => {
         expect.objectContaining({
           controlFlags: ControlFlags.StreamCancelBit,
           streamId,
-          payload: {
-            ok: false,
-            payload: {
-              code: INVALID_REQUEST_CODE,
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              message: expect.stringContaining('procedure name'),
-            },
-          },
+          payload: Err({
+            code: INVALID_REQUEST_CODE,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            message: expect.stringContaining('procedure name'),
+          }),
         }),
       );
     });
@@ -233,14 +226,11 @@ describe('cancels invalid request', () => {
         expect.objectContaining({
           controlFlags: ControlFlags.StreamCancelBit,
           streamId,
-          payload: {
-            ok: false,
-            payload: {
-              code: INVALID_REQUEST_CODE,
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              message: expect.stringContaining('find service'),
-            },
-          },
+          payload: Err({
+            code: INVALID_REQUEST_CODE,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            message: expect.stringContaining('find service'),
+          }),
         }),
       );
     });
@@ -289,14 +279,11 @@ describe('cancels invalid request', () => {
       expect.objectContaining({
         controlFlags: ControlFlags.StreamCancelBit,
         streamId,
-        payload: {
-          ok: false,
-          payload: {
-            code: INVALID_REQUEST_CODE,
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            message: expect.stringContaining('matching procedure'),
-          },
-        },
+        payload: Err({
+          code: INVALID_REQUEST_CODE,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          message: expect.stringContaining('matching procedure'),
+        }),
       }),
     );
   });
@@ -341,14 +328,11 @@ describe('cancels invalid request', () => {
         expect.objectContaining({
           controlFlags: ControlFlags.StreamCancelBit,
           streamId,
-          payload: {
-            ok: false,
-            payload: {
-              code: INVALID_REQUEST_CODE,
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              message: expect.stringContaining('init failed validation'),
-            },
-          },
+          payload: Err({
+            code: INVALID_REQUEST_CODE,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            message: expect.stringContaining('init failed validation'),
+          }),
         }),
       );
     });
@@ -403,16 +387,13 @@ describe('cancels invalid request', () => {
       expect.objectContaining({
         controlFlags: ControlFlags.StreamCancelBit,
         streamId,
-        payload: {
-          ok: false,
-          payload: {
-            code: INVALID_REQUEST_CODE,
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            message: expect.stringContaining(
-              'expected requestData or control payload',
-            ),
-          },
-        },
+        payload: Err({
+          code: INVALID_REQUEST_CODE,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          message: expect.stringContaining(
+            'expected requestData or control payload',
+          ),
+        }),
       }),
     );
   });
@@ -430,7 +411,7 @@ describe('cancels invalid request', () => {
         rpc: Procedure.rpc({
           requestInit: Type.Object({}),
           responseData: Type.Object({}),
-          handler: async () => ({ ok: true, payload: {} }),
+          handler: async () => Ok({}),
         }),
       }),
     };
@@ -465,14 +446,11 @@ describe('cancels invalid request', () => {
       expect.objectContaining({
         controlFlags: ControlFlags.StreamCancelBit,
         streamId,
-        payload: {
-          ok: false,
-          payload: {
-            code: INVALID_REQUEST_CODE,
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            message: expect.stringContaining('control payload'),
-          },
-        },
+        payload: Err({
+          code: INVALID_REQUEST_CODE,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          message: expect.stringContaining('control payload'),
+        }),
       }),
     );
   });
@@ -529,14 +507,11 @@ describe('cancels invalid request', () => {
         expect.objectContaining({
           controlFlags: ControlFlags.StreamCancelBit,
           streamId,
-          payload: {
-            ok: false,
-            payload: {
-              code: INVALID_REQUEST_CODE,
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              message: expect.stringContaining('stream is closed'),
-            },
-          },
+          payload: Err({
+            code: INVALID_REQUEST_CODE,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            message: expect.stringContaining('stream is closed'),
+          }),
         }),
       );
     });
@@ -557,7 +532,7 @@ describe('cancels invalid request', () => {
         rpc: Procedure.rpc({
           requestInit: Type.Object({}),
           responseData: Type.Object({}),
-          handler: async () => ({ ok: true, payload: {} }),
+          handler: async () => Ok({}),
         }),
         stream: Procedure.stream({
           requestInit: Type.Object({}),
@@ -576,14 +551,13 @@ describe('cancels invalid request', () => {
     // @ts-expect-error monkey-patched incompatible change :D
     delete services.service.procedures.rpc;
 
-    expect(await client.service.rpc.rpc({})).toEqual({
-      ok: false,
-      payload: {
+    expect(await client.service.rpc.rpc({})).toEqual(
+      Err({
         code: INVALID_REQUEST_CODE,
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         message: expect.stringContaining('matching procedure'),
-      },
-    });
+      }),
+    );
 
     // @ts-expect-error monkey-patched incompatible change :D
     services.service.procedures.stream.requestData = Type.Object({
@@ -594,20 +568,17 @@ describe('cancels invalid request', () => {
 
     reqWritable.write({ oldField: 'heyyo' });
     expect(await resReadable.collect()).toEqual([
-      {
-        ok: false,
-        payload: {
-          code: INVALID_REQUEST_CODE,
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          message: expect.stringContaining(
-            'expected requestData or control payload',
-          ),
-        },
-      },
+      Err({
+        code: INVALID_REQUEST_CODE,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        message: expect.stringContaining(
+          'expected requestData or control payload',
+        ),
+      }),
     ]);
   });
 
-  describe('tombestones invalid request', () => {
+  describe('tombstones invalid request', () => {
     test('responds to multiple invalid requests for the same stream only once', async () => {
       const clientTransport = getClientTransport('client');
       const serverTransport = getServerTransport();
@@ -629,23 +600,25 @@ describe('cancels invalid request', () => {
 
       createServer(serverTransport, services);
       clientTransport.connect(serverId);
+      const clientSendFn = getClientSendFn(clientTransport, serverTransport);
 
-      const serverSendSpy = vi.spyOn(serverTransport, 'send');
+      const clientOnMessage = vi.fn();
+      clientTransport.addEventListener('message', clientOnMessage);
 
       const streamId = nanoid();
-      clientTransport.send(serverId, {
+      clientSendFn({
         streamId,
         procedureName: 'stream',
         payload: {},
         controlFlags: ControlFlags.StreamOpenBit,
       });
-      clientTransport.send(serverId, {
+      clientSendFn({
         streamId,
         procedureName: 'stream',
         payload: {},
         controlFlags: ControlFlags.StreamOpenBit,
       });
-      clientTransport.send(serverId, {
+      clientSendFn({
         streamId,
         procedureName: 'stream',
         payload: {},
@@ -653,22 +626,22 @@ describe('cancels invalid request', () => {
       });
 
       await waitFor(() => {
-        expect(serverSendSpy).toHaveBeenCalledWith('client', {
-          streamId,
-          controlFlags: ControlFlags.StreamCancelBit,
-          payload: {
-            ok: false,
-            payload: {
+        expect(clientOnMessage).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({
+            streamId,
+            controlFlags: ControlFlags.StreamCancelBit,
+            payload: Err({
               code: INVALID_REQUEST_CODE,
               // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
               message: expect.stringContaining('missing service name'),
-            },
-          },
-        });
+            }),
+          }),
+        );
       });
 
       const anotherStreamId = nanoid();
-      clientTransport.send(serverId, {
+      clientSendFn({
         streamId: anotherStreamId,
         procedureName: 'stream',
         payload: {},
@@ -676,21 +649,21 @@ describe('cancels invalid request', () => {
       });
 
       await waitFor(() => {
-        expect(serverSendSpy).toHaveBeenCalledWith('client', {
-          streamId: anotherStreamId,
-          controlFlags: ControlFlags.StreamCancelBit,
-          payload: {
-            ok: false,
-            payload: {
+        expect(clientOnMessage).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({
+            streamId: anotherStreamId,
+            controlFlags: ControlFlags.StreamCancelBit,
+            payload: Err({
               code: INVALID_REQUEST_CODE,
               // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
               message: expect.stringContaining('missing service name'),
-            },
-          },
-        });
+            }),
+          }),
+        );
       });
 
-      expect(serverSendSpy).toHaveBeenCalledTimes(2);
+      expect(clientOnMessage).toHaveBeenCalledTimes(2);
     });
 
     test('starts responding to same stream after tombstones are evicted', async () => {
@@ -717,11 +690,12 @@ describe('cancels invalid request', () => {
         maxCancelledStreamTombstonesPerSession,
       });
       clientTransport.connect(serverId);
+      const clientSendFn = getClientSendFn(clientTransport, serverTransport);
 
-      const serverSendSpy = vi.spyOn(serverTransport, 'send');
-
+      const clientOnMessage = vi.fn();
+      clientTransport.addEventListener('message', clientOnMessage);
       const firstStreamId = nanoid();
-      clientTransport.send(serverId, {
+      clientSendFn({
         streamId: firstStreamId,
         procedureName: 'stream',
         payload: {},
@@ -729,22 +703,22 @@ describe('cancels invalid request', () => {
       });
 
       await waitFor(() => {
-        expect(serverSendSpy).toHaveBeenNthCalledWith(1, 'client', {
-          streamId: firstStreamId,
-          controlFlags: ControlFlags.StreamCancelBit,
-          payload: {
-            ok: false,
-            payload: {
+        expect(clientOnMessage).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({
+            streamId: firstStreamId,
+            controlFlags: ControlFlags.StreamCancelBit,
+            payload: Err({
               code: INVALID_REQUEST_CODE,
               // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
               message: expect.stringContaining('missing service name'),
-            },
-          },
-        });
+            }),
+          }),
+        );
       });
 
       for (let i = 0; i < maxCancelledStreamTombstonesPerSession; i++) {
-        clientTransport.send(serverId, {
+        clientSendFn({
           streamId: nanoid(), // new streams
           procedureName: 'stream',
           payload: {},
@@ -753,12 +727,12 @@ describe('cancels invalid request', () => {
       }
 
       await waitFor(() => {
-        expect(serverSendSpy).toHaveBeenCalledTimes(
+        expect(clientOnMessage).toHaveBeenCalledTimes(
           maxCancelledStreamTombstonesPerSession + 1,
         );
       });
 
-      clientTransport.send(serverId, {
+      clientSendFn({
         streamId: firstStreamId,
         procedureName: 'stream',
         payload: {},
@@ -766,26 +740,22 @@ describe('cancels invalid request', () => {
       });
 
       await waitFor(() => {
-        expect(serverSendSpy).toHaveBeenCalledTimes(
+        expect(clientOnMessage).toHaveBeenCalledTimes(
           maxCancelledStreamTombstonesPerSession + 2,
         );
       });
 
-      expect(serverSendSpy).toHaveBeenNthCalledWith(
+      expect(clientOnMessage).toHaveBeenNthCalledWith(
         maxCancelledStreamTombstonesPerSession + 2,
-        'client',
-        {
+        expect.objectContaining({
           streamId: firstStreamId,
           controlFlags: ControlFlags.StreamCancelBit,
-          payload: {
-            ok: false,
-            payload: {
-              code: INVALID_REQUEST_CODE,
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              message: expect.stringContaining('missing service name'),
-            },
-          },
-        },
+          payload: Err({
+            code: INVALID_REQUEST_CODE,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            message: expect.stringContaining('missing service name'),
+          }),
+        }),
       );
     });
 
@@ -818,20 +788,26 @@ describe('cancels invalid request', () => {
         maxCancelledStreamTombstonesPerSession,
       });
       client1Transport.connect(serverId);
+      const client1SendFn = getClientSendFn(client1Transport, serverTransport);
       client2Transport.connect(serverId);
+      const client2SendFn = getClientSendFn(client2Transport, serverTransport);
 
-      const serverSendSpy = vi.spyOn(serverTransport, 'send');
+      const client1OnMessage = vi.fn();
+      client1Transport.addEventListener('message', client1OnMessage);
+      const client2OnMessage = vi.fn();
+      client2Transport.addEventListener('message', client2OnMessage);
 
       const client1FirstStreamId = nanoid();
-      client1Transport.send(serverId, {
+      client1SendFn({
         streamId: client1FirstStreamId,
         procedureName: 'stream',
         payload: {},
         controlFlags: ControlFlags.StreamOpenBit,
       });
 
+      // exhaust max for client 2
       for (let i = 0; i < maxCancelledStreamTombstonesPerSession; i++) {
-        client2Transport.send(serverId, {
+        client2SendFn({
           streamId: nanoid(), // new streams
           procedureName: 'stream',
           payload: {},
@@ -840,21 +816,24 @@ describe('cancels invalid request', () => {
       }
 
       await waitFor(() => {
-        expect(serverSendSpy).toHaveBeenCalledTimes(
-          maxCancelledStreamTombstonesPerSession + 1,
+        expect(client1OnMessage).toHaveBeenCalledTimes(1);
+        expect(client2OnMessage).toHaveBeenCalledTimes(
+          maxCancelledStreamTombstonesPerSession,
         );
       });
 
-      // server should ignore this
-      client1Transport.send(serverId, {
+      // server should still ignore this via tombstone
+      // even though client 2 has exhausted its tombstones
+      client1SendFn({
         streamId: client1FirstStreamId,
         procedureName: 'stream',
         payload: {},
         controlFlags: ControlFlags.StreamOpenBit,
       });
 
+      // this should still work
       const client1LastStreamId = nanoid();
-      client1Transport.send(serverId, {
+      client1SendFn({
         streamId: client1LastStreamId,
         procedureName: 'stream',
         payload: {},
@@ -862,27 +841,12 @@ describe('cancels invalid request', () => {
       });
 
       await waitFor(() => {
-        expect(serverSendSpy).toHaveBeenCalledTimes(
-          maxCancelledStreamTombstonesPerSession + 2,
+        expect(client1OnMessage).toHaveBeenCalledTimes(2);
+        // client 2 already hit max, shouldn't have received this
+        expect(client2OnMessage).toHaveBeenCalledTimes(
+          maxCancelledStreamTombstonesPerSession,
         );
       });
-
-      expect(serverSendSpy).toHaveBeenNthCalledWith(
-        maxCancelledStreamTombstonesPerSession + 2,
-        'client1',
-        {
-          streamId: client1LastStreamId,
-          controlFlags: ControlFlags.StreamCancelBit,
-          payload: {
-            ok: false,
-            payload: {
-              code: INVALID_REQUEST_CODE,
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              message: expect.stringContaining('missing service name'),
-            },
-          },
-        },
-      );
     });
   });
 });

--- a/__tests__/invalid-request.test.ts
+++ b/__tests__/invalid-request.test.ts
@@ -17,6 +17,7 @@ import { INVALID_REQUEST_CODE } from '../router/procedures';
 import { ControlFlags } from '../transport/message';
 import { TestSetupHelpers } from './fixtures/transports';
 import { nanoid } from 'nanoid';
+import { getClientSendFn } from '../util/testHelpers';
 
 describe('cancels invalid request', () => {
   const { transport, codec } = testMatrix()[0];
@@ -56,9 +57,10 @@ describe('cancels invalid request', () => {
 
     createServer(serverTransport, services);
     clientTransport.connect(serverId);
+    const clientSendFn = getClientSendFn(clientTransport, serverTransport);
 
     const streamId = nanoid();
-    clientTransport.send(serverId, {
+    clientSendFn({
       streamId,
       serviceName: 'service',
       procedureName: 'stream',
@@ -108,9 +110,10 @@ describe('cancels invalid request', () => {
 
     createServer(serverTransport, services);
     clientTransport.connect(serverId);
+    const clientSendFn = getClientSendFn(clientTransport, serverTransport);
 
     const streamId = nanoid();
-    clientTransport.send(serverId, {
+    clientSendFn({
       streamId,
       procedureName: 'stream',
       payload: {},
@@ -159,9 +162,10 @@ describe('cancels invalid request', () => {
 
     createServer(serverTransport, services);
     clientTransport.connect(serverId);
+    const clientSendFn = getClientSendFn(clientTransport, serverTransport);
 
     const streamId = nanoid();
-    clientTransport.send(serverId, {
+    clientSendFn({
       streamId,
       serviceName: 'service',
       payload: {},
@@ -210,9 +214,10 @@ describe('cancels invalid request', () => {
 
     createServer(serverTransport, services);
     clientTransport.connect(serverId);
+    const clientSendFn = getClientSendFn(clientTransport, serverTransport);
 
     const streamId = nanoid();
-    clientTransport.send(serverId, {
+    clientSendFn({
       streamId,
       serviceName: 'serviceDoesNotExist',
       procedureName: 'stream',
@@ -262,9 +267,10 @@ describe('cancels invalid request', () => {
 
     createServer(serverTransport, services);
     clientTransport.connect(serverId);
+    const clientSendFn = getClientSendFn(clientTransport, serverTransport);
 
     const streamId = nanoid();
-    clientTransport.send(serverId, {
+    clientSendFn({
       streamId,
       serviceName: 'service',
       procedureName: 'procedureDoesNotExist',
@@ -316,9 +322,10 @@ describe('cancels invalid request', () => {
 
     createServer(serverTransport, services);
     clientTransport.connect(serverId);
+    const clientSendFn = getClientSendFn(clientTransport, serverTransport);
 
     const streamId = nanoid();
-    clientTransport.send(serverId, {
+    clientSendFn({
       streamId,
       serviceName: 'service',
       procedureName: 'stream',
@@ -368,9 +375,10 @@ describe('cancels invalid request', () => {
 
     createServer(serverTransport, services);
     clientTransport.connect(serverId);
+    const clientSendFn = getClientSendFn(clientTransport, serverTransport);
 
     const streamId = nanoid();
-    clientTransport.send(serverId, {
+    clientSendFn({
       streamId,
       serviceName: 'service',
       procedureName: 'stream',
@@ -378,7 +386,7 @@ describe('cancels invalid request', () => {
       controlFlags: ControlFlags.StreamOpenBit,
     });
 
-    clientTransport.send(serverId, {
+    clientSendFn({
       streamId,
       payload: {},
       controlFlags: 0,
@@ -429,9 +437,10 @@ describe('cancels invalid request', () => {
 
     createServer(serverTransport, services);
     clientTransport.connect(serverId);
+    const clientSendFn = getClientSendFn(clientTransport, serverTransport);
 
     const streamId = nanoid();
-    clientTransport.send(serverId, {
+    clientSendFn({
       streamId,
       serviceName: 'service',
       procedureName: 'rpc',
@@ -439,7 +448,7 @@ describe('cancels invalid request', () => {
       controlFlags: ControlFlags.StreamOpenBit,
     });
 
-    clientTransport.send(serverId, {
+    clientSendFn({
       streamId,
       payload: { wat: '1' },
       controlFlags: 0,
@@ -489,9 +498,10 @@ describe('cancels invalid request', () => {
 
     createServer(serverTransport, services);
     clientTransport.connect(serverId);
+    const clientSendFn = getClientSendFn(clientTransport, serverTransport);
 
     const streamId = nanoid();
-    clientTransport.send(serverId, {
+    clientSendFn({
       streamId,
       serviceName: 'service',
       procedureName: 'stream',
@@ -499,13 +509,13 @@ describe('cancels invalid request', () => {
       controlFlags: ControlFlags.StreamOpenBit,
     });
 
-    clientTransport.send(serverId, {
+    clientSendFn({
       streamId,
       payload: {},
       controlFlags: ControlFlags.StreamClosedBit,
     });
 
-    clientTransport.send(serverId, {
+    clientSendFn({
       streamId,
       payload: {},
       controlFlags: 0,

--- a/__tests__/serialize.test.ts
+++ b/__tests__/serialize.test.ts
@@ -527,21 +527,33 @@ describe('serialize service to jsonschema', () => {
             type: 'object',
           },
           errors: {
-            properties: {
-              code: { const: 'DIV_BY_ZERO', type: 'string' },
-              message: { type: 'string' },
-              extras: {
+            anyOf: [
+              {
                 properties: {
-                  test: {
-                    type: 'string',
+                  code: { const: 'DIV_BY_ZERO', type: 'string' },
+                  message: { type: 'string' },
+                  extras: {
+                    properties: {
+                      test: {
+                        type: 'string',
+                      },
+                    },
+                    required: ['test'],
+                    type: 'object',
                   },
                 },
-                required: ['test'],
+                required: ['code', 'message', 'extras'],
                 type: 'object',
               },
-            },
-            required: ['code', 'message', 'extras'],
-            type: 'object',
+              {
+                properties: {
+                  code: { const: 'INFINITY', type: 'string' },
+                  message: { type: 'string' },
+                },
+                required: ['code', 'message'],
+                type: 'object',
+              },
+            ],
           },
           type: 'rpc',
         },

--- a/__tests__/streams.test.ts
+++ b/__tests__/streams.test.ts
@@ -314,7 +314,10 @@ describe('Readable unit', () => {
 describe('Writable unit', () => {
   it('should write', () => {
     const writeCb = vi.fn();
-    const writable = new WritableImpl<number>(writeCb, () => undefined);
+    const writable = new WritableImpl<number>({
+      writeCb,
+      closeCb: () => undefined,
+    });
     writable.write(1);
     writable.write(2);
 
@@ -324,7 +327,10 @@ describe('Writable unit', () => {
 
   it('should close the writable', () => {
     const closeCb = vi.fn();
-    const writable = new WritableImpl<number>(() => undefined, closeCb);
+    const writable = new WritableImpl<number>({
+      writeCb: () => undefined,
+      closeCb,
+    });
 
     expect(writable.isWritable()).toBeTruthy();
 
@@ -335,7 +341,10 @@ describe('Writable unit', () => {
 
   it('should allow calling close multiple times', () => {
     const closeCb = vi.fn();
-    const writable = new WritableImpl<number>(() => undefined, closeCb);
+    const writable = new WritableImpl<number>({
+      writeCb: () => undefined,
+      closeCb,
+    });
 
     writable.close();
     writable.close();
@@ -344,10 +353,10 @@ describe('Writable unit', () => {
   });
 
   it('should throw when writing after close', () => {
-    const writable = new WritableImpl<number>(
-      () => undefined,
-      () => undefined,
-    );
+    const writable = new WritableImpl<number>({
+      writeCb: () => undefined,
+      closeCb: () => undefined,
+    });
     writable.close();
     expect(() => writable.write(1)).toThrowError(Error);
   });

--- a/__tests__/typescript-stress.test.ts
+++ b/__tests__/typescript-stress.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import {
-  Procedure,
-  ProcedureErrorSchemaType,
-  flattenErrorType,
-} from '../router/procedures';
+import { Procedure } from '../router/procedures';
 import { ServiceSchema } from '../router/services';
 import { Type } from '@sinclair/typebox';
 import { createServer } from '../router/server';
@@ -23,6 +19,7 @@ import {
   createClientHandshakeOptions,
   createServerHandshakeOptions,
 } from '../router/handshake';
+import { flattenErrorType, ProcedureErrorSchemaType } from '../router/errors';
 
 const requestData = Type.Union([
   Type.Object({ a: Type.Number() }),

--- a/__tests__/typescript-stress.test.ts
+++ b/__tests__/typescript-stress.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'vitest';
-import { Procedure, ProcedureErrorSchemaType } from '../router/procedures';
+import {
+  Procedure,
+  ProcedureErrorSchemaType,
+  flattenErrorType,
+} from '../router/procedures';
 import { ServiceSchema } from '../router/services';
 import { Type } from '@sinclair/typebox';
 import { createServer } from '../router/server';
@@ -130,7 +134,7 @@ export class MockClientTransport extends ClientTransport<Connection> {
   }
 }
 
-export class MockServerTransport extends ServerTransport<Connection> {}
+export class MockServerTransport extends ServerTransport<Connection> { }
 
 describe("ensure typescript doesn't give up trying to infer the types for large services", () => {
   test('service with many procedures hits typescript limit', () => {
@@ -401,118 +405,159 @@ describe('Procedure error schema', () => {
 
     test('union of union', () => {
       acceptErrorSchema(
-        Type.Union([
+        flattenErrorType(
           Type.Union([
-            Type.Object({
-              code: Type.Literal('1'),
-              message: Type.String(),
-            }),
-            Type.Object({
-              code: Type.Literal('2'),
-              message: Type.String(),
-            }),
+            Type.Union([
+              Type.Object({
+                code: Type.Literal('1'),
+                message: Type.String(),
+              }),
+              Type.Object({
+                code: Type.Literal('2'),
+                message: Type.String(),
+              }),
+            ]),
+            Type.Union([
+              Type.Object({
+                code: Type.Literal('3'),
+                message: Type.String(),
+              }),
+              Type.Object({
+                code: Type.Literal('4'),
+                message: Type.String(),
+              }),
+            ]),
           ]),
-          Type.Union([
-            Type.Object({
-              code: Type.Literal('3'),
-              message: Type.String(),
-            }),
-            Type.Object({
-              code: Type.Literal('4'),
-              message: Type.String(),
-            }),
-          ]),
-        ]),
+        ),
       );
     });
 
     test('union of object and union', () => {
       acceptErrorSchema(
-        Type.Union([
-          Type.Object({
-            code: Type.Literal('1'),
-            message: Type.String(),
-          }),
+        flattenErrorType(
           Type.Union([
             Type.Object({
-              code: Type.Literal('2'),
+              code: Type.Literal('1'),
               message: Type.String(),
             }),
-            Type.Object({
-              code: Type.Literal('3'),
-              message: Type.String(),
-            }),
+            Type.Union([
+              Type.Object({
+                code: Type.Literal('2'),
+                message: Type.String(),
+              }),
+              Type.Object({
+                code: Type.Literal('3'),
+                message: Type.String(),
+              }),
+            ]),
           ]),
-        ]),
+        ),
+      );
+    });
+
+    test('deeeeep nesting', () => {
+      acceptErrorSchema(
+        flattenErrorType(
+          Type.Union([
+            Type.Object({
+              code: Type.Literal('1'),
+              message: Type.String(),
+            }),
+            Type.Union([
+              Type.Object({
+                code: Type.Literal('2'),
+                message: Type.String(),
+              }),
+              Type.Union([
+                Type.Object({
+                  code: Type.Literal('3'),
+                  message: Type.String(),
+                }),
+                Type.Union([
+                  Type.Object({
+                    code: Type.Literal('4'),
+                    message: Type.String(),
+                  }),
+                  Type.Object({
+                    code: Type.Literal('5'),
+                    message: Type.String(),
+                  }),
+                ]),
+              ]),
+            ]),
+          ]),
+        ),
       );
     });
 
     test('mixed bag, union of object, unions, "union of unions", and "union of union and object" (I think)', () => {
       acceptErrorSchema(
-        Type.Union([
-          Type.Object({
-            code: Type.Literal('1'),
-            message: Type.String(),
-          }),
+        flattenErrorType(
           Type.Union([
             Type.Object({
-              code: Type.Literal('2'),
+              code: Type.Literal('1'),
               message: Type.String(),
             }),
-            Type.Object({
-              code: Type.Literal('3'),
-              message: Type.String(),
-            }),
-          ]),
-          Type.Union([
+            Type.Union([
+              Type.Object({
+                code: Type.Literal('2'),
+                message: Type.String(),
+              }),
+              Type.Object({
+                code: Type.Literal('3'),
+                message: Type.String(),
+              }),
+            ]),
+            Type.Union([
+              Type.Union([
+                Type.Object({
+                  code: Type.Literal('4'),
+                  message: Type.String(),
+                }),
+                Type.Object({
+                  code: Type.Literal('5'),
+                  message: Type.String(),
+                }),
+              ]),
+              Type.Union([
+                Type.Object({
+                  code: Type.Literal('6'),
+                  message: Type.String(),
+                }),
+                Type.Object({
+                  code: Type.Literal('7'),
+                  message: Type.String(),
+                }),
+              ]),
+            ]),
             Type.Union([
               Type.Object({
                 code: Type.Literal('4'),
                 message: Type.String(),
               }),
-              Type.Object({
-                code: Type.Literal('5'),
-                message: Type.String(),
-              }),
-            ]),
-            Type.Union([
-              Type.Object({
-                code: Type.Literal('6'),
-                message: Type.String(),
-              }),
-              Type.Object({
-                code: Type.Literal('7'),
-                message: Type.String(),
-              }),
-            ]),
-          ]),
-          Type.Union([
-            Type.Object({
-              code: Type.Literal('4'),
-              message: Type.String(),
-            }),
-            Type.Union([
-              Type.Object({
-                code: Type.Literal('4'),
-                message: Type.String(),
-              }),
-              Type.Object({
-                code: Type.Literal('5'),
-                message: Type.String(),
-              }),
-            ]),
-            Type.Union([
-              Type.Object({
-                code: Type.Literal('6'),
-                message: Type.String(),
-              }),
-              Type.Object({
-                code: Type.Literal('7'),
-                message: Type.String(),
-              }),
+              Type.Union([
+                Type.Object({
+                  code: Type.Literal('4'),
+                  message: Type.String(),
+                }),
+                Type.Object({
+                  code: Type.Literal('5'),
+                  message: Type.String(),
+                }),
+              ]),
+              Type.Union([
+                Type.Object({
+                  code: Type.Literal('6'),
+                  message: Type.String(),
+                }),
+                Type.Object({
+                  code: Type.Literal('7'),
+                  message: Type.String(),
+                }),
+              ]),
             ]),
           ]),
-        ]),
+        ),
       );
     });
   });
@@ -542,7 +587,7 @@ describe('Procedure error schema', () => {
       );
     });
 
-    test("doesn't allow nesting too deep", () => {
+    test('fails on nested union without helper', () => {
       acceptErrorSchema(
         // @ts-expect-error testing this
         Type.Union([
@@ -555,22 +600,10 @@ describe('Procedure error schema', () => {
               code: Type.Literal('2'),
               message: Type.String(),
             }),
-            Type.Union([
-              Type.Object({
-                code: Type.Literal('3'),
-                message: Type.String(),
-              }),
-              Type.Union([
-                Type.Object({
-                  code: Type.Literal('4'),
-                  message: Type.String(),
-                }),
-                Type.Object({
-                  code: Type.Literal('5'),
-                  message: Type.String(),
-                }),
-              ]),
-            ]),
+            Type.Object({
+              code: Type.Literal('3'),
+              message: Type.String(),
+            }),
           ]),
         ]),
       );

--- a/__tests__/typescript-stress.test.ts
+++ b/__tests__/typescript-stress.test.ts
@@ -134,7 +134,7 @@ export class MockClientTransport extends ClientTransport<Connection> {
   }
 }
 
-export class MockServerTransport extends ServerTransport<Connection> { }
+export class MockServerTransport extends ServerTransport<Connection> {}
 
 describe("ensure typescript doesn't give up trying to infer the types for large services", () => {
   test('service with many procedures hits typescript limit', () => {

--- a/logging/log.ts
+++ b/logging/log.ts
@@ -1,5 +1,5 @@
 import { ValueError } from '@sinclair/typebox/value';
-import { OpaqueTransportMessage } from '../transport/message';
+import { OpaqueTransportMessage, ProtocolVersion } from '../transport/message';
 
 const LoggingLevels = {
   debug: -1,
@@ -40,7 +40,7 @@ const cleanedLogFn = (log: LogFn) => {
 };
 
 export type MessageMetadata = Partial<{
-  protocolVersion: string;
+  protocolVersion: ProtocolVersion;
   clientId: string;
   connectedTo: string;
   sessionId: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.200.0-rc.20",
+  "version": "0.200.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.200.0-rc.20",
+      "version": "0.200.1",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.200.0-rc.20",
+  "version": "0.200.1",
   "type": "module",
   "exports": {
     ".": {

--- a/router/client.ts
+++ b/router/client.ts
@@ -453,11 +453,11 @@ function handleProc(
   }
 
   function onSessionStatus(evt: EventMap['sessionStatus']) {
-    if (evt.status !== 'disconnect') {
-      return;
-    }
-
-    if (evt.session.to !== serverId) {
+    if (
+      evt.status !== 'disconnect' ||
+      evt.session.to !== serverId ||
+      session.id !== evt.session.id
+    ) {
       return;
     }
 

--- a/router/client.ts
+++ b/router/client.ts
@@ -19,13 +19,7 @@ import {
   cancelMessage,
 } from '../transport/message';
 import { Static } from '@sinclair/typebox';
-import {
-  BaseErrorSchemaType,
-  Err,
-  Result,
-  AnyResultSchema,
-  ErrResultSchema,
-} from './result';
+import { Err, Result, AnyResultSchema } from './result';
 import { EventMap } from '../transport/events';
 import { Connection } from '../transport/connection';
 import { Logger } from '../logging';
@@ -35,13 +29,14 @@ import { ClientTransport } from '../transport/client';
 import { generateId } from '../transport/id';
 import { Readable, ReadableImpl, Writable, WritableImpl } from './streams';
 import { Value } from '@sinclair/typebox/value';
+import { PayloadType, ValidProcType } from './procedures';
 import {
+  BaseErrorSchemaType,
+  ErrResultSchema,
   CANCEL_CODE,
   ReaderErrorSchema,
-  PayloadType,
   UNEXPECTED_DISCONNECT_CODE,
-  ValidProcType,
-} from './procedures';
+} from './errors';
 
 const ReaderErrResultSchema = ErrResultSchema(ReaderErrorSchema);
 

--- a/router/client.ts
+++ b/router/client.ts
@@ -281,7 +281,9 @@ function handleProc(
   procedureName: string,
   abortSignal?: AbortSignal,
 ): AnyProcReturn {
-  const session = transport._getOrCreateSession(serverId);
+  const session =
+    transport.sessions.get(serverId) ??
+    transport.createUnconnectedSession(serverId);
   const sessionScopedSend = transport.getSessionBoundSendFn(
     serverId,
     session.id,

--- a/router/client.ts
+++ b/router/client.ts
@@ -281,7 +281,7 @@ function handleProc(
   procedureName: string,
   abortSignal?: AbortSignal,
 ): AnyProcReturn {
-  const session = transport.getOrCreateSession(serverId);
+  const session = transport._getOrCreateSession(serverId);
   const sessionScopedSend = transport.getSessionBoundSendFn(
     serverId,
     session.id,

--- a/router/errors.ts
+++ b/router/errors.ts
@@ -1,0 +1,131 @@
+import {
+  Kind,
+  TLiteral,
+  TNever,
+  TObject,
+  TSchema,
+  TString,
+  TUnion,
+  Type,
+} from '@sinclair/typebox';
+
+/**
+ * {@link UNCAUGHT_ERROR_CODE} is the code that is used when an error is thrown
+ * inside a procedure handler that's not required.
+ */
+export const UNCAUGHT_ERROR_CODE = 'UNCAUGHT_ERROR';
+/**
+ * {@link UNEXPECTED_DISCONNECT_CODE} is the code used the stream's session
+ * disconnect unexpetedly.
+ */
+export const UNEXPECTED_DISCONNECT_CODE = 'UNEXPECTED_DISCONNECT';
+/**
+ * {@link INVALID_REQUEST_CODE} is the code used when a client's request is invalid.
+ */
+export const INVALID_REQUEST_CODE = 'INVALID_REQUEST';
+/**
+ * {@link CANCEL_CODE} is the code used when either server or client cancels the stream.
+ */
+export const CANCEL_CODE = 'CANCEL';
+
+type TLiteralString = TLiteral<string>;
+
+export type BaseErrorSchemaType =
+  | TObject<{
+      code: TLiteralString | TUnion<Array<TLiteralString>>;
+      message: TLiteralString | TString;
+    }>
+  | TObject<{
+      code: TLiteralString | TUnion<Array<TLiteralString>>;
+      message: TLiteralString | TString;
+      extras: TSchema;
+    }>;
+
+/**
+ * Takes in a specific error schema and returns a result schema the error
+ */
+export const ErrResultSchema = <T extends BaseErrorSchemaType>(t: T) =>
+  Type.Object({
+    ok: Type.Literal(false),
+    payload: t,
+  });
+
+/**
+ * {@link ReaderErrorSchema} is the schema for all the built-in river errors that
+ * can be emitted to a reader (request reader on the server, and response reader
+ * on the client).
+ */
+export const ReaderErrorSchema = Type.Object({
+  code: Type.Union([
+    Type.Literal(UNCAUGHT_ERROR_CODE),
+    Type.Literal(UNEXPECTED_DISCONNECT_CODE),
+    Type.Literal(INVALID_REQUEST_CODE),
+    Type.Literal(CANCEL_CODE),
+  ]),
+  message: Type.String(),
+});
+
+/**
+ * Represents an acceptable schema to pass to a procedure.
+ * Just a type of a schema, not an actual schema.
+ *
+ */
+export type ProcedureErrorSchemaType =
+  | TNever
+  | BaseErrorSchemaType
+  | TUnion<Array<BaseErrorSchemaType>>;
+
+// arbitrarily nested unions
+// river doesn't accept this by default, use the `flattenErrorType` helper
+type NestableProcedureErrorSchemaType =
+  | BaseErrorSchemaType
+  | TUnion<NestableProcedureErrorSchemaTypeArray>;
+// use an interface to defer the type definition to be evaluated lazily
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface NestableProcedureErrorSchemaTypeArray
+  extends Array<NestableProcedureErrorSchemaType> {}
+
+function isUnion(schema: TSchema): schema is TUnion {
+  return schema[Kind] === 'Union';
+}
+
+type Flatten<T> = T extends BaseErrorSchemaType
+  ? T
+  : T extends TUnion<Array<infer U extends TSchema>>
+  ? Flatten<U>
+  : unknown;
+
+/**
+ * In the case where API consumers for some god-forsaken reason want to use
+ * arbitrarily nested unions, this helper flattens them to a single level.
+ *
+ * Note that loses some metadata information on the nested unions like
+ * nested description fields, etc.
+ *
+ * @param errType - An arbitrarily union-nested error schema.
+ * @returns The flattened error schema.
+ */
+export function flattenErrorType<T extends NestableProcedureErrorSchemaType>(
+  errType: T,
+): Flatten<T>;
+export function flattenErrorType(
+  errType: NestableProcedureErrorSchemaType,
+): ProcedureErrorSchemaType {
+  if (!isUnion(errType)) {
+    return errType;
+  }
+
+  const flattenedTypes: Array<BaseErrorSchemaType> = [];
+  function flatten(type: NestableProcedureErrorSchemaType) {
+    if (isUnion(type)) {
+      for (const t of type.anyOf) {
+        flatten(t);
+      }
+    } else {
+      flattenedTypes.push(type);
+    }
+  }
+
+  flatten(errType);
+  return Type.Union(flattenedTypes);
+}

--- a/router/index.ts
+++ b/router/index.ts
@@ -27,18 +27,19 @@ export type {
   UploadProcedure,
   SubscriptionProcedure,
   StreamProcedure,
-  ProcedureErrorSchemaType,
-  flattenErrorType,
 } from './procedures';
 export type { Writable, Readable } from './streams';
+export { Procedure } from './procedures';
 export {
-  Procedure,
+  ProcedureErrorSchemaType,
+  flattenErrorType,
   UNCAUGHT_ERROR_CODE,
   UNEXPECTED_DISCONNECT_CODE,
   INVALID_REQUEST_CODE,
   CANCEL_CODE,
   ReaderErrorSchema,
-} from './procedures';
+  BaseErrorSchemaType,
+} from './errors';
 export { createClient } from './client';
 export type { Client } from './client';
 export { createServer } from './server';
@@ -56,7 +57,6 @@ export type {
   ResultUnwrapOk,
   ResultUnwrapErr,
   ResponseData,
-  BaseErrorSchemaType,
 } from './result';
 export {
   createClientHandshakeOptions,

--- a/router/index.ts
+++ b/router/index.ts
@@ -28,6 +28,7 @@ export type {
   SubscriptionProcedure,
   StreamProcedure,
   ProcedureErrorSchemaType,
+  flattenErrorType,
 } from './procedures';
 export type { Writable, Readable } from './streams';
 export {

--- a/router/result.ts
+++ b/router/result.ts
@@ -1,36 +1,7 @@
-import {
-  Static,
-  TLiteral,
-  TObject,
-  TSchema,
-  TString,
-  TUnion,
-  Type,
-} from '@sinclair/typebox';
+import { Static, Type } from '@sinclair/typebox';
 import { Client } from './client';
 import { Readable } from './streams';
-
-type TLiteralString = TLiteral<string>;
-
-export type BaseErrorSchemaType =
-  | TObject<{
-      code: TLiteralString | TUnion<Array<TLiteralString>>;
-      message: TLiteralString | TString;
-    }>
-  | TObject<{
-      code: TLiteralString | TUnion<Array<TLiteralString>>;
-      message: TLiteralString | TString;
-      extras: TSchema;
-    }>;
-
-/**
- * Takes in a specific error schema and returns a result schema the error
- */
-export const ErrResultSchema = <T extends BaseErrorSchemaType>(t: T) =>
-  Type.Object({
-    ok: Type.Literal(false),
-    payload: t,
-  });
+import { BaseErrorSchemaType } from './errors';
 
 /**
  * AnyResultSchema is a schema to validate any result.

--- a/router/server.ts
+++ b/router/server.ts
@@ -1,7 +1,6 @@
 import { Static, Type } from '@sinclair/typebox';
 import {
   PayloadType,
-  ProcedureErrorSchemaType,
   ReaderErrorSchema,
   UNCAUGHT_ERROR_CODE,
   UNEXPECTED_DISCONNECT_CODE,
@@ -23,6 +22,7 @@ import {
   isStreamCancel,
   closeStreamMessage,
   cancelMessage,
+  ProtocolVersion,
   TransportClientId,
 } from '../transport/message';
 import {
@@ -30,17 +30,26 @@ import {
   ProcedureHandlerContext,
   ParsedMetadata,
 } from './context';
-import { Logger, MessageMetadata } from '../logging/log';
+import { Logger } from '../logging/log';
 import { Value, ValueError } from '@sinclair/typebox/value';
-import { Err, Result, Ok, ErrResultSchema, ErrResult } from './result';
+import {
+  Err,
+  Result,
+  Ok,
+  ErrResultSchema,
+  ErrResult,
+  BaseErrorSchemaType,
+} from './result';
 import { EventMap } from '../transport/events';
 import { coerceErrorString } from '../util/stringify';
 import { Span, SpanStatusCode } from '@opentelemetry/api';
-import { PropagationContext, createHandlerSpan } from '../tracing';
+import { createHandlerSpan, PropagationContext } from '../tracing';
 import { ServerHandshakeOptions } from './handshake';
 import { Connection } from '../transport/connection';
 import { ServerTransport } from '../transport/server';
 import { ReadableImpl, WritableImpl } from './streams';
+import { IdentifiedSession } from '../transport/sessionStateMachine/common';
+import { SessionBoundSendFn } from '../transport/transport';
 
 type StreamId = string;
 
@@ -66,27 +75,42 @@ export interface Server<Services extends AnyServiceSchemaMap> {
   /**
    * A set of stream ids that are currently open.
    */
-  openStreams: Set<StreamId>;
+  streams: Map<StreamId, ProcStream>;
 }
 
 type ProcHandlerReturn = Promise<(() => void) | void>;
 
-interface NewProcStreamInput {
-  procedure: AnyProcedure;
-  procedureName: string;
-  service: AnyService;
-  serviceName: string;
-  sessionMetadata: ParsedMetadata;
-  loggingMetadata: MessageMetadata;
+interface StreamInitProps {
+  // msg derived
   streamId: StreamId;
-  controlFlags: number;
-  tracingCtx?: PropagationContext;
+  procedureName: string;
+  serviceName: string;
   initPayload: Static<PayloadType>;
-  from: string;
-  sessionId: string;
-  protocolVersion: string;
+  tracingCtx: PropagationContext | undefined;
+  // true if the first and only message is the init payload
+  // i.e. rpc and subscription
+  procClosesWithInit: boolean;
+
+  // server level
+  serviceContext: ServiceContext & { state: object };
+  procedure: AnyProcedure;
+  sessionMetadata: ParsedMetadata;
+
+  // transport level
+  initialSession: IdentifiedSession;
+
   // TODO remove once clients migrate to v2
   passInitAsDataForBackwardsCompat: boolean;
+}
+
+interface ProcStream {
+  streamId: StreamId;
+  from: TransportClientId;
+  procedureName: string;
+  serviceName: string;
+  sessionMetadata: ParsedMetadata;
+  procedure: AnyProcedure;
+  handleMsg: (msg: OpaqueTransportMessage) => void;
 }
 
 class RiverServer<Services extends AnyServiceSchemaMap>
@@ -95,17 +119,18 @@ class RiverServer<Services extends AnyServiceSchemaMap>
   private transport: ServerTransport<Connection>;
   private contextMap: Map<AnyService, ServiceContext & { state: object }>;
   private log?: Logger;
+
   /**
    * We create a tombstones for streams cancelled by the server
    * so that we don't hit errors when the client has inflight
    * requests it sent before it saw the cancel.
-   * We track cancelled streams for every session separately, so
+   * We track cancelled streams for every client separately, so
    * that bad clients don't affect good clients.
    */
-  private serverCancelledStreams: Map<TransportClientId, LRUSet>;
+  private serverCancelledStreams: Map<TransportClientId, LRUSet<StreamId>>;
   private maxCancelledStreamTombstonesPerSession: number;
 
-  public openStreams: Set<StreamId>;
+  public streams: Map<StreamId, ProcStream>;
   public services: InstantiatedServiceSchemaMap<Services>;
 
   constructor(
@@ -135,42 +160,51 @@ class RiverServer<Services extends AnyServiceSchemaMap>
     }
 
     this.transport = transport;
-    this.openStreams = new Set();
+    this.streams = new Map();
     this.serverCancelledStreams = new Map();
     this.maxCancelledStreamTombstonesPerSession =
       maxCancelledStreamTombstonesPerSession;
     this.log = transport.log;
 
-    const handleMessage = (msg: EventMap['message']) => {
-      if (msg.to !== this.transport.clientId) {
+    const handleCreatingNewStreams = (message: EventMap['message']) => {
+      if (message.to !== this.transport.clientId) {
         this.log?.info(
           `got msg with destination that isn't this server, ignoring`,
           {
             clientId: this.transport.clientId,
-            transportMessage: msg,
+            transportMessage: message,
           },
         );
+
         return;
       }
 
-      if (this.openStreams.has(msg.streamId)) {
-        // has its own message handler
+      const streamId = message.streamId;
+      const stream = this.streams.get(streamId);
+      if (stream) {
+        stream.handleMsg(message);
         return;
       }
 
-      if (this.serverCancelledStreams.get(msg.from)?.has(msg.streamId)) {
+      // if this is a cancelled stream it's safe to ignore
+      if (this.serverCancelledStreams.get(message.from)?.has(streamId)) {
         return;
       }
 
-      const validated = this.validateNewProcStream(msg);
-
-      if (!validated) {
+      // if this stream init request is invalid, don't bother creating a stream
+      // and tell the client to cancel
+      const newStreamProps = this.validateNewProcStream(message);
+      if (!newStreamProps) {
         return;
       }
 
-      this.createNewProcStream(validated);
+      // if its not a cancelled stream, validate and create a new stream
+      const newStream = this.createNewProcStream({
+        ...newStreamProps,
+        ...message,
+      });
+      this.streams.set(streamId, newStream);
     };
-    this.transport.addEventListener('message', handleMessage);
 
     const handleSessionStatus = (evt: EventMap['sessionStatus']) => {
       if (evt.status !== 'disconnect') return;
@@ -183,88 +217,49 @@ class RiverServer<Services extends AnyServiceSchemaMap>
 
       this.serverCancelledStreams.delete(disconnectedClientId);
     };
-    this.transport.addEventListener('sessionStatus', handleSessionStatus);
 
-    this.transport.addEventListener('transportStatus', (evt) => {
+    const handleTransportStatus = (evt: EventMap['transportStatus']) => {
       if (evt.status !== 'closed') return;
-
-      this.transport.removeEventListener('message', handleMessage);
+      this.transport.removeEventListener('message', handleCreatingNewStreams);
       this.transport.removeEventListener('sessionStatus', handleSessionStatus);
-    });
+      this.transport.removeEventListener(
+        'transportStatus',
+        handleTransportStatus,
+      );
+    };
+
+    this.transport.addEventListener('message', handleCreatingNewStreams);
+    this.transport.addEventListener('sessionStatus', handleSessionStatus);
+    this.transport.addEventListener('transportStatus', handleTransportStatus);
   }
 
-  private createNewProcStream({
-    procedure,
-    procedureName,
-    service,
-    serviceName,
-    sessionMetadata,
-    loggingMetadata,
-    streamId,
-    controlFlags,
-    initPayload,
-    from,
-    sessionId,
-    tracingCtx,
-    protocolVersion,
-    passInitAsDataForBackwardsCompat,
-  }: NewProcStreamInput) {
-    this.openStreams.add(streamId);
+  private createNewProcStream(props: StreamInitProps): ProcStream {
+    const {
+      streamId,
+      initialSession,
+      procedureName,
+      serviceName,
+      procedure,
+      sessionMetadata,
+      serviceContext,
+      initPayload,
+      tracingCtx,
+      procClosesWithInit,
+      passInitAsDataForBackwardsCompat,
+    } = props;
+
+    const {
+      to: from,
+      loggingMetadata,
+      protocolVersion,
+      id: sessionId,
+    } = initialSession;
 
     let cleanClose = true;
-
-    const onServerCancel = (e: Static<typeof ReaderErrorSchema>) => {
-      if (reqReadable.isClosed() && resWritable.isClosed()) {
-        // Everything already closed, no-op.
-        return;
-      }
-
-      cleanClose = false;
-
-      const result = Err(e);
-
-      if (!reqReadable.isClosed()) {
-        reqReadable._pushValue(result);
-        closeReadable();
-      }
-
-      resWritable.close();
-      this.cancelStream(from, streamId, result);
-    };
-
-    const onSessionStatus = (evt: EventMap['sessionStatus']) => {
-      if (evt.status !== 'disconnect') {
-        return;
-      }
-
-      if (evt.session.to !== from) {
-        return;
-      }
-
-      cleanClose = false;
-
-      const errPayload = {
-        code: UNEXPECTED_DISCONNECT_CODE,
-        message: `client unexpectedly disconnected`,
-      } as const;
-      if (!reqReadable.isClosed()) {
-        reqReadable._pushValue(Err(errPayload));
-        closeReadable();
-      }
-
-      resWritable.close();
-    };
-    this.transport.addEventListener('sessionStatus', onSessionStatus);
-
     const onMessage = (msg: OpaqueTransportMessage) => {
-      if (streamId !== msg.streamId) {
-        return;
-      }
-
       if (msg.from !== from) {
         this.log?.error('got stream message from unexpected client', {
           ...loggingMetadata,
-          clientId: this.transport.clientId,
           transportMessage: msg,
           tags: ['invariant-violation'],
         });
@@ -284,7 +279,6 @@ class RiverServer<Services extends AnyServiceSchemaMap>
           });
           this.log?.warn('got stream cancel without a valid protocol error', {
             ...loggingMetadata,
-            clientId: this.transport.clientId,
             transportMessage: msg,
             validationErrors: [
               ...Value.Errors(CancelResultSchema, msg.payload),
@@ -306,7 +300,6 @@ class RiverServer<Services extends AnyServiceSchemaMap>
       if (reqReadable.isClosed()) {
         this.log?.warn('received message after request stream is closed', {
           ...loggingMetadata,
-          clientId: this.transport.clientId,
           transportMessage: msg,
           tags: ['invalid-request'],
         });
@@ -363,7 +356,6 @@ class RiverServer<Services extends AnyServiceSchemaMap>
 
       this.log?.warn(errMessage, {
         ...loggingMetadata,
-        clientId: this.transport.clientId,
         transportMessage: msg,
         validationErrors,
         tags: ['invalid-request'],
@@ -374,15 +366,87 @@ class RiverServer<Services extends AnyServiceSchemaMap>
         message: errMessage,
       });
     };
-    this.transport.addEventListener('message', onMessage);
+
+    const procStream: ProcStream = {
+      from: from,
+      streamId,
+      procedureName,
+      serviceName,
+      sessionMetadata,
+      procedure,
+      handleMsg: onMessage,
+    };
+
+    const sessionScopedSend = this.transport.getSessionBoundSendFn(
+      from,
+      sessionId,
+    );
+
+    const cancelStream = (
+      streamId: StreamId,
+      payload: ErrResult<Static<typeof ReaderErrorSchema>>,
+    ) => {
+      let cancelledForSession = this.serverCancelledStreams.get(from);
+      if (!cancelledForSession) {
+        cancelledForSession = new LRUSet(
+          this.maxCancelledStreamTombstonesPerSession,
+        );
+
+        this.serverCancelledStreams.set(from, cancelledForSession);
+      }
+
+      cancelledForSession.add(streamId);
+      this.sendCancelToClient(
+        sessionScopedSend,
+        streamId,
+        payload,
+        protocolVersion,
+      );
+    };
+
+    const onServerCancel = (e: Static<typeof ReaderErrorSchema>) => {
+      if (reqReadable.isClosed() && resWritable.isClosed()) {
+        // Everything already closed, no-op.
+        return;
+      }
+
+      cleanClose = false;
+      const result = Err(e);
+      if (!reqReadable.isClosed()) {
+        reqReadable._pushValue(result);
+        closeReadable();
+      }
+
+      resWritable.close();
+      cancelStream(streamId, result);
+    };
+
+    const onSessionStatus = (evt: EventMap['sessionStatus']) => {
+      if (evt.status !== 'disconnect' || evt.session.to !== from) {
+        return;
+      }
+
+      cleanClose = false;
+      const errPayload = {
+        code: UNEXPECTED_DISCONNECT_CODE,
+        message: 'client unexpectedly disconnected',
+      };
+
+      if (!reqReadable.isClosed()) {
+        reqReadable._pushValue(Err(errPayload));
+        closeReadable();
+      }
+
+      resWritable.close();
+    };
+    this.transport.addEventListener('sessionStatus', onSessionStatus);
 
     const finishedController = new AbortController();
     const cleanup = () => {
-      this.transport.removeEventListener('message', onMessage);
       this.transport.removeEventListener('sessionStatus', onSessionStatus);
 
       finishedController.abort();
-      this.openStreams.delete(streamId);
+      this.streams.delete(streamId);
     };
 
     const procClosesWithResponse =
@@ -414,20 +478,25 @@ class RiverServer<Services extends AnyServiceSchemaMap>
     }
 
     const resWritable = new WritableImpl<
-      Result<Static<PayloadType>, Static<ProcedureErrorSchemaType>>
-    >(
-      // write callback
-      (response) => {
-        this.transport.send(from, {
+      Result<Static<PayloadType>, Static<BaseErrorSchemaType>>
+    >({
+      writeCb: (response) => {
+        sessionScopedSend({
           streamId,
           controlFlags: procClosesWithResponse
             ? getStreamCloseBackwardsCompat(protocolVersion)
             : 0,
           payload: response,
         });
+
+        // TODO: should the procClosesWithResponse
+        // check also close the writable?
+        if (procClosesWithResponse) {
+          resWritable.close();
+        }
       },
       // close callback
-      () => {
+      closeCb: () => {
         if (!procClosesWithResponse && cleanClose) {
           // we ended, send a close bit back to the client
           // also, if the client has disconnected, we don't need to send a close
@@ -436,7 +505,7 @@ class RiverServer<Services extends AnyServiceSchemaMap>
           // TODO remove once clients migrate to v2
           message.controlFlags = getStreamCloseBackwardsCompat(protocolVersion);
 
-          this.transport.send(from, closeStreamMessage(streamId));
+          sessionScopedSend(message);
         }
 
         // TODO remove once clients migrate to v2
@@ -451,7 +520,7 @@ class RiverServer<Services extends AnyServiceSchemaMap>
           cleanup();
         }
       },
-    );
+    });
 
     const onHandlerError = (err: unknown, span: Span) => {
       const errorMsg = coerceErrorString(err);
@@ -465,7 +534,9 @@ class RiverServer<Services extends AnyServiceSchemaMap>
       });
     };
 
-    if (isStreamCloseBackwardsCompat(controlFlags, protocolVersion)) {
+    // if the init message has a close flag then we know this stream
+    // only consists of an init message and we shouldn't expect follow up data
+    if (procClosesWithInit) {
       closeReadable();
     } else if (procedure.type === 'rpc' || procedure.type === 'subscription') {
       // Though things can work just fine if they eventually follow up with a stream
@@ -477,8 +548,8 @@ class RiverServer<Services extends AnyServiceSchemaMap>
     }
 
     const handlerContext: ProcedureHandlerContext<object> = {
-      ...this.getContext(service, serviceName),
-      from,
+      ...serviceContext,
+      from: from,
       sessionId,
       metadata: sessionMetadata,
       cancel: () => {
@@ -511,7 +582,6 @@ class RiverServer<Services extends AnyServiceSchemaMap>
               }
 
               resWritable.write(responsePayload);
-              resWritable.close();
             } catch (err) {
               onHandlerError(err, span);
             } finally {
@@ -553,8 +623,6 @@ class RiverServer<Services extends AnyServiceSchemaMap>
           tracingCtx,
           async (span): ProcHandlerReturn => {
             try {
-              // TODO handle never resolving after cleanup/full close
-              // which would lead to us holding on to the closure forever
               await procedure.handler({
                 ctx: handlerContext,
                 reqInit: initPayload,
@@ -577,8 +645,6 @@ class RiverServer<Services extends AnyServiceSchemaMap>
           tracingCtx,
           async (span): ProcHandlerReturn => {
             try {
-              // TODO handle never resolving after cleanup/full close
-              // which would lead to us holding on to the closure forever
               const responsePayload = await procedure.handler({
                 ctx: handlerContext,
                 reqInit: initPayload,
@@ -589,8 +655,8 @@ class RiverServer<Services extends AnyServiceSchemaMap>
                 // A disconnect happened
                 return;
               }
+
               resWritable.write(responsePayload);
-              resWritable.close();
             } catch (err) {
               onHandlerError(err, span);
             } finally {
@@ -600,19 +666,9 @@ class RiverServer<Services extends AnyServiceSchemaMap>
         );
 
         break;
-      default:
-        this.log?.error(
-          `got request for invalid procedure type ${
-            (procedure as AnyProcedure).type
-          } at ${serviceName}.${procedureName}`,
-          {
-            ...loggingMetadata,
-            tags: ['invariant-violation'],
-          },
-        );
-
-        return;
     }
+
+    return procStream;
   }
 
   private getContext(service: AnyService, serviceName: string) {
@@ -631,32 +687,30 @@ class RiverServer<Services extends AnyServiceSchemaMap>
 
   private validateNewProcStream(
     initMessage: OpaqueTransportMessage,
-  ): null | NewProcStreamInput {
+  ): StreamInitProps | null {
+    // lifetime safety: this is a sync function so this session cant transition
+    // to another state before we finish
     const session = this.transport.sessions.get(initMessage.from);
-
     if (!session) {
-      const errMessage = `couldn't find a session for ${initMessage.from}`;
+      // this should be impossible, how did we receive a message from a session that doesn't exist?
+      // log anyways
       this.log?.error(`couldn't find session for ${initMessage.from}`, {
         clientId: this.transport.clientId,
         transportMessage: initMessage,
         tags: ['invariant-violation'],
       });
 
-      this.cancelStream(
-        initMessage.from,
-        initMessage.streamId,
-        Err({
-          code: UNCAUGHT_ERROR_CODE,
-          message: errMessage,
-        }),
-      );
-
       return null;
     }
 
+    const sessionScopedSend = this.transport.getSessionBoundSendFn(
+      initMessage.from,
+      session.id,
+    );
     const sessionMetadata = this.transport.sessionHandshakeMetadata.get(
       session.to,
     );
+
     if (!sessionMetadata) {
       const errMessage = `session doesn't have handshake metadata`;
       this.log?.error(errMessage, {
@@ -664,13 +718,14 @@ class RiverServer<Services extends AnyServiceSchemaMap>
         tags: ['invariant-violation'],
       });
 
-      this.cancelStream(
-        initMessage.from,
+      this.sendCancelToClient(
+        sessionScopedSend,
         initMessage.streamId,
         Err({
           code: UNCAUGHT_ERROR_CODE,
           message: errMessage,
         }),
+        session.protocolVersion,
       );
 
       return null;
@@ -685,13 +740,14 @@ class RiverServer<Services extends AnyServiceSchemaMap>
         tags: ['invalid-request'],
       });
 
-      this.cancelStream(
-        initMessage.from,
+      this.sendCancelToClient(
+        sessionScopedSend,
         initMessage.streamId,
         Err({
           code: INVALID_REQUEST_CODE,
           message: errMessage,
         }),
+        session.protocolVersion,
       );
 
       return null;
@@ -701,18 +757,18 @@ class RiverServer<Services extends AnyServiceSchemaMap>
       const errMessage = `missing service name in stream open message`;
       this.log?.warn(errMessage, {
         ...session.loggingMetadata,
-        clientId: this.transport.clientId,
         transportMessage: initMessage,
         tags: ['invalid-request'],
       });
 
-      this.cancelStream(
-        initMessage.from,
+      this.sendCancelToClient(
+        sessionScopedSend,
         initMessage.streamId,
         Err({
           code: INVALID_REQUEST_CODE,
           message: errMessage,
         }),
+        session.protocolVersion,
       );
 
       return null;
@@ -722,18 +778,18 @@ class RiverServer<Services extends AnyServiceSchemaMap>
       const errMessage = `missing procedure name in stream open message`;
       this.log?.warn(errMessage, {
         ...session.loggingMetadata,
-        clientId: this.transport.clientId,
         transportMessage: initMessage,
         tags: ['invalid-request'],
       });
 
-      this.cancelStream(
-        initMessage.from,
+      this.sendCancelToClient(
+        sessionScopedSend,
         initMessage.streamId,
         Err({
           code: INVALID_REQUEST_CODE,
           message: errMessage,
         }),
+        session.protocolVersion,
       );
 
       return null;
@@ -748,13 +804,14 @@ class RiverServer<Services extends AnyServiceSchemaMap>
         tags: ['invalid-request'],
       });
 
-      this.cancelStream(
-        initMessage.from,
+      this.sendCancelToClient(
+        sessionScopedSend,
         initMessage.streamId,
         Err({
           code: INVALID_REQUEST_CODE,
           message: errMessage,
         }),
+        session.protocolVersion,
       );
 
       return null;
@@ -765,24 +822,40 @@ class RiverServer<Services extends AnyServiceSchemaMap>
       const errMessage = `couldn't find a matching procedure for ${initMessage.serviceName}.${initMessage.procedureName}`;
       this.log?.warn(errMessage, {
         ...session.loggingMetadata,
-        clientId: this.transport.clientId,
         transportMessage: initMessage,
         tags: ['invalid-request'],
       });
 
-      this.cancelStream(
-        initMessage.from,
+      this.sendCancelToClient(
+        sessionScopedSend,
         initMessage.streamId,
         Err({
           code: INVALID_REQUEST_CODE,
           message: errMessage,
         }),
+        session.protocolVersion,
       );
 
       return null;
     }
 
-    const procedure = service.procedures[initMessage.procedureName];
+    const serviceContext = this.getContext(service, initMessage.serviceName);
+
+    const procedure: AnyProcedure =
+      service.procedures[initMessage.procedureName];
+
+    if (!['rpc', 'upload', 'stream', 'subscription'].includes(procedure.type)) {
+      this.log?.error(
+        `got request for invalid procedure type ${procedure.type} at ${initMessage.serviceName}.${initMessage.procedureName}`,
+        {
+          ...session.loggingMetadata,
+          transportMessage: initMessage,
+          tags: ['invariant-violation'],
+        },
+      );
+
+      return null;
+    }
 
     let passInitAsDataForBackwardsCompat = false;
     if (
@@ -808,68 +881,54 @@ class RiverServer<Services extends AnyServiceSchemaMap>
         tags: ['invalid-request'],
       });
 
-      this.cancelStream(
-        initMessage.from,
+      this.sendCancelToClient(
+        sessionScopedSend,
         initMessage.streamId,
         Err({
           code: INVALID_REQUEST_CODE,
           message: errMessage,
         }),
+        session.protocolVersion,
       );
 
       return null;
     }
 
     return {
-      sessionMetadata,
-      procedure,
-      procedureName: initMessage.procedureName,
-      service,
-      serviceName: initMessage.serviceName,
-      loggingMetadata: {
-        ...session.loggingMetadata,
-        transportMessage: initMessage,
-      },
+      initialSession: session,
       streamId: initMessage.streamId,
-      controlFlags: initMessage.controlFlags,
+      procedureName: initMessage.procedureName,
+      serviceName: initMessage.serviceName,
       tracingCtx: initMessage.tracing,
       initPayload: initMessage.payload,
-      from: initMessage.from,
-      sessionId: session.id,
-      protocolVersion: session.protocolVersion,
+      sessionMetadata,
+      procedure,
+      serviceContext,
+      procClosesWithInit: isStreamCloseBackwardsCompat(
+        initMessage.controlFlags,
+        session.protocolVersion,
+      ),
       passInitAsDataForBackwardsCompat,
     };
   }
 
-  cancelStream(
-    to: string,
-    streamId: string,
+  sendCancelToClient(
+    sessionScopedSend: SessionBoundSendFn,
+    streamId: StreamId,
     payload: ErrResult<Static<typeof ReaderErrorSchema>>,
+    // TODO remove once clients migrate to v2
+    protocolVersion: ProtocolVersion,
   ) {
-    let cancelledForSession = this.serverCancelledStreams.get(to);
-
-    if (!cancelledForSession) {
-      cancelledForSession = new LRUSet(
-        this.maxCancelledStreamTombstonesPerSession,
-      );
-
-      this.serverCancelledStreams.set(to, cancelledForSession);
-    }
-
-    cancelledForSession.add(streamId);
-
-    this.transport.send(
-      to,
-      // TODO remove once clients migrate to v2
-      this.transport.sessions.get(to)?.protocolVersion === 'v1.1'
-        ? closeStreamMessage(streamId)
-        : cancelMessage(streamId, payload),
-    );
+    const isOldProtocol = protocolVersion === 'v1.1';
+    const msg = isOldProtocol
+      ? closeStreamMessage(streamId)
+      : cancelMessage(streamId, payload);
+    sessionScopedSend(msg);
   }
 }
 
-class LRUSet {
-  private items: Set<StreamId>;
+class LRUSet<T> {
+  private items: Set<T>;
   private maxItems: number;
 
   constructor(maxItems: number) {
@@ -877,7 +936,7 @@ class LRUSet {
     this.maxItems = maxItems;
   }
 
-  add(item: string) {
+  add(item: T) {
     if (this.items.has(item)) {
       this.items.delete(item);
     } else if (this.items.size >= this.maxItems) {
@@ -889,7 +948,7 @@ class LRUSet {
     this.items.add(item);
   }
 
-  has(item: string) {
+  has(item: T) {
     return this.items.has(item);
   }
 }
@@ -897,7 +956,7 @@ class LRUSet {
 // TODO remove once clients migrate to v2
 function isStreamCancelBackwardsCompat(
   controlFlags: ControlFlags,
-  protocolVersion: string,
+  protocolVersion: ProtocolVersion,
 ) {
   if (protocolVersion === 'v1.1') {
     // in 1.1 we don't have abort
@@ -910,7 +969,7 @@ function isStreamCancelBackwardsCompat(
 // TODO remove once clients migrate to v2
 function isStreamCloseBackwardsCompat(
   controlFlags: ControlFlags,
-  protocolVersion: string,
+  protocolVersion: ProtocolVersion,
 ) {
   if (protocolVersion === 'v1.1') {
     // in v1.1 the bits for close is what we use for cancel now
@@ -921,7 +980,7 @@ function isStreamCloseBackwardsCompat(
 }
 
 // TODO remove once clients migrate to v2
-function getStreamCloseBackwardsCompat(protocolVersion: string) {
+function getStreamCloseBackwardsCompat(protocolVersion: ProtocolVersion) {
   if (protocolVersion === 'v1.1') {
     // in v1.1 the bits for close is what we use for cancel now
     return ControlFlags.StreamCancelBit;

--- a/router/server.ts
+++ b/router/server.ts
@@ -578,8 +578,8 @@ class RiverServer<Services extends AnyServiceSchemaMap>
               await procedure.handler({
                 ctx: handlerContext,
                 reqInit: initPayload,
-                reqReadable: reqReadable,
-                resWritable: resWritable,
+                reqReadable,
+                resWritable,
               });
             } catch (err) {
               onHandlerError(err, span);

--- a/router/services.ts
+++ b/router/services.ts
@@ -5,10 +5,9 @@ import {
   Unbranded,
   AnyProcedure,
   PayloadType,
-  ProcedureErrorSchemaType,
-  ReaderErrorSchema,
 } from './procedures';
 import { ServiceContext } from './context';
+import { ProcedureErrorSchemaType, ReaderErrorSchema } from './errors';
 
 /**
  * An instantiated service, probably from a {@link ServiceSchema}.

--- a/router/streams.ts
+++ b/router/streams.ts
@@ -347,9 +347,9 @@ export class WritableImpl<T> implements Writable<T> {
    */
   private closed = false;
 
-  constructor(writeCb: (value: T) => void, closeCb: () => void) {
-    this.writeCb = writeCb;
-    this.closeCb = closeCb;
+  constructor(callbacks: { writeCb: (value: T) => void; closeCb: () => void }) {
+    this.writeCb = callbacks.writeCb;
+    this.closeCb = callbacks.closeCb;
   }
 
   public write(value: T): undefined {

--- a/router/streams.ts
+++ b/router/streams.ts
@@ -1,5 +1,6 @@
 import { Static } from '@sinclair/typebox';
-import { BaseErrorSchemaType, Err, Result } from './result';
+import { Err, Result } from './result';
+import { BaseErrorSchemaType } from './errors';
 
 export const ReadableBrokenError: Static<BaseErrorSchemaType> = {
   code: 'READABLE_BROKEN',

--- a/transport/client.ts
+++ b/transport/client.ts
@@ -95,7 +95,11 @@ export abstract class ClientTransport<
     }
   }
 
-  private createUnconnectedSession(to: string): SessionNoConnection {
+  /*
+   * Creates a raw unconnected session object.
+   * This is mostly a River internal, you shouldn't need to use this directly.
+   */
+  createUnconnectedSession(to: string): SessionNoConnection {
     const session = ClientSessionStateGraph.entrypoint(
       to,
       this.clientId,
@@ -293,10 +297,6 @@ export abstract class ClientTransport<
     this.retryBudget.startRestoringBudget();
   }
 
-  getOrCreateSession(to: TransportClientId): ClientSession<ConnType> {
-    return this.sessions.get(to) ?? this.createUnconnectedSession(to);
-  }
-
   /**
    * Manually attempts to connect to a client.
    * @param to The client ID of the node to connect to.
@@ -309,7 +309,7 @@ export abstract class ClientTransport<
       return;
     }
 
-    const session = this.getOrCreateSession(to);
+    const session = this.sessions.get(to) ?? this.createUnconnectedSession(to);
     if (session.state !== SessionState.NoConnection) {
       // already trying to connect
       this.log?.debug(

--- a/transport/client.ts
+++ b/transport/client.ts
@@ -109,7 +109,7 @@ export abstract class ClientTransport<
       this.log,
     );
 
-    this.updateSession(session);
+    this.createSession(session);
     return session;
   }
 

--- a/transport/message.ts
+++ b/transport/message.ts
@@ -16,13 +16,13 @@ export const enum ControlFlags {
    */
   StreamOpenBit = 0b00010,
   /**
-   * Used when writer closes the stream.
-   */
-  StreamClosedBit = 0b01000,
-  /**
    * Used when a stream is cancelled due errors or to explicit cancellation
    */
   StreamCancelBit = 0b00100,
+  /**
+   * Used when writer closes the stream.
+   */
+  StreamClosedBit = 0b01000,
 }
 
 /**
@@ -68,8 +68,12 @@ export const ControlMessageCloseSchema = Type.Object({
   type: Type.Literal('CLOSE'),
 });
 
-export const currentProtocolVersion = 'v2.0';
-export const acceptedProtocolVersions = ['v1.1', currentProtocolVersion];
+export type ProtocolVersion = 'v0' | 'v1' | 'v1.1' | 'v2.0';
+export const currentProtocolVersion = 'v2.0' satisfies ProtocolVersion;
+export const acceptedProtocolVersions: Array<ProtocolVersion> = [
+  'v1.1',
+  currentProtocolVersion,
+] as const;
 
 export const ControlMessageHandshakeRequestSchema = Type.Object({
   type: Type.Literal('HANDSHAKE_REQ'),

--- a/transport/message.ts
+++ b/transport/message.ts
@@ -68,12 +68,14 @@ export const ControlMessageCloseSchema = Type.Object({
   type: Type.Literal('CLOSE'),
 });
 
-export type ProtocolVersion = 'v0' | 'v1' | 'v1.1' | 'v2.0';
+export type ProtocolVersion = 'v1.1' | 'v2.0';
 export const currentProtocolVersion = 'v2.0' satisfies ProtocolVersion;
-export const acceptedProtocolVersions: Array<ProtocolVersion> = [
-  'v1.1',
-  currentProtocolVersion,
-] as const;
+export const acceptedProtocolVersions = ['v1.1', currentProtocolVersion];
+export function isAcceptedProtocolVersion(
+  version: string,
+): version is ProtocolVersion {
+  return acceptedProtocolVersions.includes(version);
+}
 
 export const ControlMessageHandshakeRequestSchema = Type.Object({
   type: Type.Literal('HANDSHAKE_REQ'),

--- a/transport/server.ts
+++ b/transport/server.ts
@@ -497,7 +497,7 @@ export abstract class ServerTransport<
       );
 
     this.sessionHandshakeMetadata.set(connectedSession.to, parsedMetadata);
-    this.updateSession(connectedSession);
+    this.createSession(connectedSession);
     this.pendingSessions.delete(session);
     connectedSession.startActiveHeartbeat();
   }

--- a/transport/server.ts
+++ b/transport/server.ts
@@ -10,7 +10,7 @@ import {
   TransportClientId,
   handshakeResponseMessage,
   currentProtocolVersion,
-  ProtocolVersion,
+  isAcceptedProtocolVersion,
 } from './message';
 import {
   ProvidedServerTransportOptions,
@@ -228,8 +228,8 @@ export abstract class ServerTransport<
     }
 
     // invariant: handshake request passes all the validation
-    const gotVersion = msg.payload.protocolVersion as ProtocolVersion;
-    if (!acceptedProtocolVersions.includes(gotVersion)) {
+    const gotVersion = msg.payload.protocolVersion;
+    if (!isAcceptedProtocolVersion(gotVersion)) {
       this.rejectHandshakeRequest(
         session,
         msg.from,

--- a/transport/sessionStateMachine/common.ts
+++ b/transport/sessionStateMachine/common.ts
@@ -4,6 +4,7 @@ import {
   OpaqueTransportMessage,
   OpaqueTransportMessageSchema,
   PartialTransportMessage,
+  ProtocolVersion,
   TransportClientId,
   TransportMessage,
 } from '../message';
@@ -197,14 +198,14 @@ export interface IdentifiedSessionProps extends CommonSessionProps {
   ack: number;
   sendBuffer: Array<OpaqueTransportMessage>;
   telemetry: TelemetryInfo;
-  protocolVersion: string;
+  protocolVersion: ProtocolVersion;
 }
 
 export abstract class IdentifiedSession extends CommonSession {
   readonly id: SessionId;
   readonly telemetry: TelemetryInfo;
   readonly to: TransportClientId;
-  readonly protocolVersion: string;
+  readonly protocolVersion: ProtocolVersion;
 
   /**
    * Index of the message we will send next (excluding handshake)

--- a/transport/sessionStateMachine/transitions.ts
+++ b/transport/sessionStateMachine/transitions.ts
@@ -34,6 +34,7 @@ import {
   SessionBackingOff,
   SessionBackingOffListeners,
 } from './SessionBackingOff';
+import { ProtocolVersion } from '../message';
 
 function inheritSharedSession(
   session: IdentifiedSession,
@@ -68,7 +69,7 @@ export const SessionStateGraph = {
       from: TransportClientId,
       listeners: SessionNoConnectionListeners,
       options: SessionOptions,
-      protocolVersion: string,
+      protocolVersion: ProtocolVersion,
       log?: Logger,
     ) => {
       const id = `session-${generateId()}`;
@@ -225,7 +226,7 @@ export const SessionStateGraph = {
       to: TransportClientId,
       propagationCtx: PropagationContext | undefined,
       listeners: SessionConnectedListeners,
-      protocolVersion: string,
+      protocolVersion: ProtocolVersion,
     ): SessionConnected<ConnType> => {
       const conn = pendingSession.conn;
       const { from, options } = pendingSession;

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -181,6 +181,10 @@ export abstract class Transport<ConnType extends Connection> {
     const activeSession = this.sessions.get(session.to);
     if (activeSession) {
       const msg = `attempt to create session for ${session.to} but active session (${activeSession.id}) already exists`;
+      this.log?.error(msg, {
+        ...session.loggingMetadata,
+        tags: ['invariant-violation'],
+      });
       throw new Error(msg);
     }
 
@@ -200,11 +204,19 @@ export abstract class Transport<ConnType extends Connection> {
     const activeSession = this.sessions.get(session.to);
     if (!activeSession) {
       const msg = `attempt to transition session for ${session.to} but no active session exists`;
+      this.log?.error(msg, {
+        ...session.loggingMetadata,
+        tags: ['invariant-violation'],
+      });
       throw new Error(msg);
     }
 
     if (activeSession.id !== session.id) {
       const msg = `attempt to transition active session for ${session.to} but active session (${activeSession.id}) is different from handle (${session.id})`;
+      this.log?.error(msg, {
+        ...session.loggingMetadata,
+        tags: ['invariant-violation'],
+      });
       throw new Error(msg);
     }
 

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -318,10 +318,18 @@ export abstract class Transport<ConnType extends Connection> {
 
     return (msg: PartialTransportMessage) => {
       const session = this.sessions.get(to);
-      if (!session) return;
+      if (!session) {
+        throw new Error(
+          `session scope for ${sessionId} has ended (close), can't send`,
+        );
+      }
 
       const sameSession = session.id === sessionId;
-      if (!sameSession) return;
+      if (!sameSession) {
+        throw new Error(
+          `session scope for ${sessionId} has ended (transition), can't send`,
+        );
+      }
 
       return session.send(msg);
     };

--- a/util/testHelpers.ts
+++ b/util/testHelpers.ts
@@ -1,13 +1,7 @@
 import NodeWs, { WebSocketServer } from 'ws';
 import http from 'node:http';
-import { Err, Ok, Result, BaseErrorSchemaType } from '../router/result';
-import {
-  ProcedureErrorSchemaType,
-  ReaderErrorSchema,
-  UNCAUGHT_ERROR_CODE,
-  PayloadType,
-  Procedure,
-} from '../router/procedures';
+import { Err, Ok, Result } from '../router/result';
+import { PayloadType, Procedure } from '../router/procedures';
 import { Static } from '@sinclair/typebox';
 import {
   OpaqueTransportMessage,
@@ -37,6 +31,12 @@ import {
   SessionStateGraph,
 } from '../transport/sessionStateMachine/transitions';
 import { ClientTransport, ServerTransport } from '../transport';
+import {
+  BaseErrorSchemaType,
+  ProcedureErrorSchemaType,
+  ReaderErrorSchema,
+  UNCAUGHT_ERROR_CODE,
+} from '../router/errors';
 
 /**
  * Creates a WebSocket client that connects to a local server at the specified port.

--- a/util/testHelpers.ts
+++ b/util/testHelpers.ts
@@ -211,7 +211,10 @@ export function getClientSendFn(
   clientTransport: ClientTransport<Connection>,
   serverTransport: ServerTransport<Connection>,
 ) {
-  const session = clientTransport._getOrCreateSession(serverTransport.clientId);
+  const session =
+    clientTransport.sessions.get(serverTransport.clientId) ??
+    clientTransport.createUnconnectedSession(serverTransport.clientId);
+
   return clientTransport.getSessionBoundSendFn(
     serverTransport.clientId,
     session.id,

--- a/util/testHelpers.ts
+++ b/util/testHelpers.ts
@@ -211,7 +211,7 @@ export function getClientSendFn(
   clientTransport: ClientTransport<Connection>,
   serverTransport: ServerTransport<Connection>,
 ) {
-  const session = clientTransport.getOrCreateSession(serverTransport.clientId);
+  const session = clientTransport._getOrCreateSession(serverTransport.clientId);
   return clientTransport.getSessionBoundSendFn(
     serverTransport.clientId,
     session.id,


### PR DESCRIPTION
## Why

Cleanup and things :)

- `send` was disjoint from sessions, meaning you could accidentally have a stale handle to a send (via maybe pushing to a stream) that would push after a session has ended


<!-- Describe what you are trying to accomplish with this pull request -->

## What changed

- Scope send to a single session (`.send` on transport is now `.getSessionBoundSendFn` and, as the name suggests, returns a closure that sends along a single session)
- Don't allow nested unions in the error type, instead provide a helper to flatten a nested union to a single-level union to make codegen less complicated
- Track ProcStream explicitly again
- Server dispatches to streams rather than having each stream register a listener on the transport
  - The old approach involved dispatching to $n$ listeners per message (where $n$ is the number of streams, this can get unwieldy in a world where we have many concurrent streams)
  - New approach only has a single dispatch per message
- Made LRUSet generic for shits and giggles
- `Writable` constructor now takes an object of callbacks rather than two unnamed params for readability
- Add tests
  - cancellation after transport close
  - 

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
