### PR TITLE
Enforce maximum payload size

### DIFF
--- a/__tests__/__snapshots__/serialize.test.ts.snap
+++ b/__tests__/__snapshots__/serialize.test.ts.snap
@@ -83,6 +83,22 @@ exports[`serialize server to jsonschema > serialize entire service schema 1`] = 
                 ],
                 "type": "object",
               },
+              {
+                "properties": {
+                  "code": {
+                    "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
+                    "type": "string",
+                  },
+                  "message": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "code",
+                  "message",
+                ],
+                "type": "object",
+              },
             ],
           },
           "init": {
@@ -176,6 +192,22 @@ exports[`serialize server to jsonschema > serialize entire service schema 1`] = 
                 ],
                 "type": "object",
               },
+              {
+                "properties": {
+                  "code": {
+                    "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
+                    "type": "string",
+                  },
+                  "message": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "code",
+                  "message",
+                ],
+                "type": "object",
+              },
             ],
           },
           "init": {
@@ -252,6 +284,22 @@ exports[`serialize server to jsonschema > serialize entire service schema 1`] = 
                 "properties": {
                   "code": {
                     "const": "CANCEL",
+                    "type": "string",
+                  },
+                  "message": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "code",
+                  "message",
+                ],
+                "type": "object",
+              },
+              {
+                "properties": {
+                  "code": {
+                    "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
                     "type": "string",
                   },
                   "message": {
@@ -356,6 +404,22 @@ exports[`serialize server to jsonschema > serialize entire service schema 1`] = 
                 ],
                 "type": "object",
               },
+              {
+                "properties": {
+                  "code": {
+                    "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
+                    "type": "string",
+                  },
+                  "message": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "code",
+                  "message",
+                ],
+                "type": "object",
+              },
             ],
           },
           "init": {
@@ -446,6 +510,22 @@ exports[`serialize server to jsonschema > serialize entire service schema 1`] = 
                 "properties": {
                   "code": {
                     "const": "CANCEL",
+                    "type": "string",
+                  },
+                  "message": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "code",
+                  "message",
+                ],
+                "type": "object",
+              },
+              {
+                "properties": {
+                  "code": {
+                    "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
                     "type": "string",
                   },
                   "message": {
@@ -589,6 +669,22 @@ exports[`serialize server to jsonschema > serialize entire service schema 1`] = 
                 ],
                 "type": "object",
               },
+              {
+                "properties": {
+                  "code": {
+                    "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
+                    "type": "string",
+                  },
+                  "message": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "code",
+                  "message",
+                ],
+                "type": "object",
+              },
             ],
           },
           "init": {
@@ -697,6 +793,22 @@ exports[`serialize server to jsonschema > serialize entire service schema 1`] = 
                 ],
                 "type": "object",
               },
+              {
+                "properties": {
+                  "code": {
+                    "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
+                    "type": "string",
+                  },
+                  "message": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "code",
+                  "message",
+                ],
+                "type": "object",
+              },
             ],
           },
           "init": {
@@ -764,6 +876,22 @@ exports[`serialize server to jsonschema > serialize entire service schema 1`] = 
                 "properties": {
                   "code": {
                     "const": "CANCEL",
+                    "type": "string",
+                  },
+                  "message": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "code",
+                  "message",
+                ],
+                "type": "object",
+              },
+              {
+                "properties": {
+                  "code": {
+                    "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
                     "type": "string",
                   },
                   "message": {
@@ -868,6 +996,22 @@ exports[`serialize service to jsonschema > serialize backwards compatible with v
             ],
             "type": "object",
           },
+          {
+            "properties": {
+              "code": {
+                "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
+                "type": "string",
+              },
+              "message": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "code",
+              "message",
+            ],
+            "type": "object",
+          },
         ],
       },
       "input": {
@@ -961,6 +1105,22 @@ exports[`serialize service to jsonschema > serialize backwards compatible with v
             ],
             "type": "object",
           },
+          {
+            "properties": {
+              "code": {
+                "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
+                "type": "string",
+              },
+              "message": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "code",
+              "message",
+            ],
+            "type": "object",
+          },
         ],
       },
       "input": {
@@ -1037,6 +1197,22 @@ exports[`serialize service to jsonschema > serialize backwards compatible with v
             "properties": {
               "code": {
                 "const": "CANCEL",
+                "type": "string",
+              },
+              "message": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "code",
+              "message",
+            ],
+            "type": "object",
+          },
+          {
+            "properties": {
+              "code": {
+                "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
                 "type": "string",
               },
               "message": {
@@ -1141,6 +1317,22 @@ exports[`serialize service to jsonschema > serialize backwards compatible with v
             ],
             "type": "object",
           },
+          {
+            "properties": {
+              "code": {
+                "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
+                "type": "string",
+              },
+              "message": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "code",
+              "message",
+            ],
+            "type": "object",
+          },
         ],
       },
       "init": {
@@ -1231,6 +1423,22 @@ exports[`serialize service to jsonschema > serialize backwards compatible with v
             "properties": {
               "code": {
                 "const": "CANCEL",
+                "type": "string",
+              },
+              "message": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "code",
+              "message",
+            ],
+            "type": "object",
+          },
+          {
+            "properties": {
+              "code": {
+                "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
                 "type": "string",
               },
               "message": {
@@ -1374,6 +1582,22 @@ exports[`serialize service to jsonschema > serialize backwards compatible with v
             ],
             "type": "object",
           },
+          {
+            "properties": {
+              "code": {
+                "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
+                "type": "string",
+              },
+              "message": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "code",
+              "message",
+            ],
+            "type": "object",
+          },
         ],
       },
       "init": {
@@ -1482,6 +1706,22 @@ exports[`serialize service to jsonschema > serialize backwards compatible with v
             ],
             "type": "object",
           },
+          {
+            "properties": {
+              "code": {
+                "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
+                "type": "string",
+              },
+              "message": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "code",
+              "message",
+            ],
+            "type": "object",
+          },
         ],
       },
       "input": {
@@ -1549,6 +1789,22 @@ exports[`serialize service to jsonschema > serialize backwards compatible with v
             "properties": {
               "code": {
                 "const": "CANCEL",
+                "type": "string",
+              },
+              "message": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "code",
+              "message",
+            ],
+            "type": "object",
+          },
+          {
+            "properties": {
+              "code": {
+                "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
                 "type": "string",
               },
               "message": {
@@ -1651,6 +1907,22 @@ exports[`serialize service to jsonschema > serialize basic service 1`] = `
             ],
             "type": "object",
           },
+          {
+            "properties": {
+              "code": {
+                "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
+                "type": "string",
+              },
+              "message": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "code",
+              "message",
+            ],
+            "type": "object",
+          },
         ],
       },
       "init": {
@@ -1744,6 +2016,22 @@ exports[`serialize service to jsonschema > serialize basic service 1`] = `
             ],
             "type": "object",
           },
+          {
+            "properties": {
+              "code": {
+                "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
+                "type": "string",
+              },
+              "message": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "code",
+              "message",
+            ],
+            "type": "object",
+          },
         ],
       },
       "init": {
@@ -1820,6 +2108,22 @@ exports[`serialize service to jsonschema > serialize basic service 1`] = `
             "properties": {
               "code": {
                 "const": "CANCEL",
+                "type": "string",
+              },
+              "message": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "code",
+              "message",
+            ],
+            "type": "object",
+          },
+          {
+            "properties": {
+              "code": {
+                "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
                 "type": "string",
               },
               "message": {
@@ -1924,6 +2228,22 @@ exports[`serialize service to jsonschema > serialize basic service 1`] = `
             ],
             "type": "object",
           },
+          {
+            "properties": {
+              "code": {
+                "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
+                "type": "string",
+              },
+              "message": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "code",
+              "message",
+            ],
+            "type": "object",
+          },
         ],
       },
       "init": {
@@ -2014,6 +2334,22 @@ exports[`serialize service to jsonschema > serialize basic service 1`] = `
             "properties": {
               "code": {
                 "const": "CANCEL",
+                "type": "string",
+              },
+              "message": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "code",
+              "message",
+            ],
+            "type": "object",
+          },
+          {
+            "properties": {
+              "code": {
+                "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
                 "type": "string",
               },
               "message": {
@@ -2157,6 +2493,22 @@ exports[`serialize service to jsonschema > serialize basic service 1`] = `
             ],
             "type": "object",
           },
+          {
+            "properties": {
+              "code": {
+                "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
+                "type": "string",
+              },
+              "message": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "code",
+              "message",
+            ],
+            "type": "object",
+          },
         ],
       },
       "init": {
@@ -2265,6 +2617,22 @@ exports[`serialize service to jsonschema > serialize basic service 1`] = `
             ],
             "type": "object",
           },
+          {
+            "properties": {
+              "code": {
+                "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
+                "type": "string",
+              },
+              "message": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "code",
+              "message",
+            ],
+            "type": "object",
+          },
         ],
       },
       "init": {
@@ -2332,6 +2700,22 @@ exports[`serialize service to jsonschema > serialize basic service 1`] = `
             "properties": {
               "code": {
                 "const": "CANCEL",
+                "type": "string",
+              },
+              "message": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "code",
+              "message",
+            ],
+            "type": "object",
+          },
+          {
+            "properties": {
+              "code": {
+                "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
                 "type": "string",
               },
               "message": {
@@ -2422,6 +2806,22 @@ exports[`serialize service to jsonschema > serialize service with binary 1`] = `
             "properties": {
               "code": {
                 "const": "CANCEL",
+                "type": "string",
+              },
+              "message": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "code",
+              "message",
+            ],
+            "type": "object",
+          },
+          {
+            "properties": {
+              "code": {
+                "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
                 "type": "string",
               },
               "message": {
@@ -2578,6 +2978,22 @@ exports[`serialize service to jsonschema > serialize service with errors 1`] = `
             ],
             "type": "object",
           },
+          {
+            "properties": {
+              "code": {
+                "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
+                "type": "string",
+              },
+              "message": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "code",
+              "message",
+            ],
+            "type": "object",
+          },
         ],
       },
       "init": {
@@ -2679,6 +3095,22 @@ exports[`serialize service to jsonschema > serialize service with errors 1`] = `
             "properties": {
               "code": {
                 "const": "CANCEL",
+                "type": "string",
+              },
+              "message": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "code",
+              "message",
+            ],
+            "type": "object",
+          },
+          {
+            "properties": {
+              "code": {
+                "const": "MAX_PAYLOAD_SIZE_EXCEEDED",
                 "type": "string",
               },
               "message": {

--- a/__tests__/max-payload-size.test.ts
+++ b/__tests__/max-payload-size.test.ts
@@ -1,0 +1,203 @@
+import {
+  afterEach,
+  assert,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vitest,
+} from 'vitest';
+import { createMockTransportNetwork } from '../testUtil/fixtures/mockTransport';
+import {
+  Err,
+  Ok,
+  Procedure,
+  ServiceSchema,
+  createClient,
+  createServer,
+} from '../router';
+import { MAX_PAYLOAD_SIZE_EXCEEDED_CODE } from '../router/errors';
+import { Type } from '@sinclair/typebox';
+import { readNextResult } from '../testUtil';
+import { MaxPayloadSizeExceeded } from '../transport/sessionStateMachine/common';
+
+describe('client exceeded max payload size', () => {
+  let mockTransportNetwork: ReturnType<typeof createMockTransportNetwork>;
+
+  beforeEach(async () => {
+    mockTransportNetwork = createMockTransportNetwork({
+      client: { maxPayloadSizeBytes: 1024 },
+    });
+  });
+
+  afterEach(async () => {
+    await mockTransportNetwork.cleanup();
+  });
+
+  test('rpc init exceeds max payload size', async () => {
+    const mockHandler = vitest.fn();
+    const services = {
+      service: ServiceSchema.define({
+        echo: Procedure.rpc({
+          requestInit: Type.String(),
+          responseData: Type.String(),
+          handler: mockHandler,
+        }),
+      }),
+    };
+    createServer(mockTransportNetwork.getServerTransport(), services);
+    const client = createClient<typeof services>(
+      mockTransportNetwork.getClientTransport('client'),
+      'SERVER',
+    );
+
+    const result = await client.service.echo.rpc('0'.repeat(1025));
+    expect(result).toStrictEqual({
+      ok: false,
+      payload: {
+        code: MAX_PAYLOAD_SIZE_EXCEEDED_CODE,
+        message:
+          'client: payload exceeded maximum payload size size=1241 max=1024',
+      },
+    });
+    expect(mockHandler).not.toHaveBeenCalled();
+  });
+
+  test('stream message exceeds max payload size', async () => {
+    let handlerCanceled: Promise<null> | undefined;
+    const services = {
+      service: ServiceSchema.define({
+        echo: Procedure.stream({
+          requestInit: Type.String(),
+          requestData: Type.String(),
+          responseData: Type.String(),
+          responseError: Type.Object({
+            code: Type.Literal('ERROR'),
+            message: Type.String(),
+          }),
+          handler: async ({ ctx, reqInit, reqReadable, resWritable }) => {
+            handlerCanceled = new Promise((resolve) => {
+              ctx.signal.onabort = () => resolve(null);
+            });
+
+            resWritable.write(Ok(reqInit));
+            for await (const msg of reqReadable) {
+              if (msg.ok) {
+                resWritable.write(Ok(msg.payload));
+              } else {
+                resWritable.write(
+                  Err({
+                    code: 'ERROR',
+                    message: 'error reading from client',
+                  }),
+                );
+                break;
+              }
+            }
+          },
+        }),
+      }),
+    };
+    createServer(mockTransportNetwork.getServerTransport(), services);
+    const transport = mockTransportNetwork.getClientTransport('client');
+    const client = createClient<typeof services>(transport, 'SERVER');
+
+    const stream = client.service.echo.stream('start');
+    let result = await readNextResult(stream.resReadable);
+    expect(result).toStrictEqual({ ok: true, payload: 'start' });
+
+    let error;
+    try {
+      stream.reqWritable.write('0'.repeat(1025));
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(MaxPayloadSizeExceeded);
+
+    result = await readNextResult(stream.resReadable);
+    expect(result).toStrictEqual({
+      ok: false,
+      payload: {
+        code: MAX_PAYLOAD_SIZE_EXCEEDED_CODE,
+        message:
+          'client: payload exceeded maximum payload size size=1148 max=1024',
+      },
+    });
+    assert(handlerCanceled);
+    await handlerCanceled;
+  });
+});
+
+describe('server exceeded max payload size', () => {
+  let mockTransportNetwork: ReturnType<typeof createMockTransportNetwork>;
+
+  beforeEach(async () => {
+    mockTransportNetwork = createMockTransportNetwork({
+      server: { maxPayloadSizeBytes: 1024 },
+    });
+  });
+
+  afterEach(async () => {
+    await mockTransportNetwork.cleanup();
+  });
+
+  test('rpc response exceeds max payload size', async () => {
+    const services = {
+      service: ServiceSchema.define({
+        echo: Procedure.rpc({
+          requestInit: Type.String(),
+          responseData: Type.String(),
+          handler: async ({ reqInit }) => {
+            return Ok(reqInit);
+          },
+        }),
+      }),
+    };
+    createServer(mockTransportNetwork.getServerTransport(), services);
+    const client = createClient<typeof services>(
+      mockTransportNetwork.getClientTransport('client'),
+      'SERVER',
+    );
+
+    const result = await client.service.echo.rpc('0'.repeat(1025));
+    expect(result).toStrictEqual({
+      ok: false,
+      payload: {
+        code: MAX_PAYLOAD_SIZE_EXCEEDED_CODE,
+        message:
+          'server: payload exceeded maximum payload size size=1170 max=1024',
+      },
+    });
+  });
+
+  test('stream message exceeds max payload size', async () => {
+    const services = {
+      service: ServiceSchema.define({
+        echo: Procedure.subscription({
+          requestInit: Type.Object({}),
+          responseData: Type.String(),
+          handler: async ({ resWritable }) => {
+            resWritable.write(Ok('0'.repeat(1025)));
+          },
+        }),
+      }),
+    };
+    createServer(mockTransportNetwork.getServerTransport(), services);
+    const client = createClient<typeof services>(
+      mockTransportNetwork.getClientTransport('client'),
+      'SERVER',
+    );
+
+    const stream = client.service.echo.subscribe({});
+    const result = await readNextResult(stream.resReadable);
+    expect(result).toStrictEqual({
+      ok: false,
+      payload: {
+        code: MAX_PAYLOAD_SIZE_EXCEEDED_CODE,
+        message:
+          'server: payload exceeded maximum payload size size=1170 max=1024',
+      },
+    });
+    expect(stream.resReadable.isReadable()).toEqual(false);
+  });
+});

--- a/router/errors.ts
+++ b/router/errors.ts
@@ -27,6 +27,10 @@ export const INVALID_REQUEST_CODE = 'INVALID_REQUEST';
  * {@link CANCEL_CODE} is the code used when either server or client cancels the stream.
  */
 export const CANCEL_CODE = 'CANCEL';
+/**
+ * {@link MAX_PAYLOAD_SIZE_EXCEEDED_CODE} is the code used when a request's payload exceeds the maximum allowed size.
+ */
+export const MAX_PAYLOAD_SIZE_EXCEEDED_CODE = 'MAX_PAYLOAD_SIZE_EXCEEDED';
 
 type TLiteralString = TLiteral<string>;
 
@@ -70,6 +74,10 @@ export const ReaderErrorSchema = Type.Union([
   }),
   Type.Object({
     code: Type.Literal(CANCEL_CODE),
+    message: Type.String(),
+  }),
+  Type.Object({
+    code: Type.Literal(MAX_PAYLOAD_SIZE_EXCEEDED_CODE),
     message: Type.String(),
   }),
 ]) satisfies ProcedureErrorSchemaType;

--- a/transport/options.ts
+++ b/transport/options.ts
@@ -13,6 +13,7 @@ export const defaultTransportOptions: TransportOptions = {
   connectionTimeoutMs: 2_000,
   handshakeTimeoutMs: 1_000,
   enableTransparentSessionReconnects: true,
+  maxPayloadSizeBytes: 4 * 1024 * 1024,
   codec: NaiveJsonCodec,
 };
 


### PR DESCRIPTION
## Why

Memory is not unbounded and underlying transports have limits on maximum payload size. When we accidentally exceed the max payload size for an underlying transport, the connection can get torn down entirely. This is bad because it means one bad RPC call can bring down the entire connection.

Additionally, when things do explode, its hard to find the right error message that tells you that this was due to exceeding some payload limit.

Let's enforce a configurable max payload limit in river itself. It's up to users to make sure that this max payload size is `<=` the max payload size allowed by their transport layer.


Something to consider in the future is automatically chunking these messages in river; however, I think this is a bad idea because we want to avoid having large buffers in memory entirely. Having this restriction in river will force application developers to stream or chunk data and help avoid cases where loading large buffers into memory happens to work until we hit OOMs.

## What changed

- Add config value for setting the max payload size
    - Default is 4M to match gRPC
- Add new built-in error code: `MAX_PAYLOAD_SIZE_EXCEEDED`
- If we exceed the max payload size after encoding, throw and error
- Handle these new errors accordingly in the client procedure handler
    - If init message: inject error in the readable only client side. Server never sees these.
    - If in the middle of a stream or upload: cancel the request on the server, inject error in the readable, throw error since `write` returns `void`
- Handle these new errors accordingly in the server procedure handler
    - Return error with code `MAX_PAYLOAD_SIZE_EXCEEDED` whenever server attempts to send a payload that is too large
- Updated the protocol docs to reflect this new error

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
