### PR TITLE
rename session connect/disconnect -> created/closing/closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # River
 
-⚠️ Not production ready, while Replit is using parts of River in production, we are still going through rapid breaking changes. First production ready version will be `1.x.x` ⚠️
-
 River allows multiple clients to connect to and make remote procedure calls to a remote server as if they were local procedures.
 
 ## Long-lived streaming remote procedure calls

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ transport.addEventListener('sessionStatus', (evt) => {
   } else if (evt.status === 'closing') {
     // do other things
   } else if (evt.status === 'closed') {
-    // note that evt.session only has id + to 
+    // note that evt.session only has id + to
     // this is useful for doing things like creating a new session if
     // a session just got yanked
   }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # River
 
+⚠️ Not production ready, while Replit is using parts of River in production, we are still going through rapid breaking changes. First production ready version will be `1.x.x` ⚠️
+
 River allows multiple clients to connect to and make remote procedure calls to a remote server as if they were local procedures.
 
 ## Long-lived streaming remote procedure calls
@@ -187,10 +189,14 @@ If your application is stateful on either the server or the client, the service 
 
 ```ts
 transport.addEventListener('sessionStatus', (evt) => {
-  if (evt.status === 'connect') {
+  if (evt.status === 'created') {
     // do something
-  } else if (evt.status === 'disconnect') {
-    // do something else
+  } else if (evt.status === 'closing') {
+    // do other things
+  } else if (evt.status === 'closed') {
+    // note that evt.session only has id + to 
+    // this is useful for doing things like creating a new session if
+    // a session just got yanked
   }
 });
 

--- a/__tests__/negative.test.ts
+++ b/__tests__/negative.test.ts
@@ -205,7 +205,7 @@ describe('should handle incompatabilities', async () => {
     expect(errMock).toHaveBeenCalledTimes(0);
     expect(spy).toHaveBeenCalledWith(
       expect.objectContaining({
-        status: 'connect',
+        status: 'created',
       }),
     );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.204.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.204.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "1.0.0",
+  "version": "0.205.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "1.0.0",
+      "version": "0.205.0",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "1.0.0",
+  "version": "0.205.0",
   "type": "module",
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.204.0",
+  "version": "1.0.0",
   "type": "module",
   "exports": {
     ".": {

--- a/router/client.ts
+++ b/router/client.ts
@@ -456,7 +456,7 @@ function handleProc(
 
   function onSessionStatus(evt: EventMap['sessionStatus']) {
     if (
-      evt.status !== 'disconnect' ||
+      evt.status !== 'closing' ||
       evt.session.to !== serverId ||
       session.id !== evt.session.id
     ) {

--- a/router/server.ts
+++ b/router/server.ts
@@ -216,7 +216,7 @@ class RiverServer<Services extends AnyServiceSchemaMap>
     };
 
     const handleSessionStatus = (evt: EventMap['sessionStatus']) => {
-      if (evt.status !== 'disconnect') return;
+      if (evt.status !== 'closing') return;
 
       const disconnectedClientId = evt.session.to;
       this.log?.info(

--- a/testUtil/fixtures/matrix.ts
+++ b/testUtil/fixtures/matrix.ts
@@ -31,7 +31,9 @@ export const testMatrix = (selector?: Selector): Array<TestMatrixEntry> =>
     .map((transport) =>
       // If a selector is provided, filter transport + codecs to match the selector; otherwise, use all codecs.
       (selector
-        ? codecs.filter((codec) => selector[1] === codec.name)
+        ? codecs.filter((codec) => {
+            return selector[0] === transport.name && selector[1] === codec.name;
+          })
         : codecs
       ).map((codec) => ({
         transport,

--- a/testUtil/fixtures/matrix.ts
+++ b/testUtil/fixtures/matrix.ts
@@ -17,7 +17,7 @@ interface TestMatrixEntry {
 /**
  * Defines a selector type that pairs a valid transport with a valid codec.
  */
-type Selector = [ValidTransports, ValidCodecs];
+type Selector = [ValidTransports | 'all', ValidCodecs | 'all'];
 
 /**
  * Generates a matrix of test entries for each combination of transport and codec.
@@ -26,18 +26,23 @@ type Selector = [ValidTransports, ValidCodecs];
  * @param selector An optional tuple specifying a transport and codec to filter the matrix.
  * @returns An array of TestMatrixEntry objects representing the combinations of transport and codec.
  */
-export const testMatrix = (selector?: Selector): Array<TestMatrixEntry> =>
-  transports
+export const testMatrix = (
+  [transportSelector, codecSelector]: Selector = ['all', 'all'],
+): Array<TestMatrixEntry> => {
+  const filteredTransports = transports.filter(
+    (t) => transportSelector === 'all' || t.name === transportSelector,
+  );
+
+  const filteredCodecs = codecs.filter(
+    (c) => codecSelector === 'all' || c.name === codecSelector,
+  );
+
+  return filteredTransports
     .map((transport) =>
-      // If a selector is provided, filter transport + codecs to match the selector; otherwise, use all codecs.
-      (selector
-        ? codecs.filter((codec) => {
-            return selector[0] === transport.name && selector[1] === codec.name;
-          })
-        : codecs
-      ).map((codec) => ({
+      filteredCodecs.map((codec) => ({
         transport,
         codec,
       })),
     )
     .flat();
+};

--- a/transport/client.ts
+++ b/transport/client.ts
@@ -372,7 +372,9 @@ export abstract class ClientTransport<
    * and don't want to wait for the grace period to elapse.
    */
   hardDisconnect() {
-    for (const session of this.sessions.values()) {
+    // create a copy of the sessions to avoid modifying the map while iterating
+    const sessions = Array.from(this.sessions.values());
+    for (const session of sessions) {
       this.deleteSession(session);
     }
   }

--- a/transport/events.ts
+++ b/transport/events.ts
@@ -16,10 +16,15 @@ export type ProtocolErrorType =
 
 export interface EventMap {
   message: OpaqueTransportMessage;
-  sessionStatus: {
-    status: 'connect' | 'disconnect';
-    session: Session<Connection>;
-  };
+  sessionStatus:
+    | {
+        status: 'created' | 'closing';
+        session: Session<Connection>;
+      }
+    | {
+        status: 'closed';
+        session: Pick<Session<Connection>, 'id' | 'to'>;
+      };
   sessionTransition:
     | { state: SessionState.Connected }
     | { state: SessionState.Handshaking }

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -165,7 +165,8 @@ export abstract class Transport<ConnType extends Connection> {
   close() {
     this.status = 'closed';
 
-    for (const session of this.sessions.values()) {
+    const sessions = Array.from(this.sessions.values());
+    for (const session of sessions) {
       this.deleteSession(session);
     }
 
@@ -195,7 +196,7 @@ export abstract class Transport<ConnType extends Connection> {
 
     this.sessions.set(session.to, session);
     this.eventDispatcher.dispatchEvent('sessionStatus', {
-      status: 'connect',
+      status: 'created',
       session: session,
     });
 
@@ -246,13 +247,17 @@ export abstract class Transport<ConnType extends Connection> {
 
     session.log?.info(`closing session ${session.id}`, loggingMetadata);
     this.eventDispatcher.dispatchEvent('sessionStatus', {
-      status: 'disconnect',
+      status: 'closing',
       session: session,
     });
 
     const to = session.to;
     session.close();
     this.sessions.delete(to);
+    this.eventDispatcher.dispatchEvent('sessionStatus', {
+      status: 'closed',
+      session: { id: session.id, to: to },
+    });
   }
 
   // common listeners


### PR DESCRIPTION
## Why

nomenclature of 'connected'/'disconnected' is an artifact of when sessions were what connections are today, thats no longer accurate

this also allows us to disambiguate the 'about to close' state and 'already closed' state

these have two different cases:
1. about to close -> do any last minute cleanup and send things to the otherside before we totally yank the connection
2. already closed -> consumers can do things like manually open a new session if an old session is closed

## What changed

1. rename 'connect' -> 'created', 'disconnect' -> 'closing'
2. add a new 'closed' state which is emitted after the cleanup is done
3. fix a case where we could loop infinitely by mutating a map while iterating its values
4. add a test for the create a new session after previous session is gone case

## Versioning

- [ ] Breaking protocol change
- [x] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
