### PR TITLE
Don't include session id and connect id in span names

### DIFF
--- a/tracing/index.ts
+++ b/tracing/index.ts
@@ -49,7 +49,7 @@ export function createSessionTelemetryInfo(
     : context.active();
 
   const span = tracer.startSpan(
-    `river.session.${sessionId}`,
+    `river.session`,
     {
       attributes: {
         component: 'river',
@@ -72,7 +72,7 @@ export function createConnectionTelemetryInfo(
   info: TelemetryInfo,
 ): TelemetryInfo {
   const span = tracer.startSpan(
-    `connection ${connection.id}`,
+    `river.connection`,
     {
       attributes: {
         component: 'river',


### PR DESCRIPTION
## Why

High cardinality in span names, should be enough as attributes

## What changed

Change span names for river session and connection to exclude ids

## Versioning

- [ ] Breaking protocol change
- [x] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
