### PR TITLE
add more debug for message ordering violation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.207.1",
+  "version": "0.207.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.207.1",
+      "version": "0.207.2",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.207.1",
+  "version": "0.207.2",
   "type": "module",
   "exports": {
     ".": {

--- a/transport/sessionStateMachine/SessionConnected.ts
+++ b/transport/sessionStateMachine/SessionConnected.ts
@@ -84,7 +84,6 @@ export class SessionConnected<
         },
       });
 
-      this.closeConnection();
       throw new Error(msg);
     }
   }
@@ -147,7 +146,7 @@ export class SessionConnected<
         // this just helps us in cases where we have a proxying setup where the server has closed
         // the connection but the proxy hasn't synchronized the server-side close to the client so
         // the client isn't stuck with a pseudo-dead connection forever
-        this.closeConnection();
+        this.conn.close();
         clearInterval(this.heartbeatHandle);
         this.heartbeatHandle = undefined;
 
@@ -184,13 +183,6 @@ export class SessionConnected<
     });
   }
 
-  closeConnection() {
-    this.conn.removeDataListener(this.onMessageData);
-    this.conn.removeCloseListener(this.listeners.onConnectionClosed);
-    this.conn.removeErrorListener(this.listeners.onConnectionErrored);
-    this.conn.close();
-  }
-
   onMessageData = (msg: Uint8Array) => {
     const parsedMsg = this.parseMsg(msg);
     if (parsedMsg === null) {
@@ -224,7 +216,7 @@ export class SessionConnected<
 
         // try to recover by closing the connection and re-handshaking
         // with the session intact
-        this.closeConnection();
+        this.conn.close();
       }
 
       return;

--- a/transport/sessionStateMachine/SessionConnected.ts
+++ b/transport/sessionStateMachine/SessionConnected.ts
@@ -121,7 +121,7 @@ export class SessionConnected<
       for (const msg of this.sendBuffer) {
         this.assertSendOrdering(msg);
         this.conn.send(this.options.codec.toBuffer(msg));
-        this.seqSent = Math.max(msg.seq, this.seqSent);
+        this.seqSent = msg.seq;
       }
     }
 


### PR DESCRIPTION
## Why

still getting `invariant violation: would have sent out of order msg`

## What changed

track last 10 sent messages along with their stack trace

this unfortunately degrades message throughput from ~46krps to ~16kps but should be more than enough for prod as is, we just need to find the bug and fix it and then remove this again

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
