### PR TITLE
Include river errors in server side spans

### DIFF
--- a/router/client.ts
+++ b/router/client.ts
@@ -288,6 +288,7 @@ function handleProc(
   const procClosesWithInit = procType === 'rpc' || procType === 'subscription';
   const streamId = generateId();
   const { span, ctx } = createProcTelemetryInfo(
+    transport.tracer,
     session,
     procType,
     serviceName,

--- a/testUtil/index.ts
+++ b/testUtil/index.ts
@@ -19,6 +19,7 @@ import { SessionStateGraph } from '../transport/sessionStateMachine/transitions'
 import { BaseErrorSchemaType } from '../router/errors';
 import { ClientTransport } from '../transport/client';
 import { ServerTransport } from '../transport/server';
+import { getTracer } from '../tracing';
 
 export {
   createMockTransportNetwork,
@@ -186,6 +187,7 @@ export function dummySession() {
     },
     testingSessionOptions,
     currentProtocolVersion,
+    getTracer(),
   );
 }
 

--- a/transport/server.ts
+++ b/transport/server.ts
@@ -164,6 +164,7 @@ export abstract class ServerTransport<
         },
       },
       this.options,
+      this.tracer,
       this.log,
     );
 

--- a/transport/sessionStateMachine/common.ts
+++ b/transport/sessionStateMachine/common.ts
@@ -11,6 +11,7 @@ import {
 import { Value } from '@sinclair/typebox/value';
 import { Codec } from '../../codec';
 import { generateId } from '../id';
+import { Tracer } from '@opentelemetry/api';
 
 export const enum SessionState {
   NoConnection = 'NoConnection',
@@ -147,6 +148,7 @@ export interface SessionOptions {
 export interface CommonSessionProps {
   from: TransportClientId;
   options: SessionOptions;
+  tracer: Tracer;
   log: Logger | undefined;
 }
 
@@ -154,14 +156,16 @@ export abstract class CommonSession extends StateMachineState {
   readonly from: TransportClientId;
   readonly options: SessionOptions;
 
+  tracer: Tracer;
   log?: Logger;
   abstract get loggingMetadata(): MessageMetadata;
 
-  constructor({ from, options, log }: CommonSessionProps) {
+  constructor({ from, options, log, tracer }: CommonSessionProps) {
     super();
     this.from = from;
     this.options = options;
     this.log = log;
+    this.tracer = tracer;
   }
 
   parseMsg(msg: Uint8Array): OpaqueTransportMessage | null {

--- a/transport/sessionStateMachine/stateMachine.test.ts
+++ b/transport/sessionStateMachine/stateMachine.test.ts
@@ -35,6 +35,7 @@ import {
   SessionBackingOff,
   SessionBackingOffListeners,
 } from './SessionBackingOff';
+import { getTracer } from '../../tracing';
 
 function persistedSessionState(session: IdentifiedSession) {
   return {
@@ -145,6 +146,7 @@ function createSessionNoConnection() {
     listeners,
     testingSessionOptions,
     currentProtocolVersion,
+    getTracer(),
   );
 
   return { session, ...listeners };
@@ -221,6 +223,7 @@ function createSessionWaitingForHandshake() {
     conn,
     listeners,
     testingSessionOptions,
+    getTracer(),
   );
 
   return { session, ...listeners };

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -26,6 +26,8 @@ import {
 import { Connection } from './connection';
 import { Session, SessionStateGraph } from './sessionStateMachine/transitions';
 import { SessionId } from './sessionStateMachine/common';
+import { Tracer } from '@opentelemetry/api';
+import { getTracer } from '../tracing';
 
 /**
  * Represents the possible states of a transport.
@@ -84,6 +86,7 @@ export abstract class Transport<ConnType extends Connection> {
    */
   protected options: TransportOptions;
   log?: Logger;
+  tracer: Tracer;
 
   sessions: Map<TransportClientId, Session<ConnType>>;
 
@@ -101,6 +104,7 @@ export abstract class Transport<ConnType extends Connection> {
     this.clientId = clientId;
     this.status = 'open';
     this.sessions = new Map();
+    this.tracer = getTracer();
   }
 
   bindLogger(fn: LogFn | Logger, level?: LoggingLevel) {


### PR DESCRIPTION
## Why

This includes errors on the spans generated by the server so we have more error info.

I also changed the names of the spans to match the format that river-python is using.

In order to write a test for this, I had to make it so the tracer is created per-transport rather than having a global one.

## What changed

- De-global the tracer. The transport will construct and own a tracer instance (obtained from the global tracer provider).
- Add river errors to the server side spans
- Update the server/client spans to match the format we are using for river-python
    - This may make it harder to look at historical span data, let me know if you think this is a bad idea and I can revert it

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
