### PR TITLE
Encode messages before storing in send buffer

### DIFF
--- a/testUtil/fixtures/cleanup.ts
+++ b/testUtil/fixtures/cleanup.ts
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { assert, expect, vi } from 'vitest';
 import {
   ClientTransport,
   Connection,
@@ -68,9 +68,16 @@ export async function ensureTransportBuffersAreEventuallyEmpty(
         [...t.sessions]
           .map(([client, sess]) => {
             // get all messages that are not heartbeats
-            const buff = sess.sendBuffer.filter((msg) => {
-              return !Value.Check(ControlMessageAckSchema, msg.payload);
-            });
+            const buff = sess.sendBuffer
+              .map((encodedMsg) => {
+                const msg = sess.parseMsg(encodedMsg.data);
+                assert(msg);
+
+                return msg;
+              })
+              .filter(
+                (msg) => !Value.Check(ControlMessageAckSchema, msg.payload),
+              );
 
             return [client, buff] as [
               string,

--- a/transport/message.ts
+++ b/transport/message.ts
@@ -281,6 +281,17 @@ export type OpaqueTransportMessage = TransportMessage;
 export type TransportClientId = string;
 
 /**
+ * An encoded message that is ready to be send over the transport.
+ * The seq number is kept to keep track of which messages have been
+ * acked by the peer.
+ */
+export interface EncodedTransportMessage {
+  id: string;
+  seq: number;
+  data: Uint8Array;
+}
+
+/**
  * Checks if the given control flag (usually found in msg.controlFlag) is an ack message.
  * @param controlFlag - The control flag to check.
  * @returns True if the control flag contains the AckBit, false otherwise.

--- a/transport/sessionStateMachine/SessionConnected.ts
+++ b/transport/sessionStateMachine/SessionConnected.ts
@@ -49,11 +49,11 @@ export class SessionConnected<
   }
 
   send(msg: PartialTransportMessage): string {
-    const constructedMsg = this.constructMsg(msg);
-    this.sendBuffer.push(constructedMsg);
-    this.conn.send(this.options.codec.toBuffer(constructedMsg));
+    const encodedMsg = this.encodeMsg(msg);
+    this.sendBuffer.push(encodedMsg);
+    this.conn.send(encodedMsg.data);
 
-    return constructedMsg.id;
+    return encodedMsg.id;
   }
 
   constructor(props: SessionConnectedProps<ConnType>) {
@@ -75,7 +75,7 @@ export class SessionConnected<
       );
 
       for (const msg of this.sendBuffer) {
-        this.conn.send(this.options.codec.toBuffer(msg));
+        this.conn.send(msg.data);
       }
     }
 

--- a/transport/sessionStateMachine/stateMachine.test.ts
+++ b/transport/sessionStateMachine/stateMachine.test.ts
@@ -1891,8 +1891,8 @@ describe('session state machine', () => {
       expect(onConnectionClosed).not.toHaveBeenCalled();
       expect(onConnectionErrored).not.toHaveBeenCalled();
 
-      const msg = session.constructMsg(payloadToTransportMessage('hello'));
-      session.conn.emitData(session.options.codec.toBuffer(msg));
+      const msg = session.encodeMsg(payloadToTransportMessage('hello'));
+      session.conn.emitData(msg.data);
 
       await waitFor(async () => {
         expect(onMessage).toHaveBeenCalledTimes(1);
@@ -1940,15 +1940,13 @@ describe('session state machine', () => {
 
       // send a heartbeat
       conn.emitData(
-        session.options.codec.toBuffer(
-          session.constructMsg({
-            streamId: 'heartbeat',
-            controlFlags: ControlFlags.AckBit,
-            payload: {
-              type: 'ACK',
-            } satisfies Static<typeof ControlMessageAckSchema>,
-          }),
-        ),
+        session.encodeMsg({
+          streamId: 'heartbeat',
+          controlFlags: ControlFlags.AckBit,
+          payload: {
+            type: 'ACK',
+          } satisfies Static<typeof ControlMessageAckSchema>,
+        }).data,
       );
 
       // make sure the session acks the heartbeat
@@ -1962,15 +1960,13 @@ describe('session state machine', () => {
 
       // send a heartbeat
       conn.emitData(
-        session.options.codec.toBuffer(
-          session.constructMsg({
-            streamId: 'heartbeat',
-            controlFlags: ControlFlags.AckBit,
-            payload: {
-              type: 'ACK',
-            } satisfies Static<typeof ControlMessageAckSchema>,
-          }),
-        ),
+        session.encodeMsg({
+          streamId: 'heartbeat',
+          controlFlags: ControlFlags.AckBit,
+          payload: {
+            type: 'ACK',
+          } satisfies Static<typeof ControlMessageAckSchema>,
+        }).data,
       );
 
       expect(sessionHandle.onMessage).not.toHaveBeenCalled();

--- a/transport/sessionStateMachine/transitions.ts
+++ b/transport/sessionStateMachine/transitions.ts
@@ -1,4 +1,3 @@
-import { OpaqueTransportMessage, TransportClientId } from '..';
 import {
   SessionConnecting,
   SessionConnectingListeners,
@@ -38,7 +37,11 @@ import {
   SessionBackingOff,
   SessionBackingOffListeners,
 } from './SessionBackingOff';
-import { ProtocolVersion } from '../message';
+import {
+  EncodedTransportMessage,
+  ProtocolVersion,
+  TransportClientId,
+} from '../message';
 
 function inheritSharedSession(
   session: IdentifiedSession,
@@ -78,7 +81,7 @@ export const SessionStateGraph = {
     ) => {
       const id = `session-${generateId()}`;
       const telemetry = createSessionTelemetryInfo(id, to, from);
-      const sendBuffer: Array<OpaqueTransportMessage> = [];
+      const sendBuffer: Array<EncodedTransportMessage> = [];
 
       const session = new SessionNoConnection({
         listeners,

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -38,9 +38,7 @@ export interface DeleteSessionOptions {
   unhealthy: boolean;
 }
 
-export type SessionBoundSendFn = (
-  msg: PartialTransportMessage,
-) => string | undefined;
+export type SessionBoundSendFn = (msg: PartialTransportMessage) => string;
 
 /**
  * Transports manage the lifecycle (creation/deletion) of sessions


### PR DESCRIPTION
## Why

I want to start enforcing max payload size before we attempt to send the messages over the wire.

Ideally we can confine these errors to be per-stream so one bad RPC call doesn't explode the entire client.

As a pre-req, we need to check for the max payload size before accepting messages into the send buffer, which means we need to encode them first to figure out the full payload size.

An additional benefit is we only ever encode messages once rather than re-encoding every time we resend messages from the send buffer. Granted, this is probably not a path we hit very often.

## What changed

- Encode messages before storing them in the send buffer
    - We keep around the id / seq number since we do need to have access to these for some tests and for keeping track of which messages have been acked by the peer and can be dropped from the send buffer

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
