### PR TITLE
make ReadableIterator an async iterable iterator

### DIFF
--- a/__tests__/streams.test.ts
+++ b/__tests__/streams.test.ts
@@ -200,6 +200,25 @@ describe('Readable unit', () => {
     expect(values).toEqual([1, 2].map(Ok));
   });
 
+  it('should allow calling next and then turning it into an asyncIterator', async () => {
+    const readable = new ReadableImpl<number, SomeError>();
+    const iterator = readable[Symbol.asyncIterator]();
+    const next = iterator.next();
+    readable._pushValue(Ok(1));
+    readable._pushValue(Ok(2));
+    readable._pushValue(Ok(3));
+    readable._triggerClose();
+    expect(await next).toEqual({ value: Ok(1), done: false });
+
+    let i = 0;
+    for await (const value of iterator) {
+      expect(value).toEqual(Ok(i + 2));
+      i++;
+    }
+
+    expect(await iterator.next()).toEqual({ value: undefined, done: true });
+  });
+
   it('should support for-await-of with break', async () => {
     const readable = new ReadableImpl<number, SomeError>();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.203.0",
+  "version": "0.203.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.203.0",
+      "version": "0.203.1",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.203.0",
+  "version": "0.203.1",
   "type": "module",
   "exports": {
     ".": {

--- a/router/streams.ts
+++ b/router/streams.ts
@@ -16,7 +16,7 @@ export type ReadableResult<T, E extends Static<BaseErrorSchemaType>> = Result<
 >;
 
 /**
- * A simple {@link AsyncIterator} used in {@link Readable}
+ * A simple {@link AsyncIterableIterator} used in {@link Readable}
  * that doesn't have a the extra "return" and "throw" methods, and
  * the doesn't have a "done value" (TReturn).
  */
@@ -31,6 +31,7 @@ export interface ReadableIterator<T, E extends Static<BaseErrorSchemaType>> {
         value: undefined;
       }
   >;
+  [Symbol.asyncIterator](): ReadableIterator<T, E>;
 }
 
 /**
@@ -246,6 +247,9 @@ export class ReadableImpl<T, E extends Static<BaseErrorSchemaType>>
         const value = this.queue.shift()!;
 
         return { done: false, value } as const;
+      },
+      [Symbol.asyncIterator]() {
+        return this;
       },
       return: () => {
         this.break();


### PR DESCRIPTION
## Why

<!-- Describe what you are trying to accomplish with this pull request -->

sometimes nice to be able to do `.next` and still be able to use the iterator in an `for await ... of` loop

## What changed

implement the trivial `Symbol.asyncIterator`

this still retains 'single reader' semantics, if you have two asyncIterators from a single readable, they will just compete for the next value (same as if you had two methods both calling `.next` on the resulting iterator)

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
