### PR TITLE
Log malformed message contents in base64

### DIFF
--- a/transport/sessionStateMachine/common.ts
+++ b/transport/sessionStateMachine/common.ts
@@ -160,9 +160,8 @@ export abstract class CommonSession extends StateMachineState {
     const parsedMsg = this.options.codec.fromBuffer(msg);
 
     if (parsedMsg === null) {
-      const decodedBuffer = new TextDecoder().decode(Buffer.from(msg));
       this.log?.error(
-        `received malformed msg: ${decodedBuffer}`,
+        `received malformed msg: ${Buffer.from(msg).toString('base64')}`,
         this.loggingMetadata,
       );
 
@@ -170,12 +169,15 @@ export abstract class CommonSession extends StateMachineState {
     }
 
     if (!Value.Check(OpaqueTransportMessageSchema, parsedMsg)) {
-      this.log?.error(`received invalid msg: ${JSON.stringify(parsedMsg)}`, {
-        ...this.loggingMetadata,
-        validationErrors: [
-          ...Value.Errors(OpaqueTransportMessageSchema, parsedMsg),
-        ],
-      });
+      this.log?.error(
+        `received invalid msg: ${Buffer.from(msg).toString('base64')}`,
+        {
+          ...this.loggingMetadata,
+          validationErrors: [
+            ...Value.Errors(OpaqueTransportMessageSchema, parsedMsg),
+          ],
+        },
+      );
 
       return null;
     }

--- a/transport/sessionStateMachine/common.ts
+++ b/transport/sessionStateMachine/common.ts
@@ -169,15 +169,12 @@ export abstract class CommonSession extends StateMachineState {
     }
 
     if (!Value.Check(OpaqueTransportMessageSchema, parsedMsg)) {
-      this.log?.error(
-        `received invalid msg: ${Buffer.from(msg).toString('base64')}`,
-        {
-          ...this.loggingMetadata,
-          validationErrors: [
-            ...Value.Errors(OpaqueTransportMessageSchema, parsedMsg),
-          ],
-        },
-      );
+      this.log?.error(`received invalid msg: ${JSON.stringify(parsedMsg)}`, {
+        ...this.loggingMetadata,
+        validationErrors: [
+          ...Value.Errors(OpaqueTransportMessageSchema, parsedMsg),
+        ],
+      });
 
       return null;
     }


### PR DESCRIPTION
## Why

Noticed a number of malformed message contents in DD https://us5.datadoghq.com/logs?query=%22received%20malformed%20msg%22%20%40environment%3Aproduction&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice%2C%40riverTarget&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1726796110823&to_ts=1727400910823&live=true

However we are sending binary messages originally, so we can't tell what the original contents were once its decoded to a string. We can base64 encode the buffer and then reverse it when trying to debug what is going wrong with these messages 

<!-- Describe what you are trying to accomplish with this pull request -->

## What changed

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
