### PR TITLE
make handler spans more accurate, re-add connection span

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
         "ws": "^8.17.0"
       },
       "devDependencies": {
+        "@opentelemetry/context-async-hooks": "^1.26.0",
         "@opentelemetry/core": "^1.7.0",
         "@opentelemetry/sdk-trace-base": "^1.24.1",
-        "@opentelemetry/sdk-trace-web": "^1.24.1",
         "@stylistic/eslint-plugin": "^2.6.4",
         "@types/ws": "^8.5.5",
         "@typescript-eslint/eslint-plugin": "^7.8.0",
@@ -617,6 +617,18 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.26.0.tgz",
+      "integrity": "sha512-HedpXXYzzbaoutw6DFLWLDket2FwLkLpil4hGCZ1xYEIMTcivdfwEOISgdbLEWyG3HW52gTq2V9mOVJrONgiwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/core": {
       "version": "1.24.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
@@ -656,23 +668,6 @@
       "dependencies": {
         "@opentelemetry/core": "1.24.1",
         "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-web": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.24.1.tgz",
-      "integrity": "sha512-0w+aKRai9VREeo3VrtW+hcbrE2Fl/uKL7G+oXgRNf6pI9QLaEGuEzUTX+oxXVPBadzjOd+5dqCHYdX7UeVjzwA==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
         "@opentelemetry/semantic-conventions": "1.24.1"
       },
       "engines": {
@@ -4708,6 +4703,13 @@
       "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
       "peer": true
     },
+    "@opentelemetry/context-async-hooks": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.26.0.tgz",
+      "integrity": "sha512-HedpXXYzzbaoutw6DFLWLDket2FwLkLpil4hGCZ1xYEIMTcivdfwEOISgdbLEWyG3HW52gTq2V9mOVJrONgiwg==",
+      "dev": true,
+      "requires": {}
+    },
     "@opentelemetry/core": {
       "version": "1.24.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
@@ -4735,17 +4737,6 @@
       "requires": {
         "@opentelemetry/core": "1.24.1",
         "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1"
-      }
-    },
-    "@opentelemetry/sdk-trace-web": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.24.1.tgz",
-      "integrity": "sha512-0w+aKRai9VREeo3VrtW+hcbrE2Fl/uKL7G+oXgRNf6pI9QLaEGuEzUTX+oxXVPBadzjOd+5dqCHYdX7UeVjzwA==",
-      "dev": true,
-      "requires": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
         "@opentelemetry/semantic-conventions": "1.24.1"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.203.0",
+  "version": "0.203.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.203.0",
+      "version": "0.203.1",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -57,9 +57,9 @@
     "@sinclair/typebox": "~0.32.8"
   },
   "devDependencies": {
+    "@opentelemetry/context-async-hooks": "^1.26.0",
     "@opentelemetry/core": "^1.7.0",
     "@opentelemetry/sdk-trace-base": "^1.24.1",
-    "@opentelemetry/sdk-trace-web": "^1.24.1",
     "@stylistic/eslint-plugin": "^2.6.4",
     "@types/ws": "^8.5.5",
     "@typescript-eslint/eslint-plugin": "^7.8.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.203.0",
+  "version": "0.203.1",
   "type": "module",
   "exports": {
     ".": {

--- a/router/client.ts
+++ b/router/client.ts
@@ -535,7 +535,7 @@ function handleProc(
 
 /**
  * Waits for a message in the response AND the server to close.
- * Logs an error if we receive  multiple messages.
+ * Logs an error if we receive multiple messages.
  * Used in RPC and Upload.
  */
 async function getSingleMessage(

--- a/router/client.ts
+++ b/router/client.ts
@@ -288,7 +288,7 @@ function handleProc(
   const procClosesWithInit = procType === 'rpc' || procType === 'subscription';
   const streamId = generateId();
   const { span, ctx } = createProcTelemetryInfo(
-    transport,
+    session,
     procType,
     serviceName,
     procedureName,

--- a/router/server.ts
+++ b/router/server.ts
@@ -36,7 +36,7 @@ import { Value, ValueError } from '@sinclair/typebox/value';
 import { Err, Result, Ok, ErrResult } from './result';
 import { EventMap } from '../transport/events';
 import { coerceErrorString } from '../transport/stringifyError';
-import { Span, SpanStatusCode, context, trace } from '@opentelemetry/api';
+import { Span, SpanStatusCode } from '@opentelemetry/api';
 import { createHandlerSpan, PropagationContext } from '../tracing';
 import { ServerHandshakeOptions } from './handshake';
 import { Connection } from '../transport/connection';
@@ -73,8 +73,6 @@ export interface Server<Services extends AnyServiceSchemaMap> {
 
   close: () => Promise<void>;
 }
-
-type ProcHandlerReturn = Promise<(() => void) | void>;
 
 interface StreamInitProps {
   // msg derived
@@ -199,10 +197,19 @@ class RiverServer<Services extends AnyServiceSchemaMap>
       }
 
       // if its not a cancelled stream, validate and create a new stream
-      this.createNewProcStream({
-        ...newStreamProps,
-        ...message,
-      });
+      createHandlerSpan(
+        newStreamProps.procedure.type,
+        newStreamProps.serviceName,
+        newStreamProps.procedureName,
+        newStreamProps.streamId,
+        newStreamProps.tracingCtx,
+        (span) => {
+          this.createNewProcStream(span, {
+            ...newStreamProps,
+            ...message,
+          });
+        },
+      );
     };
 
     const handleSessionStatus = (evt: EventMap['sessionStatus']) => {
@@ -241,7 +248,7 @@ class RiverServer<Services extends AnyServiceSchemaMap>
     this.transport.addEventListener('transportStatus', handleTransportStatus);
   }
 
-  private createNewProcStream(props: StreamInitProps) {
+  private createNewProcStream(span: Span, props: StreamInitProps) {
     const {
       streamId,
       initialSession,
@@ -251,7 +258,6 @@ class RiverServer<Services extends AnyServiceSchemaMap>
       sessionMetadata,
       serviceContext,
       initPayload,
-      tracingCtx,
       procClosesWithInit,
       passInitAsDataForBackwardsCompat,
     } = props;
@@ -262,6 +268,12 @@ class RiverServer<Services extends AnyServiceSchemaMap>
       protocolVersion,
       id: sessionId,
     } = initialSession;
+
+    // dont use the session span here, we want to create a new span for the procedure
+    loggingMetadata.telemetry = {
+      traceId: span.spanContext().traceId,
+      spanId: span.spanContext().spanId,
+    };
 
     let cleanClose = true;
     const onMessage = (msg: OpaqueTransportMessage) => {
@@ -558,108 +570,78 @@ class RiverServer<Services extends AnyServiceSchemaMap>
 
     switch (procedure.type) {
       case 'rpc':
-        void createHandlerSpan(
-          procedure.type,
-          serviceName,
-          procedureName,
-          streamId,
-          tracingCtx,
-          async (span): ProcHandlerReturn => {
-            try {
-              const responsePayload = await procedure.handler({
-                ctx: handlerContextWithSpan(span),
-                reqInit: initPayload,
-              });
+        void (async () => {
+          try {
+            const responsePayload = await procedure.handler({
+              ctx: handlerContextWithSpan(span),
+              reqInit: initPayload,
+            });
 
-              if (resWritable.isClosed()) {
-                // A disconnect happened
-                return;
-              }
-
-              resWritable.write(responsePayload);
-            } catch (err) {
-              onHandlerError(err, span);
-            } finally {
-              span.end();
+            if (resWritable.isClosed()) {
+              // A disconnect happened
+              return;
             }
-          },
-        );
+
+            resWritable.write(responsePayload);
+          } catch (err) {
+            onHandlerError(err, span);
+          } finally {
+            span.end();
+          }
+        })();
         break;
       case 'stream':
-        void createHandlerSpan(
-          procedure.type,
-          serviceName,
-          procedureName,
-          streamId,
-          tracingCtx,
-          async (span): ProcHandlerReturn => {
-            try {
-              await procedure.handler({
-                ctx: handlerContextWithSpan(span),
-                reqInit: initPayload,
-                reqReadable,
-                resWritable,
-              });
-            } catch (err) {
-              onHandlerError(err, span);
-            } finally {
-              span.end();
-            }
-          },
-        );
-
+        void (async () => {
+          try {
+            await procedure.handler({
+              ctx: handlerContextWithSpan(span),
+              reqInit: initPayload,
+              reqReadable,
+              resWritable,
+            });
+          } catch (err) {
+            onHandlerError(err, span);
+          } finally {
+            span.end();
+          }
+        })();
         break;
       case 'subscription':
-        void createHandlerSpan(
-          procedure.type,
-          serviceName,
-          procedureName,
-          streamId,
-          tracingCtx,
-          async (span): ProcHandlerReturn => {
-            try {
-              await procedure.handler({
-                ctx: handlerContextWithSpan(span),
-                reqInit: initPayload,
-                resWritable: resWritable,
-              });
-            } catch (err) {
-              onHandlerError(err, span);
-            } finally {
-              span.end();
-            }
-          },
-        );
+        void (async () => {
+          try {
+            await procedure.handler({
+              ctx: handlerContextWithSpan(span),
+              reqInit: initPayload,
+              resWritable: resWritable,
+            });
+          } catch (err) {
+            onHandlerError(err, span);
+          } finally {
+            span.end();
+          }
+        })();
         break;
       case 'upload':
-        void createHandlerSpan(
-          procedure.type,
-          serviceName,
-          procedureName,
-          streamId,
-          tracingCtx,
-          async (span): ProcHandlerReturn => {
-            try {
-              const responsePayload = await procedure.handler({
-                ctx: handlerContextWithSpan(span),
-                reqInit: initPayload,
-                reqReadable: reqReadable,
-              });
+        void (async () => {
+          try {
+            const responsePayload = await procedure.handler({
+              ctx: handlerContextWithSpan(span),
+              reqInit: initPayload,
+              reqReadable: reqReadable,
+            });
 
-              if (resWritable.isClosed()) {
-                // A disconnect happened
-                return;
-              }
-
-              resWritable.write(responsePayload);
-            } catch (err) {
-              onHandlerError(err, span);
-            } finally {
-              span.end();
+            if (resWritable.isClosed()) {
+              // A disconnect happened
+              return;
             }
-          },
-        );
 
+            resWritable.write(responsePayload);
+          } catch (err) {
+            onHandlerError(err, span);
+          } finally {
+            span.end();
+          }
+        })();
         break;
     }
 

--- a/router/server.ts
+++ b/router/server.ts
@@ -36,7 +36,7 @@ import { Value, ValueError } from '@sinclair/typebox/value';
 import { Err, Result, Ok, ErrResult } from './result';
 import { EventMap } from '../transport/events';
 import { coerceErrorString } from '../transport/stringifyError';
-import { Span, SpanStatusCode } from '@opentelemetry/api';
+import { Span, SpanStatusCode, context, trace } from '@opentelemetry/api';
 import { createHandlerSpan, PropagationContext } from '../tracing';
 import { ServerHandshakeOptions } from './handshake';
 import { Connection } from '../transport/connection';

--- a/router/server.ts
+++ b/router/server.ts
@@ -198,16 +198,14 @@ class RiverServer<Services extends AnyServiceSchemaMap>
 
       // if its not a cancelled stream, validate and create a new stream
       createHandlerSpan(
+        newStreamProps.initialSession,
         newStreamProps.procedure.type,
         newStreamProps.serviceName,
         newStreamProps.procedureName,
         newStreamProps.streamId,
         newStreamProps.tracingCtx,
         (span) => {
-          this.createNewProcStream(span, {
-            ...newStreamProps,
-            ...message,
-          });
+          this.createNewProcStream(span, newStreamProps);
         },
       );
     };

--- a/tracing/index.ts
+++ b/tracing/index.ts
@@ -9,6 +9,7 @@ import {
 import { version as RIVER_VERSION } from '../package.json';
 import { ValidProcType } from '../router';
 import { ClientTransport, Connection } from '../transport';
+import { MessageMetadata } from '../logging';
 
 export interface PropagationContext {
   traceparent: string;
@@ -106,18 +107,15 @@ export function createProcTelemetryInfo(
   );
 
   const ctx = trace.setSpan(baseCtx, span);
-
-  transport.log?.info(`invoked ${serviceName}.${procedureName}`, {
+  const metadata: MessageMetadata = {
     clientId: transport.clientId,
     transportMessage: {
       procedureName,
       serviceName,
     },
-    telemetry: {
-      traceId: span.spanContext().traceId,
-      spanId: span.spanContext().spanId,
-    },
-  });
+  };
+
+  transport.log?.info(`invoked ${serviceName}.${procedureName}`, metadata);
 
   return { span, ctx };
 }

--- a/tracing/index.ts
+++ b/tracing/index.ts
@@ -11,6 +11,7 @@ import { ValidProcType } from '../router';
 import { Connection } from '../transport';
 import { MessageMetadata } from '../logging';
 import { ClientSession } from '../transport/sessionStateMachine/transitions';
+import { IdentifiedSession } from '../transport/sessionStateMachine/common';
 
 export interface PropagationContext {
   traceparent: string;
@@ -102,6 +103,7 @@ export function createProcTelemetryInfo(
         'river.streamId': streamId,
         'span.kind': 'client',
       },
+      links: [{ context: session.telemetry.span.spanContext() }],
       kind: SpanKind.CLIENT,
     },
     baseCtx,
@@ -129,6 +131,7 @@ export function createProcTelemetryInfo(
 }
 
 export function createHandlerSpan<Fn extends (span: Span) => unknown>(
+  session: IdentifiedSession,
   kind: ValidProcType,
   serviceName: string,
   procedureName: string,
@@ -151,6 +154,7 @@ export function createHandlerSpan<Fn extends (span: Span) => unknown>(
         'river.streamId': streamId,
         'span.kind': 'server',
       },
+      links: [{ context: session.telemetry.span.spanContext() }],
       kind: SpanKind.SERVER,
     },
     ctx,

--- a/tracing/tracing.test.ts
+++ b/tracing/tracing.test.ts
@@ -12,7 +12,6 @@ import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import tracer, {
   createSessionTelemetryInfo,
   getPropagationContext,
-  createHandlerSpan,
 } from './index';
 import { testMatrix } from '../testUtil/fixtures/matrix';
 import {
@@ -61,29 +60,6 @@ describe('Basic tracing tests', () => {
         Symbol.for('OpenTelemetry Context Key SPAN'),
       ) as Span,
     ).toBeTruthy();
-  });
-
-  test('createHandlerSpan', () => {
-    const parentCtx = context.active();
-    const span = tracer.startSpan('testing span', {}, parentCtx);
-    const ctx = trace.setSpan(parentCtx, span);
-
-    const propagationContext = getPropagationContext(ctx);
-    expect(propagationContext?.traceparent).toBeTruthy();
-
-    const handlerMock = vi.fn<(span: Span) => void>();
-    createHandlerSpan(
-      'rpc',
-      'myservice',
-      'myprocedure',
-      'mystream',
-      propagationContext,
-      handlerMock,
-    );
-    expect(handlerMock).toHaveBeenCalledTimes(1);
-    const createdSpan = handlerMock.mock.calls[0][0];
-    // @ts-expect-error: hacking to get parentSpanId
-    expect(createdSpan.parentSpanId).toBe(span.spanContext().spanId);
   });
 });
 

--- a/transport/connection.ts
+++ b/transport/connection.ts
@@ -17,7 +17,17 @@ export abstract class Connection {
   }
 
   get loggingMetadata(): MessageMetadata {
-    return { connId: this.id };
+    const metadata: MessageMetadata = { connId: this.id };
+
+    if (this.telemetry?.span.isRecording()) {
+      const spanContext = this.telemetry.span.spanContext();
+      metadata.telemetry = {
+        traceId: spanContext.traceId,
+        spanId: spanContext.spanId,
+      };
+    }
+
+    return metadata;
   }
 
   // can't use event emitter because we need this to work in both node + browser

--- a/transport/connection.ts
+++ b/transport/connection.ts
@@ -17,17 +17,7 @@ export abstract class Connection {
   }
 
   get loggingMetadata(): MessageMetadata {
-    const metadata: MessageMetadata = { connId: this.id };
-    const spanContext = this.telemetry?.span.spanContext();
-
-    if (this.telemetry?.span.isRecording() && spanContext) {
-      metadata.telemetry = {
-        traceId: spanContext.traceId,
-        spanId: spanContext.spanId,
-      };
-    }
-
-    return metadata;
+    return { connId: this.id };
   }
 
   // can't use event emitter because we need this to work in both node + browser

--- a/transport/sessionStateMachine/common.ts
+++ b/transport/sessionStateMachine/common.ts
@@ -247,6 +247,14 @@ export abstract class IdentifiedSession extends CommonSession {
       sessionId: this.id,
     };
 
+    if (this.telemetry.span.isRecording()) {
+      const spanContext = this.telemetry.span.spanContext();
+      metadata.telemetry = {
+        traceId: spanContext.traceId,
+        spanId: spanContext.spanId,
+      };
+    }
+
     return metadata;
   }
 

--- a/transport/sessionStateMachine/common.ts
+++ b/transport/sessionStateMachine/common.ts
@@ -241,20 +241,11 @@ export abstract class IdentifiedSession extends CommonSession {
   }
 
   get loggingMetadata(): MessageMetadata {
-    const spanContext = this.telemetry.span.spanContext();
-
     const metadata: MessageMetadata = {
       clientId: this.from,
       connectedTo: this.to,
       sessionId: this.id,
     };
-
-    if (this.telemetry.span.isRecording()) {
-      metadata.telemetry = {
-        traceId: spanContext.traceId,
-        spanId: spanContext.spanId,
-      };
-    }
 
     return metadata;
   }

--- a/transport/sessionStateMachine/transitions.ts
+++ b/transport/sessionStateMachine/transitions.ts
@@ -14,7 +14,7 @@ import {
   IdentifiedSessionWithGracePeriodProps,
   SessionOptions,
 } from './common';
-import { PropagationContext, createSessionTelemetryInfo } from '../../tracing';
+import { PropagationContext, createConnectionTelemetryInfo, createSessionTelemetryInfo } from '../../tracing';
 import {
   SessionWaitingForHandshake,
   SessionWaitingForHandshakeListeners,
@@ -187,6 +187,7 @@ export const SessionStateGraph = {
         ...carriedState,
       });
 
+      conn.telemetry = createConnectionTelemetryInfo(conn, session.telemetry);
       session.log?.info(
         `session ${session.id} transition from Connecting to Handshaking`,
         {
@@ -262,6 +263,8 @@ export const SessionStateGraph = {
         listeners,
         ...carriedState,
       });
+
+      conn.telemetry = createConnectionTelemetryInfo(conn, session.telemetry);
       session.log?.info(
         `session ${session.id} transition from WaitingForHandshake to Connected`,
         {

--- a/transport/sessionStateMachine/transitions.ts
+++ b/transport/sessionStateMachine/transitions.ts
@@ -14,7 +14,11 @@ import {
   IdentifiedSessionWithGracePeriodProps,
   SessionOptions,
 } from './common';
-import { PropagationContext, createConnectionTelemetryInfo, createSessionTelemetryInfo } from '../../tracing';
+import {
+  PropagationContext,
+  createConnectionTelemetryInfo,
+  createSessionTelemetryInfo,
+} from '../../tracing';
 import {
   SessionWaitingForHandshake,
   SessionWaitingForHandshakeListeners,


### PR DESCRIPTION
## Why

- a lot of proc handler specific log messages didnt get picked up by the right tracer
- move proc stream <> handler proxy messages into the handler span
- move the invoked message into the client handler span
- re-add connection telemetry
- span linking between procs/handlers and their originating sessions
- we use https://www.npmjs.com/package/@opentelemetry/context-async-hooks so context is tracked safely in an async context so we should leverage that

## What changed


<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
