### PR TITLE
make client-side heartbeat timeout instead of interval based

### DIFF
--- a/testUtil/duplex/duplexPair.ts
+++ b/testUtil/duplex/duplexPair.ts
@@ -56,6 +56,17 @@ export function duplexPair(): [DuplexSide, DuplexSide] {
   const side1 = new DuplexSide();
   side0[kInitOtherSide](side1);
   side1[kInitOtherSide](side0);
+  side0.on('close', () => {
+    setImmediate(() => {
+      side1.destroy();
+    });
+  });
+
+  side1.on('close', () => {
+    setImmediate(() => {
+      side0.destroy();
+    });
+  });
 
   return [side0, side1];
 }

--- a/testUtil/fixtures/mockTransport.ts
+++ b/testUtil/fixtures/mockTransport.ts
@@ -166,14 +166,14 @@ export function createMockTransportNetwork(
 
       // kill all connections while we're at it
       for (const conn of Object.values(connections.get())) {
-        conn.serverToClient.end();
-        conn.clientToServer.end();
+        conn.serverToClient.destroy();
+        conn.clientToServer.destroy();
       }
     },
     cleanup() {
       for (const conn of Object.values(connections.get())) {
-        conn.serverToClient.end();
-        conn.clientToServer.end();
+        conn.serverToClient.destroy();
+        conn.clientToServer.destroy();
       }
     },
   };

--- a/transport/sessionStateMachine/SessionConnecting.ts
+++ b/transport/sessionStateMachine/SessionConnecting.ts
@@ -83,7 +83,6 @@ export class SessionConnecting<
 
   _handleStateExit(): void {
     super._handleStateExit();
-
     if (this.connectionTimeout) {
       clearTimeout(this.connectionTimeout);
       this.connectionTimeout = undefined;
@@ -91,8 +90,9 @@ export class SessionConnecting<
   }
 
   _handleClose(): void {
+    super._handleClose();
+
     // close the pending connection if it resolves
     this.bestEffortClose();
-    super._handleClose();
   }
 }

--- a/transport/sessionStateMachine/common.ts
+++ b/transport/sessionStateMachine/common.ts
@@ -281,10 +281,6 @@ export abstract class IdentifiedSession extends CommonSession {
   constructMsg<Payload>(
     partialMsg: PartialTransportMessage<Payload>,
   ): TransportMessage<Payload> {
-    if (this._isConsumed) {
-      throw new Error(ERR_CONSUMED);
-    }
-
     const msg = {
       ...partialMsg,
       id: generateId(),


### PR DESCRIPTION
## Why

- https://developer.chrome.com/blog/timer-throttling-in-chrome-88 causes intervals to be heavily throttled, prefer to use a single timeout

## What changed

- refactor to use a single timeout instead of heartbeatsUntilDead * intervals
- fix some mock transport harness logic
- remove stack tracking code, it didnt tell us much 😭 

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
