### PR TITLE
Update typebox to support ~0.34.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.7.0",
-        "@sinclair/typebox": "~0.32.8"
+        "@sinclair/typebox": ">=0.32.8 <0.35.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.208.1",
+  "version": "0.208.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.208.1",
+      "version": "0.208.2",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.7.0",
-        "@sinclair/typebox": ">=0.32.8 <0.35.0"
+        "@sinclair/typebox": "~0.32.8 || ~0.34.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.208.1",
+  "version": "0.208.2",
   "type": "module",
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.7.0",
-    "@sinclair/typebox": ">=0.32.8 <0.35.0"
+    "@sinclair/typebox": "~0.32.8 || ~0.34.0"
   },
   "devDependencies": {
     "@opentelemetry/context-async-hooks": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.7.0",
-    "@sinclair/typebox": "~0.32.8"
+    "@sinclair/typebox": ">=0.32.8 <0.35.0"
   },
   "devDependencies": {
     "@opentelemetry/context-async-hooks": "^1.26.0",


### PR DESCRIPTION
## Why

The latest TypeBox introduces Module and Ref. We should support that.

## What changed

- Change `@sinclair/typebox` peerDependency to `~0.32.8 || ~0.34.0`

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
