### PR TITLE
Add a special logging tag to uncaught handler exceptions

### DIFF
--- a/logging/log.ts
+++ b/logging/log.ts
@@ -22,7 +22,8 @@ export type Tags =
   | 'invariant-violation'
   | 'state-transition'
   | 'invalid-request'
-  | 'unhealthy-session';
+  | 'unhealthy-session'
+  | 'uncaught-handler-error';
 
 const cleanedLogFn = (log: LogFn) => {
   return (msg: string, metadata?: MessageMetadata) => {
@@ -53,7 +54,7 @@ export type MessageMetadata = Partial<{
     traceId: string;
     spanId: string;
   };
-  extras: unknown;
+  extras?: Record<string, unknown>;
 }>;
 
 export class BaseLogger implements Logger {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.200.3",
+  "version": "0.200.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.200.3",
+      "version": "0.200.4",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.200.3",
+  "version": "0.200.4",
   "type": "module",
   "exports": {
     ".": {

--- a/router/server.ts
+++ b/router/server.ts
@@ -515,7 +515,9 @@ class RiverServer<Services extends AnyServiceSchemaMap>
           },
           extras: {
             error: errorMsg,
+            originalException: err,
           },
+          tags: ['uncaught-handler-error'],
         },
       );
 

--- a/transport/impls/ws/connection.ts
+++ b/transport/impls/ws/connection.ts
@@ -1,8 +1,8 @@
 import { Connection } from '../../connection';
 import { WsLike } from './wslike';
 
-interface ConnectionInfoExtras {
-  headers: Record<string, string>;
+interface ConnectionInfoExtras extends Record<string, unknown> {
+  headers: Record<string, unknown>;
 }
 
 const WS_HEALTHY_CLOSE_CODE = 1000;

--- a/transport/impls/ws/connection.ts
+++ b/transport/impls/ws/connection.ts
@@ -2,7 +2,7 @@ import { Connection } from '../../connection';
 import { WsLike } from './wslike';
 
 interface ConnectionInfoExtras extends Record<string, unknown> {
-  headers: Record<string, unknown>;
+  headers: Record<string, string>;
 }
 
 const WS_HEALTHY_CLOSE_CODE = 1000;


### PR DESCRIPTION
## Why

We want to pipe uncaught errors in handlers to Sentry, we think it's ok to do that via the logger as opposed to having a special error callback.

## What changed

- Add tag `uncaught-handler-error`
- Include `originalException` in `extras` (for proper stack traces)
- Change `extras` in logs from `unknown` to an optional `Record<string, unknown>` (we're using it that way anyway, just makes it easier to handle)

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
