### PR TITLE
allow ctx.cancel to be returned in all procs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.205.2",
+  "version": "0.206.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.205.2",
+      "version": "0.206.0",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.205.2",
+  "version": "0.206.0",
   "type": "module",
   "exports": {
     ".": {

--- a/router/context.ts
+++ b/router/context.ts
@@ -1,6 +1,9 @@
 import { Span } from '@opentelemetry/api';
 import { TransportClientId } from '../transport/message';
 import { SessionId } from '../transport/sessionStateMachine/common';
+import { ErrResult } from './result';
+import { CancelResultSchema } from './errors';
+import { Static } from '@sinclair/typebox';
 
 /**
  * ServiceContext exist for the purpose of declaration merging
@@ -75,7 +78,7 @@ export type ProcedureHandlerContext<State> = ServiceContext & {
    * Cancelling is not the same as closing procedure calls gracefully, please refer to
    * the river documentation to understand the difference between the two concepts.
    */
-  cancel: () => void;
+  cancel: (message?: string) => ErrResult<Static<typeof CancelResultSchema>>;
   /**
    * This signal is a standard [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
    * triggered when the procedure invocation is done. This signal tracks the invocation/request finishing

--- a/router/errors.ts
+++ b/router/errors.ts
@@ -73,6 +73,14 @@ export function castTypeboxValueErrors(
 }
 
 /**
+ * A schema for cancel payloads sent from the client
+ */
+export const CancelResultSchema = Type.Object({
+  code: Type.Literal(CANCEL_CODE),
+  message: Type.String(),
+});
+
+/**
  * {@link ReaderErrorSchema} is the schema for all the built-in river errors that
  * can be emitted to a reader (request reader on the server, and response reader
  * on the client).
@@ -96,10 +104,7 @@ export const ReaderErrorSchema = Type.Union([
       }),
     ),
   }),
-  Type.Object({
-    code: Type.Literal(CANCEL_CODE),
-    message: Type.String(),
-  }),
+  CancelResultSchema,
 ]) satisfies ProcedureErrorSchemaType;
 
 /**

--- a/router/procedures.ts
+++ b/router/procedures.ts
@@ -3,7 +3,11 @@ import { Static, TNever, TSchema, Type } from '@sinclair/typebox';
 import { ProcedureHandlerContext } from './context';
 import { Result } from './result';
 import { Readable, Writable } from './streams';
-import { ProcedureErrorSchemaType, ReaderErrorSchema } from './errors';
+import {
+  CancelResultSchema,
+  ProcedureErrorSchemaType,
+  ReaderErrorSchema,
+} from './errors';
 
 /**
  * Brands a type to prevent it from being directly constructed.
@@ -35,6 +39,8 @@ export type ValidProcType =
  */
 export type PayloadType = TSchema;
 
+export type Cancellable<T> = T | Static<typeof CancelResultSchema>;
+
 /**
  * Procedure for a single message in both directions (1:1).
  *
@@ -57,7 +63,7 @@ export interface RpcProcedure<
   handler(param: {
     ctx: ProcedureHandlerContext<State>;
     reqInit: Static<RequestInit>;
-  }): Promise<Result<Static<ResponseData>, Static<ResponseErr>>>;
+  }): Promise<Result<Static<ResponseData>, Cancellable<Static<ResponseErr>>>>;
 }
 
 /**
@@ -90,7 +96,7 @@ export interface UploadProcedure<
       Static<RequestData>,
       Static<typeof ReaderErrorSchema>
     >;
-  }): Promise<Result<Static<ResponseData>, Static<ResponseErr>>>;
+  }): Promise<Result<Static<ResponseData>, Cancellable<Static<ResponseErr>>>>;
 }
 
 /**
@@ -115,7 +121,9 @@ export interface SubscriptionProcedure<
   handler(param: {
     ctx: ProcedureHandlerContext<State>;
     reqInit: Static<RequestInit>;
-    resWritable: Writable<Result<Static<ResponseData>, Static<ResponseErr>>>;
+    resWritable: Writable<
+      Result<Static<ResponseData>, Cancellable<Static<ResponseErr>>>
+    >;
   }): Promise<void | undefined>;
 }
 
@@ -149,7 +157,9 @@ export interface StreamProcedure<
       Static<RequestData>,
       Static<typeof ReaderErrorSchema>
     >;
-    resWritable: Writable<Result<Static<ResponseData>, Static<ResponseErr>>>;
+    resWritable: Writable<
+      Result<Static<ResponseData>, Cancellable<Static<ResponseErr>>>
+    >;
   }): Promise<void | undefined>;
 }
 

--- a/testUtil/fixtures/services.ts
+++ b/testUtil/fixtures/services.ts
@@ -287,6 +287,25 @@ export const UploadableServiceSchema = ServiceSchema.define({
       return Ok({ result: `${reqInit.prefix} ${result}` });
     },
   }),
+
+  cancellableAdd: Procedure.upload({
+    requestInit: Type.Object({}),
+    requestData: Type.Object({ n: Type.Number() }),
+    responseData: Type.Object({ result: Type.Number() }),
+    async handler({ ctx, reqReadable }) {
+      let result = 0;
+      for await (const req of reqReadable) {
+        const n = unwrapOrThrow(req).n;
+        if (result + n >= 10) {
+          return ctx.cancel("can't add more than 10");
+        }
+
+        result += n;
+      }
+
+      return Ok({ result: result });
+    },
+  }),
 });
 
 const RecursivePayload = Type.Recursive((This) =>


### PR DESCRIPTION
## Why

we want to be able to cancel a procedure from within a handler (e.g. in the upload case, if the client unexpectedly disconnects, we probably want to just cancel instead of returning some bogus result)

## What changed

union the cancel type into all procedure handlers, we don't need to change the client as the client already has cancel in the reader type

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
