### PR TITLE
more invariant fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.207.3",
+  "version": "0.207.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.207.3",
+      "version": "0.207.4",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.207.3",
+  "version": "0.207.4",
   "type": "module",
   "exports": {
     ".": {

--- a/router/client.ts
+++ b/router/client.ts
@@ -32,13 +32,10 @@ import { Value } from '@sinclair/typebox/value';
 import { PayloadType, ValidProcType } from './procedures';
 import {
   BaseErrorSchemaType,
-  ErrResultSchema,
   CANCEL_CODE,
-  ReaderErrorSchema,
+  ReaderErrorResultSchema,
   UNEXPECTED_DISCONNECT_CODE,
 } from './errors';
-
-const ReaderErrResultSchema = ErrResultSchema(ReaderErrorSchema);
 
 interface CallOptions {
   signal?: AbortSignal;
@@ -384,22 +381,22 @@ function handleProc(
       cleanClose = false;
 
       span.addEvent('received cancel');
-      let cancelResult: Static<typeof ReaderErrResultSchema>;
+      let cancelResult: Static<typeof ReaderErrorResultSchema>;
 
-      if (Value.Check(ReaderErrResultSchema, msg.payload)) {
+      if (Value.Check(ReaderErrorResultSchema, msg.payload)) {
         cancelResult = msg.payload;
       } else {
         cancelResult = Err({
           code: CANCEL_CODE,
           message: 'stream cancelled with invalid payload',
         });
-        transport.log?.error(
+        transport.log?.warn(
           'got stream cancel without a valid protocol error',
           {
             clientId: transport.clientId,
             transportMessage: msg,
             validationErrors: [
-              ...Value.Errors(ReaderErrResultSchema, msg.payload),
+              ...Value.Errors(ReaderErrorResultSchema, msg.payload),
             ],
           },
         );

--- a/router/context.ts
+++ b/router/context.ts
@@ -2,7 +2,7 @@ import { Span } from '@opentelemetry/api';
 import { TransportClientId } from '../transport/message';
 import { SessionId } from '../transport/sessionStateMachine/common';
 import { ErrResult } from './result';
-import { CancelResultSchema } from './errors';
+import { CancelErrorSchema } from './errors';
 import { Static } from '@sinclair/typebox';
 
 /**
@@ -78,7 +78,7 @@ export type ProcedureHandlerContext<State> = ServiceContext & {
    * Cancelling is not the same as closing procedure calls gracefully, please refer to
    * the river documentation to understand the difference between the two concepts.
    */
-  cancel: (message?: string) => ErrResult<Static<typeof CancelResultSchema>>;
+  cancel: (message?: string) => ErrResult<Static<typeof CancelErrorSchema>>;
   /**
    * This signal is a standard [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
    * triggered when the procedure invocation is done. This signal tracks the invocation/request finishing

--- a/router/errors.ts
+++ b/router/errors.ts
@@ -75,10 +75,12 @@ export function castTypeboxValueErrors(
 /**
  * A schema for cancel payloads sent from the client
  */
-export const CancelResultSchema = Type.Object({
+export const CancelErrorSchema = Type.Object({
   code: Type.Literal(CANCEL_CODE),
   message: Type.String(),
 });
+
+export const CancelResultSchema = ErrResultSchema(CancelErrorSchema);
 
 /**
  * {@link ReaderErrorSchema} is the schema for all the built-in river errors that
@@ -104,8 +106,10 @@ export const ReaderErrorSchema = Type.Union([
       }),
     ),
   }),
-  CancelResultSchema,
+  CancelErrorSchema,
 ]) satisfies ProcedureErrorSchemaType;
+
+export const ReaderErrorResultSchema = ErrResultSchema(ReaderErrorSchema);
 
 /**
  * Represents an acceptable schema to pass to a procedure.

--- a/router/procedures.ts
+++ b/router/procedures.ts
@@ -4,7 +4,7 @@ import { ProcedureHandlerContext } from './context';
 import { Result } from './result';
 import { Readable, Writable } from './streams';
 import {
-  CancelResultSchema,
+  CancelErrorSchema,
   ProcedureErrorSchemaType,
   ReaderErrorSchema,
 } from './errors';
@@ -39,7 +39,7 @@ export type ValidProcType =
  */
 export type PayloadType = TSchema;
 
-export type Cancellable<T> = T | Static<typeof CancelResultSchema>;
+export type Cancellable<T> = T | Static<typeof CancelErrorSchema>;
 
 /**
  * Procedure for a single message in both directions (1:1).

--- a/router/server.ts
+++ b/router/server.ts
@@ -283,9 +283,9 @@ class RiverServer<Services extends AnyServiceSchemaMap>
       }
 
       if (isStreamCancelBackwardsCompat(msg.controlFlags, protocolVersion)) {
-        let cancelResult: ErrResult<Static<typeof CancelResultSchema>>;
+        let cancelResult: Static<typeof CancelResultSchema>;
         if (Value.Check(CancelResultSchema, msg.payload)) {
-          cancelResult = Err(msg.payload);
+          cancelResult = msg.payload;
         } else {
           // If the payload is unexpected, then we just construct our own cancel result
           cancelResult = Err({

--- a/testUtil/fixtures/mockTransport.ts
+++ b/testUtil/fixtures/mockTransport.ts
@@ -18,21 +18,15 @@ export class InMemoryConnection extends Connection {
     this.conn.allowHalfOpen = false;
 
     this.conn.on('data', (data: Uint8Array) => {
-      for (const cb of this.dataListeners) {
-        cb(data);
-      }
+      this.dataListener?.(data);
     });
 
     this.conn.on('close', () => {
-      for (const cb of this.closeListeners) {
-        cb();
-      }
+      this.closeListener?.();
     });
 
     this.conn.on('error', (err) => {
-      for (const cb of this.errorListeners) {
-        cb(err);
-      }
+      this.errorListener?.(err);
     });
   }
 

--- a/transport/client.ts
+++ b/transport/client.ts
@@ -319,17 +319,6 @@ export abstract class ClientTransport<
 
     const res = connectedSession.sendBufferedMessages();
     if (!res.ok) {
-      this.log?.error(`failed to send buffered messages: ${res.reason}`, {
-        ...connectedSession.loggingMetadata,
-        transportMessage: msg,
-      });
-
-      this.protocolError({
-        type: ProtocolError.MessageSendFailure,
-        message: res.reason,
-      });
-      this.deleteSession(connectedSession, { unhealthy: true });
-
       return;
     }
 

--- a/transport/server.ts
+++ b/transport/server.ts
@@ -545,20 +545,6 @@ export abstract class ServerTransport<
 
     const bufferSendRes = connectedSession.sendBufferedMessages();
     if (!bufferSendRes.ok) {
-      this.log?.error(
-        `failed to send buffered messages: ${bufferSendRes.reason}`,
-        {
-          ...connectedSession.loggingMetadata,
-          transportMessage: msg,
-        },
-      );
-
-      this.protocolError({
-        type: ProtocolError.MessageSendFailure,
-        message: bufferSendRes.reason,
-      });
-      this.deleteSession(connectedSession, { unhealthy: true });
-
       return;
     }
 

--- a/transport/sessionStateMachine/SessionConnected.ts
+++ b/transport/sessionStateMachine/SessionConnected.ts
@@ -91,9 +91,9 @@ export class SessionConnected<
     this.conn = props.conn;
     this.listeners = props.listeners;
 
-    this.conn.addDataListener(this.onMessageData);
-    this.conn.addCloseListener(this.listeners.onConnectionClosed);
-    this.conn.addErrorListener(this.listeners.onConnectionErrored);
+    this.conn.setDataListener(this.onMessageData);
+    this.conn.setCloseListener(this.listeners.onConnectionClosed);
+    this.conn.setErrorListener(this.listeners.onConnectionErrored);
   }
 
   sendBufferedMessages(): SendBufferResult {
@@ -240,9 +240,9 @@ export class SessionConnected<
 
   _handleStateExit(): void {
     super._handleStateExit();
-    this.conn.removeDataListener(this.onMessageData);
-    this.conn.removeCloseListener(this.listeners.onConnectionClosed);
-    this.conn.removeErrorListener(this.listeners.onConnectionErrored);
+    this.conn.removeDataListener();
+    this.conn.removeCloseListener();
+    this.conn.removeErrorListener();
 
     if (this.heartbeatHandle) {
       clearInterval(this.heartbeatHandle);

--- a/transport/sessionStateMachine/SessionHandshaking.ts
+++ b/transport/sessionStateMachine/SessionHandshaking.ts
@@ -56,9 +56,9 @@ export class SessionHandshaking<
       this.listeners.onHandshakeTimeout();
     }, this.options.handshakeTimeoutMs);
 
-    this.conn.addDataListener(this.onHandshakeData);
-    this.conn.addErrorListener(this.listeners.onConnectionErrored);
-    this.conn.addCloseListener(this.listeners.onConnectionClosed);
+    this.conn.setDataListener(this.onHandshakeData);
+    this.conn.setErrorListener(this.listeners.onConnectionErrored);
+    this.conn.setCloseListener(this.listeners.onConnectionClosed);
   }
 
   get loggingMetadata() {
@@ -88,9 +88,9 @@ export class SessionHandshaking<
 
   _handleStateExit(): void {
     super._handleStateExit();
-    this.conn.removeDataListener(this.onHandshakeData);
-    this.conn.removeErrorListener(this.listeners.onConnectionErrored);
-    this.conn.removeCloseListener(this.listeners.onConnectionClosed);
+    this.conn.removeDataListener();
+    this.conn.removeErrorListener();
+    this.conn.removeCloseListener();
 
     if (this.handshakeTimeout) {
       clearTimeout(this.handshakeTimeout);

--- a/transport/sessionStateMachine/SessionWaitingForHandshake.ts
+++ b/transport/sessionStateMachine/SessionWaitingForHandshake.ts
@@ -54,9 +54,9 @@ export class SessionWaitingForHandshake<
       this.listeners.onHandshakeTimeout();
     }, this.options.handshakeTimeoutMs);
 
-    this.conn.addDataListener(this.onHandshakeData);
-    this.conn.addErrorListener(this.listeners.onConnectionErrored);
-    this.conn.addCloseListener(this.listeners.onConnectionClosed);
+    this.conn.setDataListener(this.onHandshakeData);
+    this.conn.setErrorListener(this.listeners.onConnectionErrored);
+    this.conn.setCloseListener(this.listeners.onConnectionClosed);
   }
 
   get loggingMetadata() {
@@ -88,9 +88,9 @@ export class SessionWaitingForHandshake<
   }
 
   _handleStateExit(): void {
-    this.conn.removeDataListener(this.onHandshakeData);
-    this.conn.removeErrorListener(this.listeners.onConnectionErrored);
-    this.conn.removeCloseListener(this.listeners.onConnectionClosed);
+    this.conn.removeDataListener();
+    this.conn.removeErrorListener();
+    this.conn.removeCloseListener();
     clearTimeout(this.handshakeTimeout);
     this.handshakeTimeout = undefined;
   }

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -260,7 +260,7 @@ export abstract class Transport<ConnType extends Connection> {
 
   // common listeners
   protected onSessionGracePeriodElapsed(session: Session<ConnType>) {
-    this.log?.warn(
+    this.log?.info(
       `session to ${session.to} grace period elapsed, closing`,
       session.loggingMetadata,
     );


### PR DESCRIPTION
## Why + What changed

- fix `got stream cancel without a valid protocol error`
- fix `session state has been consumed and is no longer valid: getting loggingMetadata on consumed state` (logging after protocol error + session deletion)

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
