### PR TITLE
Add read-only middleware support

### DIFF
--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -194,21 +194,13 @@ describe('middleware test', () => {
 
   test('apply multiple middlewares in order', async () => {
     const services = { test: TestServiceSchema };
-    // counter for checking the call order
-    let callOrder = 0;
     const middleware1 = vi.fn(({ next }: MiddlewareParam) => {
-      callOrder++;
-      expect(callOrder).toBe(1);
       next();
     });
     const middleware2 = vi.fn(({ next }: MiddlewareParam) => {
-      callOrder++;
-      expect(callOrder).toBe(2);
       next();
     });
     const middleware3 = vi.fn(({ next }: MiddlewareParam) => {
-      callOrder++;
-      expect(callOrder).toBe(3);
       next();
     });
     createServer(mockTransportNetwork.getServerTransport(), services, {
@@ -220,6 +212,13 @@ describe('middleware test', () => {
     );
 
     const result = await client.test.add.rpc({ n: 3 });
+
+    expect(middleware1.mock.invocationCallOrder[0]).toBeLessThan(
+      middleware2.mock.invocationCallOrder[0],
+    );
+    expect(middleware2.mock.invocationCallOrder[0]).toBeLessThan(
+      middleware3.mock.invocationCallOrder[0],
+    );
     expect(result).toStrictEqual({ ok: true, payload: { result: 3 } });
   });
 });

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../testUtil/fixtures/services';
 import { createClient, createServer } from '../router';
 import { createMockTransportNetwork } from '../testUtil/fixtures/mockTransport';
+import { MiddlewareParam } from '../router/server';
 
 describe('middleware test', () => {
   let mockTransportNetwork: ReturnType<typeof createMockTransportNetwork>;
@@ -22,7 +23,7 @@ describe('middleware test', () => {
 
   test('apply read-only middleware to rpc', async () => {
     const services = { test: TestServiceSchema };
-    const middleware = vi.fn();
+    const middleware = vi.fn(({ next }: MiddlewareParam) => next());
     createServer(mockTransportNetwork.getServerTransport(), services, {
       middlewares: [middleware],
     });
@@ -55,7 +56,7 @@ describe('middleware test', () => {
 
   test('apply read-only middleware to stream', async () => {
     const services = { test: TestServiceSchema };
-    const middleware = vi.fn();
+    const middleware = vi.fn(({ next }: MiddlewareParam) => next());
     createServer(mockTransportNetwork.getServerTransport(), services, {
       middlewares: [middleware],
     });
@@ -98,7 +99,7 @@ describe('middleware test', () => {
 
   test('apply read-only middleware to subscriptions', async () => {
     const services = { test: SubscribableServiceSchema };
-    const middleware = vi.fn();
+    const middleware = vi.fn(({ next }: MiddlewareParam) => next());
     createServer(mockTransportNetwork.getServerTransport(), services, {
       middlewares: [middleware],
     });
@@ -155,7 +156,7 @@ describe('middleware test', () => {
 
   test('apply read-only middleware to uploads', async () => {
     const services = { test: UploadableServiceSchema };
-    const middleware = vi.fn();
+    const middleware = vi.fn(({ next }: MiddlewareParam) => next());
     createServer(mockTransportNetwork.getServerTransport(), services, {
       middlewares: [middleware],
     });
@@ -195,17 +196,20 @@ describe('middleware test', () => {
     const services = { test: TestServiceSchema };
     // counter for checking the call order
     let callOrder = 0;
-    const middleware1 = vi.fn(() => {
+    const middleware1 = vi.fn(({ next }: MiddlewareParam) => {
       callOrder++;
       expect(callOrder).toBe(1);
+      next();
     });
-    const middleware2 = vi.fn(() => {
+    const middleware2 = vi.fn(({ next }: MiddlewareParam) => {
       callOrder++;
       expect(callOrder).toBe(2);
+      next();
     });
-    const middleware3 = vi.fn(() => {
+    const middleware3 = vi.fn(({ next }: MiddlewareParam) => {
       callOrder++;
       expect(callOrder).toBe(3);
+      next();
     });
     createServer(mockTransportNetwork.getServerTransport(), services, {
       middlewares: [middleware1, middleware2, middleware3],

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -1,0 +1,220 @@
+import { isReadableDone, readNextResult } from '../testUtil';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  TestServiceSchema,
+  SubscribableServiceSchema,
+  UploadableServiceSchema,
+} from '../testUtil/fixtures/services';
+import { createClient, createServer } from '../router';
+import { createMockTransportNetwork } from '../testUtil/fixtures/mockTransport';
+
+describe('middleware test', () => {
+  let mockTransportNetwork: ReturnType<typeof createMockTransportNetwork>;
+
+  beforeEach(async () => {
+    mockTransportNetwork = createMockTransportNetwork();
+  });
+
+  afterEach(async () => {
+    await mockTransportNetwork.cleanup();
+  });
+
+  test('apply read-only middleware to rpc', async () => {
+    const services = { test: TestServiceSchema };
+    const middleware = vi.fn();
+    createServer(mockTransportNetwork.getServerTransport(), services, {
+      middlewares: [middleware],
+    });
+    const client = createClient<typeof services>(
+      mockTransportNetwork.getClientTransport('client'),
+      'SERVER',
+    );
+
+    const result = await client.test.add.rpc({ n: 3 });
+    expect(middleware).toHaveBeenCalledOnce();
+    expect(middleware).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          serviceName: 'test',
+          procedureName: 'add',
+          sessionId: expect.stringContaining('session-'),
+          span: expect.objectContaining({}),
+          streamId: expect.stringContaining(''),
+          signal: expect.objectContaining({}),
+          state: expect.objectContaining({}),
+        }),
+        reqInit: {
+          n: 3,
+        },
+      }),
+    );
+
+    expect(result).toStrictEqual({ ok: true, payload: { result: 3 } });
+  });
+
+  test('apply read-only middleware to stream', async () => {
+    const services = { test: TestServiceSchema };
+    const middleware = vi.fn();
+    createServer(mockTransportNetwork.getServerTransport(), services, {
+      middlewares: [middleware],
+    });
+    const client = createClient<typeof services>(
+      mockTransportNetwork.getClientTransport('client'),
+      'SERVER',
+    );
+
+    const { reqWritable, resReadable } = client.test.echo.stream({});
+
+    reqWritable.write({ msg: 'abc', ignore: false });
+    reqWritable.write({ msg: 'def', ignore: true });
+    reqWritable.write({ msg: 'ghi', ignore: false });
+    reqWritable.close();
+
+    const result1 = await readNextResult(resReadable);
+    expect(result1).toStrictEqual({ ok: true, payload: { response: 'abc' } });
+
+    const result2 = await readNextResult(resReadable);
+    expect(result2).toStrictEqual({ ok: true, payload: { response: 'ghi' } });
+
+    expect(await isReadableDone(resReadable)).toEqual(true);
+
+    expect(middleware).toHaveBeenCalledOnce();
+    expect(middleware).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          serviceName: 'test',
+          procedureName: 'echo',
+          sessionId: expect.stringContaining('session-'),
+          span: expect.objectContaining({}),
+          streamId: expect.stringContaining(''),
+          signal: expect.objectContaining({}),
+          state: expect.objectContaining({}),
+        }),
+        reqInit: {},
+      }),
+    );
+  });
+
+  test('apply read-only middleware to subscriptions', async () => {
+    const services = { test: SubscribableServiceSchema };
+    const middleware = vi.fn();
+    createServer(mockTransportNetwork.getServerTransport(), services, {
+      middlewares: [middleware],
+    });
+    const client = createClient<typeof services>(
+      mockTransportNetwork.getClientTransport('client'),
+      'SERVER',
+    );
+
+    const { resReadable } = client.test.value.subscribe({});
+
+    const streamResult1 = await readNextResult(resReadable);
+    expect(streamResult1).toStrictEqual({ ok: true, payload: { result: 0 } });
+
+    expect(middleware).toHaveBeenCalledOnce();
+    expect(middleware).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          serviceName: 'test',
+          procedureName: 'value',
+          sessionId: expect.stringContaining('session-'),
+          span: expect.objectContaining({}),
+          streamId: expect.stringContaining(''),
+          signal: expect.objectContaining({}),
+          state: expect.objectContaining({}),
+        }),
+        reqInit: {},
+      }),
+    );
+
+    const result = await client.test.add.rpc({ n: 3 });
+    expect(result).toStrictEqual({ ok: true, payload: { result: 3 } });
+
+    expect(middleware).toHaveBeenCalledTimes(2);
+    expect(middleware).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          serviceName: 'test',
+          procedureName: 'add',
+          sessionId: expect.stringContaining('session-'),
+          span: expect.objectContaining({}),
+          streamId: expect.stringContaining(''),
+          signal: expect.objectContaining({}),
+          state: expect.objectContaining({}),
+        }),
+        reqInit: {
+          n: 3,
+        },
+      }),
+    );
+
+    const streamResult2 = await readNextResult(resReadable);
+    expect(streamResult2).toStrictEqual({ ok: true, payload: { result: 3 } });
+  });
+
+  test('apply read-only middleware to uploads', async () => {
+    const services = { test: UploadableServiceSchema };
+    const middleware = vi.fn();
+    createServer(mockTransportNetwork.getServerTransport(), services, {
+      middlewares: [middleware],
+    });
+    const client = createClient<typeof services>(
+      mockTransportNetwork.getClientTransport('client'),
+      'SERVER',
+    );
+
+    const { reqWritable, finalize } = client.test.addMultiple.upload({});
+
+    reqWritable.write({ n: 1 });
+    reqWritable.write({ n: 2 });
+    reqWritable.close();
+    expect(await finalize()).toStrictEqual({
+      ok: true,
+      payload: { result: 3 },
+    });
+
+    expect(middleware).toHaveBeenCalledOnce();
+    expect(middleware).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          serviceName: 'test',
+          procedureName: 'addMultiple',
+          sessionId: expect.stringContaining('session-'),
+          span: expect.objectContaining({}),
+          streamId: expect.stringContaining(''),
+          signal: expect.objectContaining({}),
+          state: expect.objectContaining({}),
+        }),
+        reqInit: {},
+      }),
+    );
+  });
+
+  test('apply multiple middlewares in order', async () => {
+    const services = { test: TestServiceSchema };
+    // counter for checking the call order
+    let callOrder = 0;
+    const middleware1 = vi.fn(() => {
+      callOrder++;
+      expect(callOrder).toBe(1);
+    });
+    const middleware2 = vi.fn(() => {
+      callOrder++;
+      expect(callOrder).toBe(2);
+    });
+    const middleware3 = vi.fn(() => {
+      callOrder++;
+      expect(callOrder).toBe(3);
+    });
+    createServer(mockTransportNetwork.getServerTransport(), services, {
+      middlewares: [middleware1, middleware2, middleware3],
+    });
+    const client = createClient<typeof services>(
+      mockTransportNetwork.getClientTransport('client'),
+      'SERVER',
+    );
+
+    const result = await client.test.add.rpc({ n: 3 });
+    expect(result).toStrictEqual({ ok: true, payload: { result: 3 } });
+  });
+});

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -6,11 +6,17 @@ import {
   TestServiceSchema,
   SubscribableServiceSchema,
   UploadableServiceSchema,
-  AsyncStorageSchemas,
 } from '../testUtil/fixtures/services';
-import { createClient, createServer } from '../router';
+import {
+  createClient,
+  createServer,
+  Ok,
+  Procedure,
+  ServiceSchema,
+  Middleware,
+} from '../router';
 import { createMockTransportNetwork } from '../testUtil/fixtures/mockTransport';
-import { MiddlewareContext, MiddlewareParam } from '../router/server';
+import { Type } from '@sinclair/typebox';
 
 describe('middleware test', () => {
   let mockTransportNetwork: ReturnType<typeof createMockTransportNetwork>;
@@ -25,7 +31,7 @@ describe('middleware test', () => {
 
   test('apply read-only middleware to rpc', async () => {
     const services = { test: TestServiceSchema };
-    const middleware = vi.fn(({ next }: MiddlewareParam) => next());
+    const middleware = vi.fn<Middleware>(({ next }) => next());
     createServer(mockTransportNetwork.getServerTransport(), services, {
       middlewares: [middleware],
     });
@@ -58,7 +64,7 @@ describe('middleware test', () => {
 
   test('apply read-only middleware to stream', async () => {
     const services = { test: TestServiceSchema };
-    const middleware = vi.fn(({ next }: MiddlewareParam) => next());
+    const middleware = vi.fn<Middleware>(({ next }) => next());
     createServer(mockTransportNetwork.getServerTransport(), services, {
       middlewares: [middleware],
     });
@@ -101,7 +107,7 @@ describe('middleware test', () => {
 
   test('apply read-only middleware to subscriptions', async () => {
     const services = { test: SubscribableServiceSchema };
-    const middleware = vi.fn(({ next }: MiddlewareParam) => next());
+    const middleware = vi.fn<Middleware>(({ next }) => next());
     createServer(mockTransportNetwork.getServerTransport(), services, {
       middlewares: [middleware],
     });
@@ -158,7 +164,7 @@ describe('middleware test', () => {
 
   test('apply read-only middleware to uploads', async () => {
     const services = { test: UploadableServiceSchema };
-    const middleware = vi.fn(({ next }: MiddlewareParam) => next());
+    const middleware = vi.fn<Middleware>(({ next }) => next());
     createServer(mockTransportNetwork.getServerTransport(), services, {
       middlewares: [middleware],
     });
@@ -196,13 +202,13 @@ describe('middleware test', () => {
 
   test('apply multiple middlewares in order', async () => {
     const services = { test: TestServiceSchema };
-    const middleware1 = vi.fn(({ next }: MiddlewareParam) => {
+    const middleware1 = vi.fn<Middleware>(({ next }) => {
       next();
     });
-    const middleware2 = vi.fn(({ next }: MiddlewareParam) => {
+    const middleware2 = vi.fn<Middleware>(({ next }) => {
       next();
     });
-    const middleware3 = vi.fn(({ next }: MiddlewareParam) => {
+    const middleware3 = vi.fn<Middleware>(({ next }) => {
       next();
     });
     createServer(mockTransportNetwork.getServerTransport(), services, {
@@ -224,133 +230,115 @@ describe('middleware test', () => {
     expect(result).toStrictEqual({ ok: true, payload: { result: 3 } });
   });
 
-  test('can capture uncaught promise rejection with context', async () => {
-    const services = { test: AsyncStorageSchemas };
-    const asyncLocalStorage = new AsyncLocalStorage<MiddlewareContext>();
+  // The reason we have a test for AsyncLocalStorage is that it depends on the
+  // details of how the server applies middlewares; they have to be called within
+  // callbacks so that the context is preserved.
+  // Unfortunately we put our selves in a tough situation where vitest doesn't support
+  // async hooks when using fake timers, and we have fake timers in our global setup, so
+  // we only rely on Promise.resolve().then(() => {}) to test context propagation.
+  test('AsyncLocalStorage context is propagated via AsyncLocalStorage.run', async () => {
+    const storage = new AsyncLocalStorage<{
+      readByHandler: boolean;
+      readByHandlerSignal: boolean;
+      readByOtherMiddleware: boolean;
+      readByMiddlewareSignal: boolean;
+    }>();
 
-    let capturedError: Error | null = null;
-    let capturedErrorCtx: MiddlewareContext | null = null;
+    const AsyncStorageSchemas = ServiceSchema.define({
+      gimmeStore: Procedure.rpc({
+        requestInit: Type.Object({}),
+        responseData: Type.Object({}),
+        async handler({ ctx }) {
+          ctx.signal.addEventListener('abort', () => {
+            const s = storage.getStore();
+            if (s) {
+              s.readByHandlerSignal = true;
+            }
+          });
 
-    const unhandledRejectionListener = (error: Error) => {
-      capturedError = error;
-      capturedErrorCtx = asyncLocalStorage.getStore() ?? null;
+          return Promise.resolve().then(() => {
+            const s = storage.getStore();
+            if (s) {
+              s.readByHandler = true;
+            }
+
+            return Ok({});
+          });
+        },
+      }),
+    });
+
+    // Kind of a funky AsyncLocalStorage set up where the store is
+    // actually accessible everywhere but we promise to always get it from
+    // the storage instance and only use store in our tests.
+    const store = {
+      readByHandler: false,
+      readByHandlerSignal: false,
+      readByOtherMiddleware: false,
+      readByMiddlewareSignal: false,
     };
 
-    process.on('unhandledRejection', unhandledRejectionListener);
+    const middleware = vi.fn<Middleware>(({ ctx, next }) => {
+      ctx.signal.addEventListener('abort', () => {
+        const s = storage.getStore();
+        if (s) {
+          s.readByMiddlewareSignal = true;
+        }
+      });
 
-    const middleware = vi.fn(({ ctx, next }: MiddlewareParam) => {
-      asyncLocalStorage.run(ctx, next);
+      storage.run(store, () => {
+        next();
+      });
     });
-    createServer(mockTransportNetwork.getServerTransport(), services, {
-      middlewares: [middleware],
-    });
-    const client = createClient<typeof services>(
-      mockTransportNetwork.getClientTransport('client'),
-      'SERVER',
-    );
+    // testing that middlewares in the chain inheret context from the previous
+    const middlewarThatReadsFromStorage = vi.fn<Middleware>(({ next }) => {
+      const s = storage.getStore();
+      if (s) {
+        s.readByOtherMiddleware = true;
+      }
 
-    const result = await client.test.uncaughtPromise.rpc({});
-    expect(result.ok).toBe(true);
-
-    process.off('unhandledRejection', unhandledRejectionListener);
-
-    expect(capturedError).not.toBeNull();
-    expect(capturedErrorCtx).not.toBeNull();
-    expect((capturedErrorCtx as unknown as MiddlewareContext).serviceName).toBe(
-      'test',
-    );
-    expect(
-      (capturedErrorCtx as unknown as MiddlewareContext).procedureName,
-    ).toBe('uncaughtPromise');
-  });
-
-  test('can capture uncaught exception in middleware with context', async () => {
-    const services = { test: TestServiceSchema };
-    const asyncLocalStorage = new AsyncLocalStorage<MiddlewareContext>();
-
-    let capturedError: Error | null = null;
-    let capturedErrorCtx: MiddlewareContext | null = null;
-
-    const unhandledExceptionListener = (error: Error) => {
-      capturedError = error;
-      capturedErrorCtx = asyncLocalStorage.getStore() ?? null;
-    };
-
-    process.on('uncaughtException', unhandledExceptionListener);
-
-    const asyncStorageMiddleware = vi.fn(({ ctx, next }: MiddlewareParam) => {
-      asyncLocalStorage.enterWith(ctx);
-      // asyncLocalStorage.run(ctx, next);
       next();
     });
-    const errorMiddleware = vi.fn(() => {
-      throw new Error('error from middleware');
+    // these extraneous looking middlewares are to make sure that different shapes of
+    // middlewares running in the same context don't interfere with each other.
+    const timeoutMiddleware = vi.fn<Middleware>(({ next }) => {
+      Promise.resolve().then(() => {
+        next();
+      });
     });
-    createServer(mockTransportNetwork.getServerTransport(), services, {
-      middlewares: [asyncStorageMiddleware, errorMiddleware],
-    });
-    const client = createClient<typeof services>(
-      mockTransportNetwork.getClientTransport('client'),
-      'SERVER',
-    );
+    const promiseMiddleware = vi.fn<Middleware>(async ({ next }) => {
+      await Promise.resolve();
 
-    void client.test.add.rpc({
-      n: 3,
-    });
-
-    await new Promise((resolve) => setTimeout(resolve, 50));
-
-    expect(capturedError).not.toBeNull();
-    expect(capturedErrorCtx).not.toBeNull();
-    expect((capturedErrorCtx as unknown as MiddlewareContext).serviceName).toBe(
-      'test',
-    );
-    expect(
-      (capturedErrorCtx as unknown as MiddlewareContext).procedureName,
-    ).toBe('add');
-  });
-
-  test('can capture uncaught exception in middleware with context', async () => {
-    const services = { test: AsyncStorageSchemas };
-    const asyncLocalStorage = new AsyncLocalStorage<MiddlewareContext>();
-
-    let capturedError: Error | null = null;
-    let capturedErrorCtx: MiddlewareContext | null = null;
-
-    const unhandledExceptionListener = (error: Error) => {
-      capturedError = error;
-      capturedErrorCtx = asyncLocalStorage.getStore() ?? null;
-    };
-
-    process.on('uncaughtException', unhandledExceptionListener);
-
-    const asyncStorageMiddleware = vi.fn(({ ctx, next }: MiddlewareParam) => {
-      asyncLocalStorage.enterWith(ctx);
-      // asyncLocalStorage.run(ctx, next);
       next();
+
+      await Promise.resolve();
     });
-    const errorMiddleware = vi.fn(() => {
-      throw new Error('error from middleware');
-    });
+
+    const services = { test: AsyncStorageSchemas };
+
     createServer(mockTransportNetwork.getServerTransport(), services, {
-      middlewares: [asyncStorageMiddleware, errorMiddleware],
+      middlewares: [
+        timeoutMiddleware,
+        promiseMiddleware,
+        middleware,
+        middlewarThatReadsFromStorage,
+        timeoutMiddleware,
+        promiseMiddleware,
+      ],
     });
     const client = createClient<typeof services>(
       mockTransportNetwork.getClientTransport('client'),
       'SERVER',
     );
 
-    void client.test.throwErrorFromTimeout.rpc({});
+    await client.test.gimmeStore.rpc({});
 
-    await new Promise((resolve) => setTimeout(resolve, 50));
-
-    expect(capturedError).not.toBeNull();
-    expect(capturedErrorCtx).not.toBeNull();
-    expect((capturedErrorCtx as unknown as MiddlewareContext).serviceName).toBe(
-      'test',
-    );
-    expect(
-      (capturedErrorCtx as unknown as MiddlewareContext).procedureName,
-    ).toBe('throwErrorFromTimeout');
+    expect(middleware).toHaveBeenCalledOnce();
+    expect(store).toStrictEqual({
+      readByHandler: true,
+      readByHandlerSignal: true,
+      readByOtherMiddleware: true,
+      readByMiddlewareSignal: true,
+    });
   });
 });

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { isReadableDone, readNextResult } from '../testUtil';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import {

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -302,7 +302,7 @@ describe('middleware test', () => {
     // these extraneous looking middlewares are to make sure that different shapes of
     // middlewares running in the same context don't interfere with each other.
     const timeoutMiddleware = vi.fn<Middleware>(({ next }) => {
-      Promise.resolve().then(() => {
+      void Promise.resolve().then(() => {
         next();
       });
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,14 +21,14 @@
         "@types/ws": "^8.5.5",
         "@typescript-eslint/eslint-plugin": "^7.8.0",
         "@typescript-eslint/parser": "^7.8.0",
-        "@vitest/ui": "^3.0.9",
+        "@vitest/ui": "^3.1.1",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
         "prettier": "^3.0.0",
         "tsup": "^8.4.0",
         "typescript": "^5.4.5",
-        "vitest": "^3.0.9"
+        "vitest": "^3.1.1"
       },
       "engines": {
         "node": ">=16"
@@ -1615,14 +1615,13 @@
       "dev": true
     },
     "node_modules/@vitest/expect": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.9.tgz",
-      "integrity": "sha512-5eCqRItYgIML7NNVgJj6TVCmdzE7ZVgJhruW0ziSQV4V7PvLkDL1bBkBdcTs/VuIz0IxPb5da1IDSqc1TR9eig==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.1.tgz",
+      "integrity": "sha512-q/zjrW9lgynctNbwvFtQkGK9+vvHA5UzVi2V8APrp1C6fG6/MuYYkmlx4FubuqLycCeSdHD5aadWfua/Vr0EUA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.0.9",
-        "@vitest/utils": "3.0.9",
+        "@vitest/spy": "3.1.1",
+        "@vitest/utils": "3.1.1",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -1631,13 +1630,12 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.9.tgz",
-      "integrity": "sha512-ryERPIBOnvevAkTq+L1lD+DTFBRcjueL9lOUfXsLfwP92h4e+Heb+PjiqS3/OURWPtywfafK0kj++yDFjWUmrA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.1.tgz",
+      "integrity": "sha512-bmpJJm7Y7i9BBELlLuuM1J1Q6EQ6K5Ye4wcyOpOMXMcePYKSIYlpcrCm4l/O6ja4VJA5G2aMJiuZkZdnxlC3SA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.0.9",
+        "@vitest/spy": "3.1.1",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -1658,11 +1656,10 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.9.tgz",
-      "integrity": "sha512-OW9F8t2J3AwFEwENg3yMyKWweF7oRJlMyHOMIhO5F3n0+cgQAJZBjNgrF8dLwFTEXl5jUqBLXd9QyyKv8zEcmA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.1.tgz",
+      "integrity": "sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^2.0.0"
       },
@@ -1671,13 +1668,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.9.tgz",
-      "integrity": "sha512-NX9oUXgF9HPfJSwl8tUZCMP1oGx2+Sf+ru6d05QjzQz4OwWg0psEzwY6VexP2tTHWdOkhKHUIZH+fS6nA7jfOw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.1.tgz",
+      "integrity": "sha512-X/d46qzJuEDO8ueyjtKfxffiXraPRfmYasoC4i5+mlLEJ10UvPb0XH5M9C3gWuxd7BAQhpK42cJgJtq53YnWVA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.0.9",
+        "@vitest/utils": "3.1.1",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1685,13 +1681,12 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.9.tgz",
-      "integrity": "sha512-AiLUiuZ0FuA+/8i19mTYd+re5jqjEc2jZbgJ2up0VY0Ddyyxg/uUtBDpIFAy4uzKaQxOW8gMgBdAJJ2ydhu39A==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.1.tgz",
+      "integrity": "sha512-bByMwaVWe/+1WDf9exFxWWgAixelSdiwo2p33tpqIlM14vW7PRV5ppayVXtfycqze4Qhtwag5sVhX400MLBOOw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.0.9",
+        "@vitest/pretty-format": "3.1.1",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -1700,11 +1695,10 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.9.tgz",
-      "integrity": "sha512-/CcK2UDl0aQ2wtkp3YVWldrpLRNCfVcIOFGlVGKO4R5eajsH393Z1yiXLVQ7vWsj26JOEjeZI0x5sm5P4OGUNQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.1.tgz",
+      "integrity": "sha512-+EmrUOOXbKzLkTDwlsc/xrwOlPDXyVk3Z6P6K4oiCndxz7YLpp/0R0UsWVOKT0IXWjjBJuSMk6D27qipaupcvQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "tinyspy": "^3.0.2"
       },
@@ -1713,13 +1707,12 @@
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.0.9.tgz",
-      "integrity": "sha512-FpZD4aIv/qNpwkV3XbLV6xldWFHMgoNWAJEgg5GmpObmAOLAErpYjew9dDwXdYdKOS3iZRKdwI+P3JOJcYeUBg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.1.1.tgz",
+      "integrity": "sha512-2HpiRIYg3dlvAJBV9RtsVswFgUSJK4Sv7QhpxoP0eBGkYwzGIKP34PjaV00AULQi9Ovl6LGyZfsetxDWY5BQdQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.0.9",
+        "@vitest/utils": "3.1.1",
         "fflate": "^0.8.2",
         "flatted": "^3.3.3",
         "pathe": "^2.0.3",
@@ -1731,17 +1724,16 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "3.0.9"
+        "vitest": "3.1.1"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.9.tgz",
-      "integrity": "sha512-ilHM5fHhZ89MCp5aAaM9uhfl1c2JdxVxl3McqsdVyVNN6JffnEen8UMCdRTzOhGXNQGo5GNL9QugHrz727Wnng==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.1.tgz",
+      "integrity": "sha512-1XIjflyaU2k3HMArJ50bwSh3wKWPD6Q47wz/NUSmRV0zNywPc4w79ARjg/i/aNINHwA+mIALhUVqD9/aUvZNgg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.0.9",
+        "@vitest/pretty-format": "3.1.1",
         "loupe": "^3.1.3",
         "tinyrainbow": "^2.0.0"
       },
@@ -1835,7 +1827,6 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       }
@@ -1907,7 +1898,6 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
       "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "assertion-error": "^2.0.1",
         "check-error": "^2.1.1",
@@ -1955,7 +1945,6 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
       "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 16"
       }
@@ -2058,7 +2047,6 @@
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
       "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2111,8 +2099,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
       "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/esbuild": {
       "version": "0.25.1",
@@ -2359,7 +2346,6 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
@@ -2871,8 +2857,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
       "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
@@ -2886,7 +2871,6 @@
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
       "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
@@ -3150,7 +3134,6 @@
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
       "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 14.16"
       }
@@ -3882,7 +3865,6 @@
       "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
       "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -4055,7 +4037,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
       "integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
         "postcss": "^8.5.3",
@@ -4123,11 +4104,10 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.9.tgz",
-      "integrity": "sha512-w3Gdx7jDcuT9cNn9jExXgOyKmf5UOTb6WMHz8LGAm54eS1Elf5OuBhCxl6zJxGhEeIkgsE1WbHuoL0mj/UXqXg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.1.tgz",
+      "integrity": "sha512-V+IxPAE2FvXpTCHXyNem0M+gWm6J7eRyWPR6vYoG/Gl+IscNOjXzztUhimQgTxaAoUoj40Qqimaa0NLIOOAH4w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
         "debug": "^4.4.0",
@@ -4146,31 +4126,30 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.9.tgz",
-      "integrity": "sha512-BbcFDqNyBlfSpATmTtXOAOj71RNKDDvjBM/uPfnxxVGrG+FSH2RQIwgeEngTaTkuU/h0ScFvf+tRcKfYXzBybQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.1.tgz",
+      "integrity": "sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "3.0.9",
-        "@vitest/mocker": "3.0.9",
-        "@vitest/pretty-format": "^3.0.9",
-        "@vitest/runner": "3.0.9",
-        "@vitest/snapshot": "3.0.9",
-        "@vitest/spy": "3.0.9",
-        "@vitest/utils": "3.0.9",
+        "@vitest/expect": "3.1.1",
+        "@vitest/mocker": "3.1.1",
+        "@vitest/pretty-format": "^3.1.1",
+        "@vitest/runner": "3.1.1",
+        "@vitest/snapshot": "3.1.1",
+        "@vitest/spy": "3.1.1",
+        "@vitest/utils": "3.1.1",
         "chai": "^5.2.0",
         "debug": "^4.4.0",
-        "expect-type": "^1.1.0",
+        "expect-type": "^1.2.0",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3",
-        "std-env": "^3.8.0",
+        "std-env": "^3.8.1",
         "tinybench": "^2.9.0",
         "tinyexec": "^0.3.2",
         "tinypool": "^1.0.2",
         "tinyrainbow": "^2.0.0",
         "vite": "^5.0.0 || ^6.0.0",
-        "vite-node": "3.0.9",
+        "vite-node": "3.1.1",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -4186,8 +4165,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.0.9",
-        "@vitest/ui": "3.0.9",
+        "@vitest/browser": "3.1.1",
+        "@vitest/ui": "3.1.1",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -5283,74 +5262,74 @@
       "dev": true
     },
     "@vitest/expect": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.9.tgz",
-      "integrity": "sha512-5eCqRItYgIML7NNVgJj6TVCmdzE7ZVgJhruW0ziSQV4V7PvLkDL1bBkBdcTs/VuIz0IxPb5da1IDSqc1TR9eig==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.1.tgz",
+      "integrity": "sha512-q/zjrW9lgynctNbwvFtQkGK9+vvHA5UzVi2V8APrp1C6fG6/MuYYkmlx4FubuqLycCeSdHD5aadWfua/Vr0EUA==",
       "dev": true,
       "requires": {
-        "@vitest/spy": "3.0.9",
-        "@vitest/utils": "3.0.9",
+        "@vitest/spy": "3.1.1",
+        "@vitest/utils": "3.1.1",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       }
     },
     "@vitest/mocker": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.9.tgz",
-      "integrity": "sha512-ryERPIBOnvevAkTq+L1lD+DTFBRcjueL9lOUfXsLfwP92h4e+Heb+PjiqS3/OURWPtywfafK0kj++yDFjWUmrA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.1.tgz",
+      "integrity": "sha512-bmpJJm7Y7i9BBELlLuuM1J1Q6EQ6K5Ye4wcyOpOMXMcePYKSIYlpcrCm4l/O6ja4VJA5G2aMJiuZkZdnxlC3SA==",
       "dev": true,
       "requires": {
-        "@vitest/spy": "3.0.9",
+        "@vitest/spy": "3.1.1",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       }
     },
     "@vitest/pretty-format": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.9.tgz",
-      "integrity": "sha512-OW9F8t2J3AwFEwENg3yMyKWweF7oRJlMyHOMIhO5F3n0+cgQAJZBjNgrF8dLwFTEXl5jUqBLXd9QyyKv8zEcmA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.1.tgz",
+      "integrity": "sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA==",
       "dev": true,
       "requires": {
         "tinyrainbow": "^2.0.0"
       }
     },
     "@vitest/runner": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.9.tgz",
-      "integrity": "sha512-NX9oUXgF9HPfJSwl8tUZCMP1oGx2+Sf+ru6d05QjzQz4OwWg0psEzwY6VexP2tTHWdOkhKHUIZH+fS6nA7jfOw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.1.tgz",
+      "integrity": "sha512-X/d46qzJuEDO8ueyjtKfxffiXraPRfmYasoC4i5+mlLEJ10UvPb0XH5M9C3gWuxd7BAQhpK42cJgJtq53YnWVA==",
       "dev": true,
       "requires": {
-        "@vitest/utils": "3.0.9",
+        "@vitest/utils": "3.1.1",
         "pathe": "^2.0.3"
       }
     },
     "@vitest/snapshot": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.9.tgz",
-      "integrity": "sha512-AiLUiuZ0FuA+/8i19mTYd+re5jqjEc2jZbgJ2up0VY0Ddyyxg/uUtBDpIFAy4uzKaQxOW8gMgBdAJJ2ydhu39A==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.1.tgz",
+      "integrity": "sha512-bByMwaVWe/+1WDf9exFxWWgAixelSdiwo2p33tpqIlM14vW7PRV5ppayVXtfycqze4Qhtwag5sVhX400MLBOOw==",
       "dev": true,
       "requires": {
-        "@vitest/pretty-format": "3.0.9",
+        "@vitest/pretty-format": "3.1.1",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       }
     },
     "@vitest/spy": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.9.tgz",
-      "integrity": "sha512-/CcK2UDl0aQ2wtkp3YVWldrpLRNCfVcIOFGlVGKO4R5eajsH393Z1yiXLVQ7vWsj26JOEjeZI0x5sm5P4OGUNQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.1.tgz",
+      "integrity": "sha512-+EmrUOOXbKzLkTDwlsc/xrwOlPDXyVk3Z6P6K4oiCndxz7YLpp/0R0UsWVOKT0IXWjjBJuSMk6D27qipaupcvQ==",
       "dev": true,
       "requires": {
         "tinyspy": "^3.0.2"
       }
     },
     "@vitest/ui": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.0.9.tgz",
-      "integrity": "sha512-FpZD4aIv/qNpwkV3XbLV6xldWFHMgoNWAJEgg5GmpObmAOLAErpYjew9dDwXdYdKOS3iZRKdwI+P3JOJcYeUBg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.1.1.tgz",
+      "integrity": "sha512-2HpiRIYg3dlvAJBV9RtsVswFgUSJK4Sv7QhpxoP0eBGkYwzGIKP34PjaV00AULQi9Ovl6LGyZfsetxDWY5BQdQ==",
       "dev": true,
       "requires": {
-        "@vitest/utils": "3.0.9",
+        "@vitest/utils": "3.1.1",
         "fflate": "^0.8.2",
         "flatted": "^3.3.3",
         "pathe": "^2.0.3",
@@ -5360,12 +5339,12 @@
       }
     },
     "@vitest/utils": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.9.tgz",
-      "integrity": "sha512-ilHM5fHhZ89MCp5aAaM9uhfl1c2JdxVxl3McqsdVyVNN6JffnEen8UMCdRTzOhGXNQGo5GNL9QugHrz727Wnng==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.1.tgz",
+      "integrity": "sha512-1XIjflyaU2k3HMArJ50bwSh3wKWPD6Q47wz/NUSmRV0zNywPc4w79ARjg/i/aNINHwA+mIALhUVqD9/aUvZNgg==",
       "dev": true,
       "requires": {
-        "@vitest/pretty-format": "3.0.9",
+        "@vitest/pretty-format": "3.1.1",
         "loupe": "^3.1.3",
         "tinyrainbow": "^2.0.0"
       }
@@ -6933,9 +6912,9 @@
       }
     },
     "vite-node": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.9.tgz",
-      "integrity": "sha512-w3Gdx7jDcuT9cNn9jExXgOyKmf5UOTb6WMHz8LGAm54eS1Elf5OuBhCxl6zJxGhEeIkgsE1WbHuoL0mj/UXqXg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.1.tgz",
+      "integrity": "sha512-V+IxPAE2FvXpTCHXyNem0M+gWm6J7eRyWPR6vYoG/Gl+IscNOjXzztUhimQgTxaAoUoj40Qqimaa0NLIOOAH4w==",
       "dev": true,
       "requires": {
         "cac": "^6.7.14",
@@ -6946,30 +6925,30 @@
       }
     },
     "vitest": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.9.tgz",
-      "integrity": "sha512-BbcFDqNyBlfSpATmTtXOAOj71RNKDDvjBM/uPfnxxVGrG+FSH2RQIwgeEngTaTkuU/h0ScFvf+tRcKfYXzBybQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.1.tgz",
+      "integrity": "sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q==",
       "dev": true,
       "requires": {
-        "@vitest/expect": "3.0.9",
-        "@vitest/mocker": "3.0.9",
-        "@vitest/pretty-format": "^3.0.9",
-        "@vitest/runner": "3.0.9",
-        "@vitest/snapshot": "3.0.9",
-        "@vitest/spy": "3.0.9",
-        "@vitest/utils": "3.0.9",
+        "@vitest/expect": "3.1.1",
+        "@vitest/mocker": "3.1.1",
+        "@vitest/pretty-format": "^3.1.1",
+        "@vitest/runner": "3.1.1",
+        "@vitest/snapshot": "3.1.1",
+        "@vitest/spy": "3.1.1",
+        "@vitest/utils": "3.1.1",
         "chai": "^5.2.0",
         "debug": "^4.4.0",
-        "expect-type": "^1.1.0",
+        "expect-type": "^1.2.0",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3",
-        "std-env": "^3.8.0",
+        "std-env": "^3.8.1",
         "tinybench": "^2.9.0",
         "tinyexec": "^0.3.2",
         "tinypool": "^1.0.2",
         "tinyrainbow": "^2.0.0",
         "vite": "^5.0.0 || ^6.0.0",
-        "vite-node": "3.0.9",
+        "vite-node": "3.1.1",
         "why-is-node-running": "^2.3.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -64,14 +64,14 @@
     "@types/ws": "^8.5.5",
     "@typescript-eslint/eslint-plugin": "^7.8.0",
     "@typescript-eslint/parser": "^7.8.0",
-    "@vitest/ui": "^3.0.9",
+    "@vitest/ui": "^3.1.1",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "prettier": "^3.0.0",
     "tsup": "^8.4.0",
     "typescript": "^5.4.5",
-    "vitest": "^3.0.9"
+    "vitest": "^3.1.1"
   },
   "scripts": {
     "check": "tsc --noEmit && npm run format && npm run lint",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.207.4",
+  "version": "0.208.0",
   "type": "module",
   "exports": {
     ".": {

--- a/router/index.ts
+++ b/router/index.ts
@@ -43,7 +43,7 @@ export {
 export { createClient } from './client';
 export type { Client } from './client';
 export { createServer } from './server';
-export type { Server } from './server';
+export type { Server, Middleware, MiddlewareParam } from './server';
 export type {
   ParsedMetadata,
   ServiceContext,

--- a/router/index.ts
+++ b/router/index.ts
@@ -43,7 +43,12 @@ export {
 export { createClient } from './client';
 export type { Client } from './client';
 export { createServer } from './server';
-export type { Server, Middleware, MiddlewareParam } from './server';
+export type {
+  Server,
+  Middleware,
+  MiddlewareParam,
+  MiddlewareContext,
+} from './server';
 export type {
   ParsedMetadata,
   ServiceContext,

--- a/router/server.ts
+++ b/router/server.ts
@@ -1011,7 +1011,7 @@ function getStreamCloseBackwardsCompat(protocolVersion: ProtocolVersion) {
   return ControlFlags.StreamClosedBit;
 }
 
-interface MiddlewareContext
+export interface MiddlewareContext
   extends Readonly<Omit<ProcedureHandlerContext<unknown>, 'cancel'>> {
   readonly streamId: StreamId;
   readonly procedureName: string;

--- a/router/server.ts
+++ b/router/server.ts
@@ -663,25 +663,21 @@ class RiverServer<Services extends AnyServiceSchemaMap>
       }
     };
 
-    const applyMiddlewares = (handlerToRun: () => Promise<void>) => {
-      this.middlewares.reduceRight(
-        (next: () => void, middleware: Middleware) => {
-          return () => {
-            middleware({
-              ctx: middlewareContext,
-              reqInit: initPayload,
-              next,
-            });
-          };
-        },
-        () => {
-          void handlerToRun();
-        },
-      )(); // Immediately invoke the generated middleware chain function
-    };
-
     // Start the middleware chain, which will eventually call runProcedureHandler
-    applyMiddlewares(runProcedureHandler);
+    this.middlewares.reduceRight(
+      (next: () => void, middleware: Middleware) => {
+        return () => {
+          middleware({
+            ctx: middlewareContext,
+            reqInit: initPayload,
+            next,
+          });
+        };
+      },
+      () => {
+        void runProcedureHandler();
+      },
+    )();
 
     if (!finishedController.signal.aborted) {
       this.streams.set(streamId, procStream);

--- a/testUtil/fixtures/services.ts
+++ b/testUtil/fixtures/services.ts
@@ -367,29 +367,3 @@ export function SchemaWithAsyncDisposableStateAndScaffold(
 
   return scaffold.finalize(procs);
 }
-
-export const AsyncStorageSchemas = ServiceSchema.define({
-  uncaughtPromise: Procedure.rpc({
-    requestInit: Type.Object({}),
-    responseData: Type.Object({}),
-    async handler() {
-      void new Promise((_, reject) => {
-        reject(new Error('Error from promise'));
-      });
-
-      return Ok({});
-    },
-  }),
-
-  throwErrorFromTimeout: Procedure.rpc({
-    requestInit: Type.Object({}),
-    responseData: Type.Object({}),
-    async handler() {
-      setTimeout(() => {
-        throw new Error('Error from timeout');
-      });
-
-      return Ok({});
-    },
-  }),
-});

--- a/testUtil/fixtures/services.ts
+++ b/testUtil/fixtures/services.ts
@@ -374,7 +374,19 @@ export const AsyncStorageSchemas = ServiceSchema.define({
     responseData: Type.Object({}),
     async handler() {
       void new Promise((_, reject) => {
-        reject(new Error('Error from timeout'));
+        reject(new Error('Error from promise'));
+      });
+
+      return Ok({});
+    },
+  }),
+
+  throwErrorFromTimeout: Procedure.rpc({
+    requestInit: Type.Object({}),
+    responseData: Type.Object({}),
+    async handler() {
+      setTimeout(() => {
+        throw new Error('Error from timeout');
       });
 
       return Ok({});

--- a/testUtil/fixtures/services.ts
+++ b/testUtil/fixtures/services.ts
@@ -367,3 +367,17 @@ export function SchemaWithAsyncDisposableStateAndScaffold(
 
   return scaffold.finalize(procs);
 }
+
+export const AsyncStorageSchemas = ServiceSchema.define({
+  uncaughtPromise: Procedure.rpc({
+    requestInit: Type.Object({}),
+    responseData: Type.Object({}),
+    async handler() {
+      void new Promise((_, reject) => {
+        reject(new Error('Error from timeout'));
+      });
+
+      return Ok({});
+    },
+  }),
+});


### PR DESCRIPTION
## Why

This PR adds support of read-only middleware support. Before a procedure is called, river will go through a chain of middleware synchronously and the middlewares are read-only so they shouldn't modify the context.

<!-- Describe what you are trying to accomplish with this pull request -->

## What changed

- Add `middlewares` in server options
- Chain and run middlewares before procedure calls
- Add middleware tests

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
