### PR TITLE
Fix readable losing error types

### DIFF
--- a/__tests__/typescript-stress.test.ts
+++ b/__tests__/typescript-stress.test.ts
@@ -20,6 +20,7 @@ import {
   createServerHandshakeOptions,
 } from '../router/handshake';
 import { flattenErrorType, ProcedureErrorSchemaType } from '../router/errors';
+import { ReadableImpl } from '../router/streams';
 
 const requestData = Type.Union([
   Type.Object({ a: Type.Number() }),
@@ -605,5 +606,31 @@ describe('Procedure error schema', () => {
         ]),
       );
     });
+  });
+});
+
+describe('Readable types', () => {
+  // Skip, we're only testing types
+  test.skip('should maintain result types', async () => {
+    function acceptsErrors(_code: 'SOME_ERROR' | 'READABLE_BROKEN') {
+      // pass
+    }
+
+    function acceptsSuccess(_success: 'SUCCESS') {
+      // pass
+    }
+
+    const readable = new ReadableImpl<
+      'SUCCESS',
+      { code: 'SOME_ERROR'; message: string }
+    >();
+    for await (const value of readable) {
+      if (value.ok) {
+        acceptsSuccess(value.payload);
+        continue;
+      }
+
+      acceptsErrors(value.payload.code);
+    }
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.200.2",
+  "version": "0.200.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.200.2",
+      "version": "0.200.3",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.200.2",
+  "version": "0.200.3",
   "type": "module",
   "exports": {
     ".": {

--- a/router/streams.ts
+++ b/router/streams.ts
@@ -183,7 +183,7 @@ export class ReadableImpl<T, E extends Static<BaseErrorSchemaType>>
    */
   private next: PromiseWithResolvers<void> | null = null;
 
-  public [Symbol.asyncIterator](): ReadableIterator<T, E> {
+  public [Symbol.asyncIterator]() {
     if (this.locked) {
       throw new TypeError('Readable is already locked');
     }

--- a/router/streams.ts
+++ b/router/streams.ts
@@ -2,10 +2,10 @@ import { Static } from '@sinclair/typebox';
 import { Err, Result } from './result';
 import { BaseErrorSchemaType } from './errors';
 
-export const ReadableBrokenError: Static<BaseErrorSchemaType> = {
+export const ReadableBrokenError = {
   code: 'READABLE_BROKEN',
   message: 'Readable was broken before it is fully consumed',
-} as const;
+} as const satisfies Static<BaseErrorSchemaType>;
 
 /**
  * Similar to {@link Result} but with an extra error to handle cases where {@link Readable.break} is called
@@ -183,7 +183,7 @@ export class ReadableImpl<T, E extends Static<BaseErrorSchemaType>>
    */
   private next: PromiseWithResolvers<void> | null = null;
 
-  public [Symbol.asyncIterator]() {
+  public [Symbol.asyncIterator](): ReadableIterator<T, E> {
     if (this.locked) {
       throw new TypeError('Readable is already locked');
     }


### PR DESCRIPTION
## Why

Readable was losing error types

## What changed

Removed type annotation from `ReadableBrokenError` and replaced it with `satisfies`, since it seems like even with `as const` it follows the generalized annotation.

## Versioning

- [ ] Breaking protocol change
- [x] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
