### PR TITLE
Fix Typebox to ~0.34.0

### DIFF
--- a/__tests__/invalid-request.test.ts
+++ b/__tests__/invalid-request.test.ts
@@ -396,7 +396,10 @@ describe('cancels invalid request', () => {
             totalErrors: 2,
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             firstValidationErrors: expect.arrayContaining([
-              { path: '/mustSendThings', message: 'Required property' },
+              {
+                path: '/mustSendThings',
+                message: 'Expected required property',
+              },
               { path: '/mustSendThings', message: 'Expected string' },
             ]),
           },
@@ -595,7 +598,10 @@ describe('cancels invalid request', () => {
           totalErrors: 2,
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           firstValidationErrors: expect.arrayContaining([
-            { path: '/newRequiredField', message: 'Required property' },
+            {
+              path: '/newRequiredField',
+              message: 'Expected required property',
+            },
             { path: '/newRequiredField', message: 'Expected string' },
           ]),
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.7.0",
-        "@sinclair/typebox": "~0.32.8 || ~0.34.0"
+        "@sinclair/typebox": "~0.34.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1079,9 +1079,9 @@
       ]
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.32.8",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.32.8.tgz",
-      "integrity": "sha512-ifqNG6GBr0QRao2Vy+2P2WzxkOnpGmHfZCFXWwuR/0elH4h79mGXN8mEYwnJ2qGEr7MGgfqvf8Njwj4dBGFMBA==",
+      "version": "0.34.33",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.33.tgz",
+      "integrity": "sha512-5HAV9exOMcXRUxo+9iYB5n09XxzCXnfy4VTNW4xnDv+FgjzAGY989C28BIdljKqmF+ZltUwujE3aossvcVtq6g==",
       "peer": true
     },
     "node_modules/@stylistic/eslint-plugin": {
@@ -4921,9 +4921,9 @@
       "optional": true
     },
     "@sinclair/typebox": {
-      "version": "0.32.8",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.32.8.tgz",
-      "integrity": "sha512-ifqNG6GBr0QRao2Vy+2P2WzxkOnpGmHfZCFXWwuR/0elH4h79mGXN8mEYwnJ2qGEr7MGgfqvf8Njwj4dBGFMBA==",
+      "version": "0.34.33",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.33.tgz",
+      "integrity": "sha512-5HAV9exOMcXRUxo+9iYB5n09XxzCXnfy4VTNW4xnDv+FgjzAGY989C28BIdljKqmF+ZltUwujE3aossvcVtq6g==",
       "peer": true
     },
     "@stylistic/eslint-plugin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.208.2",
+  "version": "0.208.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.208.2",
+      "version": "0.208.3",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,11 @@
         "ws": "^8.17.0"
       },
       "devDependencies": {
+        "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/context-async-hooks": "^1.26.0",
         "@opentelemetry/core": "^1.7.0",
         "@opentelemetry/sdk-trace-base": "^1.24.1",
+        "@sinclair/typebox": "~0.34.0",
         "@stylistic/eslint-plugin": "^2.6.4",
         "@types/ws": "^8.5.5",
         "@typescript-eslint/eslint-plugin": "^7.8.0",
@@ -708,7 +710,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
       "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1082,7 +1084,7 @@
       "version": "0.34.33",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.33.tgz",
       "integrity": "sha512-5HAV9exOMcXRUxo+9iYB5n09XxzCXnfy4VTNW4xnDv+FgjzAGY989C28BIdljKqmF+ZltUwujE3aossvcVtq6g==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@stylistic/eslint-plugin": {
       "version": "2.6.4",
@@ -4723,7 +4725,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
       "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
-      "peer": true
+      "dev": true
     },
     "@opentelemetry/context-async-hooks": {
       "version": "1.26.0",
@@ -4924,7 +4926,7 @@
       "version": "0.34.33",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.33.tgz",
       "integrity": "sha512-5HAV9exOMcXRUxo+9iYB5n09XxzCXnfy4VTNW4xnDv+FgjzAGY989C28BIdljKqmF+ZltUwujE3aossvcVtq6g==",
-      "peer": true
+      "dev": true
     },
     "@stylistic/eslint-plugin": {
       "version": "2.6.4",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.7.0",
-    "@sinclair/typebox": "~0.32.8 || ~0.34.0"
+    "@sinclair/typebox": "~0.34.0"
   },
   "devDependencies": {
     "@opentelemetry/context-async-hooks": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -57,9 +57,11 @@
     "@sinclair/typebox": "~0.34.0"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.7.0",
     "@opentelemetry/context-async-hooks": "^1.26.0",
     "@opentelemetry/core": "^1.7.0",
     "@opentelemetry/sdk-trace-base": "^1.24.1",
+    "@sinclair/typebox": "~0.34.0",
     "@stylistic/eslint-plugin": "^2.6.4",
     "@types/ws": "^8.5.5",
     "@typescript-eslint/eslint-plugin": "^7.8.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.208.2",
+  "version": "0.208.3",
   "type": "module",
   "exports": {
     ".": {

--- a/router/services.ts
+++ b/router/services.ts
@@ -165,7 +165,7 @@ export type TStrict<T extends TSchema> = T;
 /**
  * Omits compositing symbols from this schema.
  * The same approach that was previously used in the deprecated Type.Strict function.
- * https://github.com/sinclairzx81/typebox/blob/5a5431439f7d5ca6b494d0d18fbfd7b1a356d67c/changelog/0.34.0.md#strict
+ * https://github.com/sinclairzx81/typebox/blob/master/changelog/0.34.0.md#strict
  */
 export function Strict<T extends TSchema>(schema: T): TStrict<T> {
   return JSON.parse(JSON.stringify(schema)) as TStrict<T>;

--- a/router/services.ts
+++ b/router/services.ts
@@ -160,15 +160,13 @@ export interface SerializedServerSchemaProtocolv1 {
   services: Record<string, SerializedServiceSchemaProtocolv1>;
 }
 
-export type TStrict<T extends TSchema> = T;
-
 /**
  * Omits compositing symbols from this schema.
  * The same approach that was previously used in the deprecated Type.Strict function.
  * https://github.com/sinclairzx81/typebox/blob/master/changelog/0.34.0.md#strict
  */
-export function Strict<T extends TSchema>(schema: T): TStrict<T> {
-  return JSON.parse(JSON.stringify(schema)) as TStrict<T>;
+export function Strict<T extends TSchema>(schema: T): T {
+  return JSON.parse(JSON.stringify(schema)) as T;
 }
 
 // TODO remove once clients migrate to v2

--- a/router/services.ts
+++ b/router/services.ts
@@ -160,6 +160,17 @@ export interface SerializedServerSchemaProtocolv1 {
   services: Record<string, SerializedServiceSchemaProtocolv1>;
 }
 
+export type TStrict<T extends TSchema> = T;
+
+/**
+ * Omits compositing symbols from this schema.
+ * The same approach that was previously used in the deprecated Type.Strict function.
+ * https://github.com/sinclairzx81/typebox/blob/5a5431439f7d5ca6b494d0d18fbfd7b1a356d67c/changelog/0.34.0.md#strict
+ */
+export function Strict<T extends TSchema>(schema: T): TStrict<T> {
+  return JSON.parse(JSON.stringify(schema)) as TStrict<T>;
+}
+
 // TODO remove once clients migrate to v2
 /**
  * Same as {@link serializeSchema} but with a format that is compatible with
@@ -183,7 +194,7 @@ export function serializeSchemaV1Compat(
   };
 
   if (handshakeSchema) {
-    schema.handshakeSchema = Type.Strict(handshakeSchema);
+    schema.handshakeSchema = Strict(handshakeSchema);
   }
 
   return schema;
@@ -226,7 +237,7 @@ export function serializeSchema(
   };
 
   if (handshakeSchema) {
-    schema.handshakeSchema = Type.Strict(handshakeSchema);
+    schema.handshakeSchema = Strict(handshakeSchema);
   }
 
   return schema;
@@ -439,8 +450,8 @@ export class ServiceSchema<
         Object.entries(this.procedures).map(([procName, procDef]) => [
           procName,
           {
-            init: Type.Strict(procDef.requestInit),
-            output: Type.Strict(procDef.responseData),
+            init: Strict(procDef.requestInit),
+            output: Strict(procDef.responseData),
             errors: getSerializedProcErrors(procDef),
             // Only add `description` field if the type declares it.
             ...('description' in procDef
@@ -450,7 +461,7 @@ export class ServiceSchema<
             // Only add the `input` field if the type declares it.
             ...('requestData' in procDef
               ? {
-                  input: Type.Strict(procDef.requestData),
+                  input: Strict(procDef.requestData),
                 }
               : {}),
           },
@@ -479,8 +490,8 @@ export class ServiceSchema<
                 {
                   // BACKWARDS COMPAT: map init to input for protocolv1
                   // this is the only change needed to make it compatible.
-                  input: Type.Strict(procDef.requestInit),
-                  output: Type.Strict(procDef.responseData),
+                  input: Strict(procDef.requestInit),
+                  output: Strict(procDef.responseData),
                   errors: getSerializedProcErrors(procDef),
                   // Only add `description` field if the type declares it.
                   ...('description' in procDef
@@ -496,15 +507,15 @@ export class ServiceSchema<
             return [
               procName,
               {
-                init: Type.Strict(procDef.requestInit),
-                output: Type.Strict(procDef.responseData),
+                init: Strict(procDef.requestInit),
+                output: Strict(procDef.responseData),
                 errors: getSerializedProcErrors(procDef),
                 // Only add `description` field if the type declares it.
                 ...('description' in procDef
                   ? { description: procDef.description }
                   : {}),
                 type: procDef.type,
-                input: Type.Strict(procDef.requestData),
+                input: Strict(procDef.requestData),
               },
             ];
           },
@@ -541,14 +552,14 @@ function getSerializedProcErrors(
     !('responseError' in procDef) ||
     procDef.responseError[Kind] === 'Never'
   ) {
-    return Type.Strict(ReaderErrorSchema);
+    return Strict(ReaderErrorSchema);
   }
 
   const withProtocolErrors = flattenErrorType(
     Type.Union([procDef.responseError, ReaderErrorSchema]),
   );
 
-  return Type.Strict(withProtocolErrors);
+  return Strict(withProtocolErrors);
 }
 
 /**


### PR DESCRIPTION
## Why

There is no need support both `~0.32.8` and `~0.34.0`. We can just use `~0.34.0`

## What changed

- Fix Typebox to `~0.34.0`
- Handle breaking change in `0.34.0` where `Type.Strict()` is removed.

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
