### PR TITLE
log uncaught errors in handlers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.200.1",
+  "version": "0.200.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.200.1",
+      "version": "0.200.2",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",
@@ -18,7 +18,6 @@
         "@opentelemetry/sdk-trace-base": "^1.24.1",
         "@opentelemetry/sdk-trace-web": "^1.24.1",
         "@stylistic/eslint-plugin": "^2.6.4",
-        "@stylistic/eslint-plugin-ts": "^2.6.4",
         "@types/ws": "^8.5.5",
         "@typescript-eslint/eslint-plugin": "^7.8.0",
         "@typescript-eslint/parser": "^7.8.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.200.1",
+  "version": "0.200.2",
   "type": "module",
   "exports": {
     ".": {

--- a/router/server.ts
+++ b/router/server.ts
@@ -509,6 +509,10 @@ class RiverServer<Services extends AnyServiceSchemaMap>
         `${serviceName}.${procedureName} handler threw an uncaught error`,
         {
           ...loggingMetadata,
+          transportMessage: {
+            procedureName,
+            serviceName,
+          },
           extras: {
             error: errorMsg,
           },

--- a/router/server.ts
+++ b/router/server.ts
@@ -505,6 +505,16 @@ class RiverServer<Services extends AnyServiceSchemaMap>
       span.recordException(err instanceof Error ? err : new Error(errorMsg));
       span.setStatus({ code: SpanStatusCode.ERROR });
 
+      this.log?.error(
+        `${serviceName}.${procedureName} handler threw an uncaught error`,
+        {
+          ...loggingMetadata,
+          extras: {
+            error: errorMsg,
+          },
+        },
+      );
+
       onServerCancel({
         code: UNCAUGHT_ERROR_CODE,
         message: errorMsg,
@@ -518,10 +528,7 @@ class RiverServer<Services extends AnyServiceSchemaMap>
     } else if (procedure.type === 'rpc' || procedure.type === 'subscription') {
       // Though things can work just fine if they eventually follow up with a stream
       // control message with a close bit set, it's an unusual client implementation!
-      this.log?.warn('sent an init without a stream close', {
-        ...loggingMetadata,
-        clientId: this.transport.clientId,
-      });
+      this.log?.warn('sent an init without a stream close', loggingMetadata);
     }
 
     const handlerContext: ProcedureHandlerContext<object> = {


### PR DESCRIPTION
## Why

having o11y into why procedures died unexpectedly is good, we used to have this but lost it in the migration

## What changed

re-log errors in procs

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
