### PR TITLE
make passive heartbeat case respond async

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.207.0",
+  "version": "0.207.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.207.0",
+      "version": "0.207.1",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.207.0",
+  "version": "0.207.1",
   "type": "module",
   "exports": {
     ".": {

--- a/transport/sessionStateMachine/SessionConnected.ts
+++ b/transport/sessionStateMachine/SessionConnected.ts
@@ -84,8 +84,7 @@ export class SessionConnected<
     // send any buffered messages
     if (this.sendBuffer.length > 0) {
       this.log?.info(
-        `sending ${
-          this.sendBuffer.length
+        `sending ${this.sendBuffer.length
         } buffered messages, starting at seq ${this.nextSeq()}`,
         this.loggingMetadata,
       );
@@ -227,6 +226,9 @@ export class SessionConnected<
     // heartbeat mode and should send a response to the ack
     if (!this.isActivelyHeartbeating) {
       // purposefully make this async to avoid weird browser behavior
+      // where _some_ browsers will decide that it is ok to interrupt fully
+      // synchronous code execution (e.g. an existing .send) to receive a
+      // websocket message and hit this codepath
       void Promise.resolve().then(() => {
         this.sendHeartbeat();
       });

--- a/transport/sessionStateMachine/SessionConnected.ts
+++ b/transport/sessionStateMachine/SessionConnected.ts
@@ -84,7 +84,8 @@ export class SessionConnected<
     // send any buffered messages
     if (this.sendBuffer.length > 0) {
       this.log?.info(
-        `sending ${this.sendBuffer.length
+        `sending ${
+          this.sendBuffer.length
         } buffered messages, starting at seq ${this.nextSeq()}`,
         this.loggingMetadata,
       );

--- a/transport/sessionStateMachine/common.ts
+++ b/transport/sessionStateMachine/common.ts
@@ -281,6 +281,10 @@ export abstract class IdentifiedSession extends CommonSession {
   constructMsg<Payload>(
     partialMsg: PartialTransportMessage<Payload>,
   ): TransportMessage<Payload> {
+    if (this._isConsumed) {
+      throw new Error(ERR_CONSUMED);
+    }
+
     const msg = {
       ...partialMsg,
       id: generateId(),

--- a/transport/sessionStateMachine/stateMachine.test.ts
+++ b/transport/sessionStateMachine/stateMachine.test.ts
@@ -1958,7 +1958,9 @@ describe('session state machine', () => {
       );
 
       // make sure the session acks the heartbeat
-      expect(conn.send).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(conn.send).toHaveBeenCalledTimes(1);
+      });
     });
 
     test('does not dispatch acks', async () => {


### PR DESCRIPTION
## Why

- we've traded all of our `received out-of-order msg, closing connection` for `invariant violation: would have sent out of order msg`
- some browsers allow events to [pre-empt / interrupt existing sync code](https://sqlpey.com/javascript/is-javascript-truly-single-threaded/#intricacies-of-event-triggering) which could cause problems

## What changed

- make the response wait a tick

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
