### PR TITLE
small type updates: unexport unwrapOrThrow, add regression test for ctx.cancel return

### DIFF
--- a/__tests__/typescript-stress.test.ts
+++ b/__tests__/typescript-stress.test.ts
@@ -234,7 +234,33 @@ const services = {
       requestInit: Type.Object({}),
       requestData: Type.Object({ n: Type.Number() }),
       responseData: Type.Object({ n: Type.Number() }),
-      async handler() {
+      responseError: flattenErrorType(
+        Type.Union([
+          Type.Object({
+            code: Type.Literal('ERROR1'),
+            message: Type.String(),
+          }),
+          Type.Object({
+            code: Type.Literal('ERROR2'),
+            message: Type.String(),
+          }),
+        ]),
+      ),
+      async handler({ ctx, reqReadable }) {
+        for await (const { ok, payload } of reqReadable) {
+          if (!ok) {
+            return ctx.cancel();
+          }
+
+          if (payload.n === 1) {
+            return Err({ code: 'ERROR1', message: 'n is 1' });
+          }
+
+          if (payload.n === 2) {
+            return Err({ code: 'ERROR2', message: 'n is 2' });
+          }
+        }
+
         return Ok({ n: 1 });
       },
     }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.206.0",
+  "version": "0.207.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.206.0",
+      "version": "0.207.0",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.206.0",
+  "version": "0.207.0",
   "type": "module",
   "exports": {
     ".": {

--- a/router/index.ts
+++ b/router/index.ts
@@ -49,7 +49,7 @@ export type {
   ServiceContext,
   ProcedureHandlerContext,
 } from './context';
-export { Ok, Err, unwrapOrThrow } from './result';
+export { Ok, Err } from './result';
 export type {
   Result,
   ErrResult,


### PR DESCRIPTION
## Why

- people kept misusing unwrapOrThrow in production procedures

## What changed

- unexport unwrapOrThrow
- add a simple regression test for ctx.cancel in a union-ed case

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [x] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
