### PR TITLE
fix(json codec): encode the empty buffer properly

### DIFF
--- a/codec/codec.test.ts
+++ b/codec/codec.test.ts
@@ -17,6 +17,11 @@ describe.each(codecs)('codec -- $name', ({ codec }) => {
     expect(codec.fromBuffer(codec.toBuffer(msg))).toStrictEqual(msg);
   });
 
+  test('encodes the empty buffer properly', () => {
+    const msg = { test: new Uint8Array(0) };
+    expect(codec.fromBuffer(codec.toBuffer(msg))).toStrictEqual(msg);
+  });
+
   test('skips optional fields', () => {
     const msg = { test: undefined };
     expect(codec.fromBuffer(codec.toBuffer(msg))).toStrictEqual({});

--- a/codec/json.ts
+++ b/codec/json.ts
@@ -51,7 +51,7 @@ export const NaiveJsonCodec: Codec = {
     const parsed = JSON.parse(
       decoder.decode(buff),
       function reviver(_key, val: unknown) {
-        if ((val as Base64EncodedValue | undefined)?.$t) {
+        if ((val as Base64EncodedValue | undefined)?.$t !== undefined) {
           return base64ToUint8Array((val as Base64EncodedValue).$t);
         } else {
           return val;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.208.0",
+  "version": "0.208.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.208.0",
+      "version": "0.208.1",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.208.0",
+  "version": "0.208.1",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Why

`{ $t: "" }` means that `$t` is false-y so we dont treat it as the buffer type

## What changed

make it a strict undefined check

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
