### PR TITLE
dont need multiple listeners on connection

### DIFF
--- a/testUtil/fixtures/mockTransport.ts
+++ b/testUtil/fixtures/mockTransport.ts
@@ -18,21 +18,15 @@ export class InMemoryConnection extends Connection {
     this.conn.allowHalfOpen = false;
 
     this.conn.on('data', (data: Uint8Array) => {
-      for (const cb of this.dataListeners) {
-        cb(data);
-      }
+      this.dataListener?.(data);
     });
 
     this.conn.on('close', () => {
-      for (const cb of this.closeListeners) {
-        cb();
-      }
+      this.closeListener?.();
     });
 
     this.conn.on('error', (err) => {
-      for (const cb of this.errorListeners) {
-        cb(err);
-      }
+      this.errorListener?.(err);
     });
   }
 

--- a/transport/sessionStateMachine/SessionConnected.ts
+++ b/transport/sessionStateMachine/SessionConnected.ts
@@ -91,9 +91,9 @@ export class SessionConnected<
     this.conn = props.conn;
     this.listeners = props.listeners;
 
-    this.conn.addDataListener(this.onMessageData);
-    this.conn.addCloseListener(this.listeners.onConnectionClosed);
-    this.conn.addErrorListener(this.listeners.onConnectionErrored);
+    this.conn.setDataListener(this.onMessageData);
+    this.conn.setCloseListener(this.listeners.onConnectionClosed);
+    this.conn.setErrorListener(this.listeners.onConnectionErrored);
   }
 
   sendBufferedMessages(): SendBufferResult {
@@ -240,9 +240,9 @@ export class SessionConnected<
 
   _handleStateExit(): void {
     super._handleStateExit();
-    this.conn.removeDataListener(this.onMessageData);
-    this.conn.removeCloseListener(this.listeners.onConnectionClosed);
-    this.conn.removeErrorListener(this.listeners.onConnectionErrored);
+    this.conn.removeDataListener();
+    this.conn.removeCloseListener();
+    this.conn.removeErrorListener();
 
     if (this.heartbeatHandle) {
       clearInterval(this.heartbeatHandle);

--- a/transport/sessionStateMachine/SessionHandshaking.ts
+++ b/transport/sessionStateMachine/SessionHandshaking.ts
@@ -56,9 +56,9 @@ export class SessionHandshaking<
       this.listeners.onHandshakeTimeout();
     }, this.options.handshakeTimeoutMs);
 
-    this.conn.addDataListener(this.onHandshakeData);
-    this.conn.addErrorListener(this.listeners.onConnectionErrored);
-    this.conn.addCloseListener(this.listeners.onConnectionClosed);
+    this.conn.setDataListener(this.onHandshakeData);
+    this.conn.setErrorListener(this.listeners.onConnectionErrored);
+    this.conn.setCloseListener(this.listeners.onConnectionClosed);
   }
 
   get loggingMetadata() {
@@ -88,9 +88,9 @@ export class SessionHandshaking<
 
   _handleStateExit(): void {
     super._handleStateExit();
-    this.conn.removeDataListener(this.onHandshakeData);
-    this.conn.removeErrorListener(this.listeners.onConnectionErrored);
-    this.conn.removeCloseListener(this.listeners.onConnectionClosed);
+    this.conn.removeDataListener();
+    this.conn.removeErrorListener();
+    this.conn.removeCloseListener();
 
     if (this.handshakeTimeout) {
       clearTimeout(this.handshakeTimeout);

--- a/transport/sessionStateMachine/SessionWaitingForHandshake.ts
+++ b/transport/sessionStateMachine/SessionWaitingForHandshake.ts
@@ -54,9 +54,9 @@ export class SessionWaitingForHandshake<
       this.listeners.onHandshakeTimeout();
     }, this.options.handshakeTimeoutMs);
 
-    this.conn.addDataListener(this.onHandshakeData);
-    this.conn.addErrorListener(this.listeners.onConnectionErrored);
-    this.conn.addCloseListener(this.listeners.onConnectionClosed);
+    this.conn.setDataListener(this.onHandshakeData);
+    this.conn.setErrorListener(this.listeners.onConnectionErrored);
+    this.conn.setCloseListener(this.listeners.onConnectionClosed);
   }
 
   get loggingMetadata() {
@@ -88,9 +88,9 @@ export class SessionWaitingForHandshake<
   }
 
   _handleStateExit(): void {
-    this.conn.removeDataListener(this.onHandshakeData);
-    this.conn.removeErrorListener(this.listeners.onConnectionErrored);
-    this.conn.removeCloseListener(this.listeners.onConnectionClosed);
+    this.conn.removeDataListener();
+    this.conn.removeErrorListener();
+    this.conn.removeCloseListener();
     clearTimeout(this.handshakeTimeout);
     this.handshakeTimeout = undefined;
   }


### PR DESCRIPTION
## Why

the connection class used to support a set of listeners for each type, YAGNI! and can conceal potential failures where we are dispatching events to multiple sessions

## What changed

make listeners `cb | undefined` instead of `Set<cb>`

## Versioning

- [ ] Breaking protocol change
- [x] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
