### PR TITLE
better validation errors, dont include all errors

### DIFF
--- a/__tests__/__snapshots__/serialize.test.ts.snap
+++ b/__tests__/__snapshots__/serialize.test.ts.snap
@@ -57,6 +57,36 @@ exports[`serialize server to jsonschema > serialize entire service schema 1`] = 
                     "const": "INVALID_REQUEST",
                     "type": "string",
                   },
+                  "extras": {
+                    "properties": {
+                      "firstValidationErrors": {
+                        "items": {
+                          "properties": {
+                            "message": {
+                              "type": "string",
+                            },
+                            "path": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "path",
+                            "message",
+                          ],
+                          "type": "object",
+                        },
+                        "type": "array",
+                      },
+                      "totalErrors": {
+                        "type": "number",
+                      },
+                    },
+                    "required": [
+                      "firstValidationErrors",
+                      "totalErrors",
+                    ],
+                    "type": "object",
+                  },
                   "message": {
                     "type": "string",
                   },
@@ -150,6 +180,36 @@ exports[`serialize server to jsonschema > serialize entire service schema 1`] = 
                     "const": "INVALID_REQUEST",
                     "type": "string",
                   },
+                  "extras": {
+                    "properties": {
+                      "firstValidationErrors": {
+                        "items": {
+                          "properties": {
+                            "message": {
+                              "type": "string",
+                            },
+                            "path": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "path",
+                            "message",
+                          ],
+                          "type": "object",
+                        },
+                        "type": "array",
+                      },
+                      "totalErrors": {
+                        "type": "number",
+                      },
+                    },
+                    "required": [
+                      "firstValidationErrors",
+                      "totalErrors",
+                    ],
+                    "type": "object",
+                  },
                   "message": {
                     "type": "string",
                   },
@@ -237,6 +297,36 @@ exports[`serialize server to jsonschema > serialize entire service schema 1`] = 
                   "code": {
                     "const": "INVALID_REQUEST",
                     "type": "string",
+                  },
+                  "extras": {
+                    "properties": {
+                      "firstValidationErrors": {
+                        "items": {
+                          "properties": {
+                            "message": {
+                              "type": "string",
+                            },
+                            "path": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "path",
+                            "message",
+                          ],
+                          "type": "object",
+                        },
+                        "type": "array",
+                      },
+                      "totalErrors": {
+                        "type": "number",
+                      },
+                    },
+                    "required": [
+                      "firstValidationErrors",
+                      "totalErrors",
+                    ],
+                    "type": "object",
                   },
                   "message": {
                     "type": "string",
@@ -329,6 +419,36 @@ exports[`serialize server to jsonschema > serialize entire service schema 1`] = 
                   "code": {
                     "const": "INVALID_REQUEST",
                     "type": "string",
+                  },
+                  "extras": {
+                    "properties": {
+                      "firstValidationErrors": {
+                        "items": {
+                          "properties": {
+                            "message": {
+                              "type": "string",
+                            },
+                            "path": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "path",
+                            "message",
+                          ],
+                          "type": "object",
+                        },
+                        "type": "array",
+                      },
+                      "totalErrors": {
+                        "type": "number",
+                      },
+                    },
+                    "required": [
+                      "firstValidationErrors",
+                      "totalErrors",
+                    ],
+                    "type": "object",
                   },
                   "message": {
                     "type": "string",
@@ -431,6 +551,36 @@ exports[`serialize server to jsonschema > serialize entire service schema 1`] = 
                   "code": {
                     "const": "INVALID_REQUEST",
                     "type": "string",
+                  },
+                  "extras": {
+                    "properties": {
+                      "firstValidationErrors": {
+                        "items": {
+                          "properties": {
+                            "message": {
+                              "type": "string",
+                            },
+                            "path": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "path",
+                            "message",
+                          ],
+                          "type": "object",
+                        },
+                        "type": "array",
+                      },
+                      "totalErrors": {
+                        "type": "number",
+                      },
+                    },
+                    "required": [
+                      "firstValidationErrors",
+                      "totalErrors",
+                    ],
+                    "type": "object",
                   },
                   "message": {
                     "type": "string",
@@ -563,6 +713,36 @@ exports[`serialize server to jsonschema > serialize entire service schema 1`] = 
                     "const": "INVALID_REQUEST",
                     "type": "string",
                   },
+                  "extras": {
+                    "properties": {
+                      "firstValidationErrors": {
+                        "items": {
+                          "properties": {
+                            "message": {
+                              "type": "string",
+                            },
+                            "path": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "path",
+                            "message",
+                          ],
+                          "type": "object",
+                        },
+                        "type": "array",
+                      },
+                      "totalErrors": {
+                        "type": "number",
+                      },
+                    },
+                    "required": [
+                      "firstValidationErrors",
+                      "totalErrors",
+                    ],
+                    "type": "object",
+                  },
                   "message": {
                     "type": "string",
                   },
@@ -671,6 +851,36 @@ exports[`serialize server to jsonschema > serialize entire service schema 1`] = 
                     "const": "INVALID_REQUEST",
                     "type": "string",
                   },
+                  "extras": {
+                    "properties": {
+                      "firstValidationErrors": {
+                        "items": {
+                          "properties": {
+                            "message": {
+                              "type": "string",
+                            },
+                            "path": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "path",
+                            "message",
+                          ],
+                          "type": "object",
+                        },
+                        "type": "array",
+                      },
+                      "totalErrors": {
+                        "type": "number",
+                      },
+                    },
+                    "required": [
+                      "firstValidationErrors",
+                      "totalErrors",
+                    ],
+                    "type": "object",
+                  },
                   "message": {
                     "type": "string",
                   },
@@ -749,6 +959,36 @@ exports[`serialize server to jsonschema > serialize entire service schema 1`] = 
                   "code": {
                     "const": "INVALID_REQUEST",
                     "type": "string",
+                  },
+                  "extras": {
+                    "properties": {
+                      "firstValidationErrors": {
+                        "items": {
+                          "properties": {
+                            "message": {
+                              "type": "string",
+                            },
+                            "path": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "path",
+                            "message",
+                          ],
+                          "type": "object",
+                        },
+                        "type": "array",
+                      },
+                      "totalErrors": {
+                        "type": "number",
+                      },
+                    },
+                    "required": [
+                      "firstValidationErrors",
+                      "totalErrors",
+                    ],
+                    "type": "object",
                   },
                   "message": {
                     "type": "string",
@@ -842,6 +1082,36 @@ exports[`serialize service to jsonschema > serialize backwards compatible with v
                 "const": "INVALID_REQUEST",
                 "type": "string",
               },
+              "extras": {
+                "properties": {
+                  "firstValidationErrors": {
+                    "items": {
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                        },
+                        "path": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "path",
+                        "message",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "totalErrors": {
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "firstValidationErrors",
+                  "totalErrors",
+                ],
+                "type": "object",
+              },
               "message": {
                 "type": "string",
               },
@@ -935,6 +1205,36 @@ exports[`serialize service to jsonschema > serialize backwards compatible with v
                 "const": "INVALID_REQUEST",
                 "type": "string",
               },
+              "extras": {
+                "properties": {
+                  "firstValidationErrors": {
+                    "items": {
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                        },
+                        "path": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "path",
+                        "message",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "totalErrors": {
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "firstValidationErrors",
+                  "totalErrors",
+                ],
+                "type": "object",
+              },
               "message": {
                 "type": "string",
               },
@@ -1022,6 +1322,36 @@ exports[`serialize service to jsonschema > serialize backwards compatible with v
               "code": {
                 "const": "INVALID_REQUEST",
                 "type": "string",
+              },
+              "extras": {
+                "properties": {
+                  "firstValidationErrors": {
+                    "items": {
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                        },
+                        "path": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "path",
+                        "message",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "totalErrors": {
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "firstValidationErrors",
+                  "totalErrors",
+                ],
+                "type": "object",
               },
               "message": {
                 "type": "string",
@@ -1114,6 +1444,36 @@ exports[`serialize service to jsonschema > serialize backwards compatible with v
               "code": {
                 "const": "INVALID_REQUEST",
                 "type": "string",
+              },
+              "extras": {
+                "properties": {
+                  "firstValidationErrors": {
+                    "items": {
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                        },
+                        "path": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "path",
+                        "message",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "totalErrors": {
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "firstValidationErrors",
+                  "totalErrors",
+                ],
+                "type": "object",
               },
               "message": {
                 "type": "string",
@@ -1216,6 +1576,36 @@ exports[`serialize service to jsonschema > serialize backwards compatible with v
               "code": {
                 "const": "INVALID_REQUEST",
                 "type": "string",
+              },
+              "extras": {
+                "properties": {
+                  "firstValidationErrors": {
+                    "items": {
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                        },
+                        "path": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "path",
+                        "message",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "totalErrors": {
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "firstValidationErrors",
+                  "totalErrors",
+                ],
+                "type": "object",
               },
               "message": {
                 "type": "string",
@@ -1348,6 +1738,36 @@ exports[`serialize service to jsonschema > serialize backwards compatible with v
                 "const": "INVALID_REQUEST",
                 "type": "string",
               },
+              "extras": {
+                "properties": {
+                  "firstValidationErrors": {
+                    "items": {
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                        },
+                        "path": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "path",
+                        "message",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "totalErrors": {
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "firstValidationErrors",
+                  "totalErrors",
+                ],
+                "type": "object",
+              },
               "message": {
                 "type": "string",
               },
@@ -1456,6 +1876,36 @@ exports[`serialize service to jsonschema > serialize backwards compatible with v
                 "const": "INVALID_REQUEST",
                 "type": "string",
               },
+              "extras": {
+                "properties": {
+                  "firstValidationErrors": {
+                    "items": {
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                        },
+                        "path": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "path",
+                        "message",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "totalErrors": {
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "firstValidationErrors",
+                  "totalErrors",
+                ],
+                "type": "object",
+              },
               "message": {
                 "type": "string",
               },
@@ -1534,6 +1984,36 @@ exports[`serialize service to jsonschema > serialize backwards compatible with v
               "code": {
                 "const": "INVALID_REQUEST",
                 "type": "string",
+              },
+              "extras": {
+                "properties": {
+                  "firstValidationErrors": {
+                    "items": {
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                        },
+                        "path": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "path",
+                        "message",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "totalErrors": {
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "firstValidationErrors",
+                  "totalErrors",
+                ],
+                "type": "object",
               },
               "message": {
                 "type": "string",
@@ -1625,6 +2105,36 @@ exports[`serialize service to jsonschema > serialize basic service 1`] = `
                 "const": "INVALID_REQUEST",
                 "type": "string",
               },
+              "extras": {
+                "properties": {
+                  "firstValidationErrors": {
+                    "items": {
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                        },
+                        "path": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "path",
+                        "message",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "totalErrors": {
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "firstValidationErrors",
+                  "totalErrors",
+                ],
+                "type": "object",
+              },
               "message": {
                 "type": "string",
               },
@@ -1718,6 +2228,36 @@ exports[`serialize service to jsonschema > serialize basic service 1`] = `
                 "const": "INVALID_REQUEST",
                 "type": "string",
               },
+              "extras": {
+                "properties": {
+                  "firstValidationErrors": {
+                    "items": {
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                        },
+                        "path": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "path",
+                        "message",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "totalErrors": {
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "firstValidationErrors",
+                  "totalErrors",
+                ],
+                "type": "object",
+              },
               "message": {
                 "type": "string",
               },
@@ -1805,6 +2345,36 @@ exports[`serialize service to jsonschema > serialize basic service 1`] = `
               "code": {
                 "const": "INVALID_REQUEST",
                 "type": "string",
+              },
+              "extras": {
+                "properties": {
+                  "firstValidationErrors": {
+                    "items": {
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                        },
+                        "path": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "path",
+                        "message",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "totalErrors": {
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "firstValidationErrors",
+                  "totalErrors",
+                ],
+                "type": "object",
               },
               "message": {
                 "type": "string",
@@ -1897,6 +2467,36 @@ exports[`serialize service to jsonschema > serialize basic service 1`] = `
               "code": {
                 "const": "INVALID_REQUEST",
                 "type": "string",
+              },
+              "extras": {
+                "properties": {
+                  "firstValidationErrors": {
+                    "items": {
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                        },
+                        "path": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "path",
+                        "message",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "totalErrors": {
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "firstValidationErrors",
+                  "totalErrors",
+                ],
+                "type": "object",
               },
               "message": {
                 "type": "string",
@@ -1999,6 +2599,36 @@ exports[`serialize service to jsonschema > serialize basic service 1`] = `
               "code": {
                 "const": "INVALID_REQUEST",
                 "type": "string",
+              },
+              "extras": {
+                "properties": {
+                  "firstValidationErrors": {
+                    "items": {
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                        },
+                        "path": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "path",
+                        "message",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "totalErrors": {
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "firstValidationErrors",
+                  "totalErrors",
+                ],
+                "type": "object",
               },
               "message": {
                 "type": "string",
@@ -2131,6 +2761,36 @@ exports[`serialize service to jsonschema > serialize basic service 1`] = `
                 "const": "INVALID_REQUEST",
                 "type": "string",
               },
+              "extras": {
+                "properties": {
+                  "firstValidationErrors": {
+                    "items": {
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                        },
+                        "path": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "path",
+                        "message",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "totalErrors": {
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "firstValidationErrors",
+                  "totalErrors",
+                ],
+                "type": "object",
+              },
               "message": {
                 "type": "string",
               },
@@ -2239,6 +2899,36 @@ exports[`serialize service to jsonschema > serialize basic service 1`] = `
                 "const": "INVALID_REQUEST",
                 "type": "string",
               },
+              "extras": {
+                "properties": {
+                  "firstValidationErrors": {
+                    "items": {
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                        },
+                        "path": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "path",
+                        "message",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "totalErrors": {
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "firstValidationErrors",
+                  "totalErrors",
+                ],
+                "type": "object",
+              },
               "message": {
                 "type": "string",
               },
@@ -2317,6 +3007,36 @@ exports[`serialize service to jsonschema > serialize basic service 1`] = `
               "code": {
                 "const": "INVALID_REQUEST",
                 "type": "string",
+              },
+              "extras": {
+                "properties": {
+                  "firstValidationErrors": {
+                    "items": {
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                        },
+                        "path": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "path",
+                        "message",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "totalErrors": {
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "firstValidationErrors",
+                  "totalErrors",
+                ],
+                "type": "object",
               },
               "message": {
                 "type": "string",
@@ -2407,6 +3127,36 @@ exports[`serialize service to jsonschema > serialize service with binary 1`] = `
               "code": {
                 "const": "INVALID_REQUEST",
                 "type": "string",
+              },
+              "extras": {
+                "properties": {
+                  "firstValidationErrors": {
+                    "items": {
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                        },
+                        "path": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "path",
+                        "message",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "totalErrors": {
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "firstValidationErrors",
+                  "totalErrors",
+                ],
+                "type": "object",
               },
               "message": {
                 "type": "string",
@@ -2552,6 +3302,36 @@ exports[`serialize service to jsonschema > serialize service with errors 1`] = `
                 "const": "INVALID_REQUEST",
                 "type": "string",
               },
+              "extras": {
+                "properties": {
+                  "firstValidationErrors": {
+                    "items": {
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                        },
+                        "path": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "path",
+                        "message",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "totalErrors": {
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "firstValidationErrors",
+                  "totalErrors",
+                ],
+                "type": "object",
+              },
               "message": {
                 "type": "string",
               },
@@ -2664,6 +3444,36 @@ exports[`serialize service to jsonschema > serialize service with errors 1`] = `
               "code": {
                 "const": "INVALID_REQUEST",
                 "type": "string",
+              },
+              "extras": {
+                "properties": {
+                  "firstValidationErrors": {
+                    "items": {
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                        },
+                        "path": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "path",
+                        "message",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "totalErrors": {
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "firstValidationErrors",
+                  "totalErrors",
+                ],
+                "type": "object",
               },
               "message": {
                 "type": "string",

--- a/__tests__/invalid-request.test.ts
+++ b/__tests__/invalid-request.test.ts
@@ -16,7 +16,7 @@ import {
   waitFor,
 } from '../testUtil/fixtures/cleanup';
 import { EventMap } from '../transport';
-import { INVALID_REQUEST_CODE } from '../router/errors';
+import { INVALID_REQUEST_CODE, ValidationErrors } from '../router/errors';
 import { ControlFlags } from '../transport/message';
 import { TestSetupHelpers } from '../testUtil/fixtures/transports';
 import { nanoid } from 'nanoid';
@@ -391,10 +391,15 @@ describe('cancels invalid request', () => {
         streamId,
         payload: Err({
           code: INVALID_REQUEST_CODE,
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          message: expect.stringContaining(
-            'expected requestData or control payload',
-          ),
+          message: 'message in requestData position did not match schema',
+          extras: {
+            totalErrors: 2,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            firstValidationErrors: expect.arrayContaining([
+              { path: '/mustSendThings', message: 'Required property' },
+              { path: '/mustSendThings', message: 'Expected string' },
+            ]),
+          },
         }),
       }),
     );
@@ -451,8 +456,14 @@ describe('cancels invalid request', () => {
           streamId,
           payload: Err({
             code: INVALID_REQUEST_CODE,
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            message: expect.stringContaining('control payload'),
+            message: 'message in control payload position did not match schema',
+            extras: {
+              totalErrors: 1,
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              firstValidationErrors: expect.arrayContaining([
+                { path: '', message: 'Expected union value' },
+              ]),
+            },
           }),
         }),
       );
@@ -578,8 +589,16 @@ describe('cancels invalid request', () => {
         code: INVALID_REQUEST_CODE,
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         message: expect.stringContaining(
-          'expected requestData or control payload',
+          'message in requestData position did not match schema',
         ),
+        extras: {
+          totalErrors: 2,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          firstValidationErrors: expect.arrayContaining([
+            { path: '/newRequiredField', message: 'Required property' },
+            { path: '/newRequiredField', message: 'Expected string' },
+          ]),
+        },
       }),
     ]);
   });

--- a/__tests__/invalid-request.test.ts
+++ b/__tests__/invalid-request.test.ts
@@ -16,7 +16,7 @@ import {
   waitFor,
 } from '../testUtil/fixtures/cleanup';
 import { EventMap } from '../transport';
-import { INVALID_REQUEST_CODE, ValidationErrors } from '../router/errors';
+import { INVALID_REQUEST_CODE } from '../router/errors';
 import { ControlFlags } from '../transport/message';
 import { TestSetupHelpers } from '../testUtil/fixtures/transports';
 import { nanoid } from 'nanoid';

--- a/logging/log.ts
+++ b/logging/log.ts
@@ -1,4 +1,3 @@
-import { ValueError } from '@sinclair/typebox/value';
 import { OpaqueTransportMessage, ProtocolVersion } from '../transport/message';
 import { context, trace } from '@opentelemetry/api';
 

--- a/logging/log.ts
+++ b/logging/log.ts
@@ -61,7 +61,7 @@ export type MessageMetadata = Partial<{
   sessionId: string;
   connId: string;
   transportMessage: Partial<OpaqueTransportMessage>;
-  validationErrors: Array<ValueError>;
+  validationErrors: Array<{ path: string; message: string }>;
   tags: Array<Tags>;
   telemetry: {
     traceId: string;

--- a/router/server.ts
+++ b/router/server.ts
@@ -34,7 +34,7 @@ import {
   ParsedMetadata,
 } from './context';
 import { Logger } from '../logging/log';
-import { Value, ValueError } from '@sinclair/typebox/value';
+import { Value } from '@sinclair/typebox/value';
 import { Err, Result, Ok, ErrResult } from './result';
 import { EventMap } from '../transport/events';
 import { coerceErrorString } from '../transport/stringifyError';


### PR DESCRIPTION
## Why

previously, if you accidentally sent the wrong payload (e.g. mismatched service versions), you would get `expected requestData or control payload` which is a very unclear message given that you did provide `requestData`, its just wrong

## What changed

- tweaked the error message to be more straightforward
- include extras in the invalid message back to the client

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
