### PR TITLE
chore: bump typebox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.26.10",
+  "version": "0.26.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.26.10",
+      "version": "0.26.11",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.7.0",
-        "@sinclair/typebox": "~0.32.8"
+        "@sinclair/typebox": "~0.34.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -982,9 +982,10 @@
       ]
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.32.8",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.32.8.tgz",
-      "integrity": "sha512-ifqNG6GBr0QRao2Vy+2P2WzxkOnpGmHfZCFXWwuR/0elH4h79mGXN8mEYwnJ2qGEr7MGgfqvf8Njwj4dBGFMBA==",
+      "version": "0.34.33",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.33.tgz",
+      "integrity": "sha512-5HAV9exOMcXRUxo+9iYB5n09XxzCXnfy4VTNW4xnDv+FgjzAGY989C28BIdljKqmF+ZltUwujE3aossvcVtq6g==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/@types/estree": {
@@ -4881,9 +4882,9 @@
       "optional": true
     },
     "@sinclair/typebox": {
-      "version": "0.32.8",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.32.8.tgz",
-      "integrity": "sha512-ifqNG6GBr0QRao2Vy+2P2WzxkOnpGmHfZCFXWwuR/0elH4h79mGXN8mEYwnJ2qGEr7MGgfqvf8Njwj4dBGFMBA==",
+      "version": "0.34.33",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.33.tgz",
+      "integrity": "sha512-5HAV9exOMcXRUxo+9iYB5n09XxzCXnfy4VTNW4xnDv+FgjzAGY989C28BIdljKqmF+ZltUwujE3aossvcVtq6g==",
       "peer": true
     },
     "@types/estree": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.26.10",
+  "version": "0.26.11",
   "type": "module",
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.7.0",
-    "@sinclair/typebox": "~0.32.8"
+    "@sinclair/typebox": "~0.34.0"
   },
   "devDependencies": {
     "@opentelemetry/sdk-trace-base": "^1.24.1",

--- a/router/services.ts
+++ b/router/services.ts
@@ -1,4 +1,4 @@
-import { Type, TUnion, TSchema } from '@sinclair/typebox';
+import { TUnion, TSchema } from '@sinclair/typebox';
 import { RiverError, RiverUncaughtSchema } from './result';
 import {
   Branded,
@@ -155,6 +155,15 @@ export interface SerializedServerSchema {
   services: Record<string, SerializedServiceSchema>;
 }
 
+/**
+ * Omits compositing symbols from this schema.
+ * The same approach that was previously used in the deprecated Type.Strict function.
+ * https://github.com/sinclairzx81/typebox/blob/master/changelog/0.34.0.md#strict
+ */
+export function Strict<T extends TSchema>(schema: T): T {
+  return JSON.parse(JSON.stringify(schema)) as T;
+}
+
 export function serializeSchema(
   services: AnyServiceSchemaMap,
   handshakeSchema?: TSchema,
@@ -171,7 +180,7 @@ export function serializeSchema(
   };
 
   if (handshakeSchema) {
-    schema.handshakeSchema = Type.Strict(handshakeSchema);
+    schema.handshakeSchema = Strict(handshakeSchema);
   }
 
   return schema;
@@ -384,8 +393,8 @@ export class ServiceSchema<
         Object.entries(this.procedures).map(([procName, procDef]) => [
           procName,
           {
-            input: Type.Strict(procDef.input),
-            output: Type.Strict(procDef.output),
+            input: Strict(procDef.input),
+            output: Strict(procDef.output),
             // Only add `description` field if the type declares it.
             ...('description' in procDef
               ? { description: procDef.description }
@@ -393,14 +402,14 @@ export class ServiceSchema<
             // Only add the `errors` field if the type declares it.
             ...('errors' in procDef
               ? {
-                  errors: Type.Strict(procDef.errors),
+                  errors: Strict(procDef.errors),
                 }
               : {}),
             type: procDef.type,
             // Only add the `init` field if the type declares it.
             ...('init' in procDef
               ? {
-                  init: Type.Strict(procDef.init),
+                  init: Strict(procDef.init),
                 }
               : {}),
           },


### PR DESCRIPTION
## Why

dont have disagreeing typebox version reqs

## What changed

- bump `@sinclair/typebox` from ~0.32.8 to ~0.34.0
- remove deprecated Type.Strict for our own (basically backport of https://github.com/replit/river/commit/1eca7c7d9a3bfdafabcca4ff6ff95e911815f5ac)

## Versioning

- [ ] Breaking protocol change
- [x] Breaking ts/js API change