### PR TITLE
PROTOCOL typo

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -604,7 +604,7 @@ After validating the message, the session associated with the connection SHOULD 
 - Removing all messages from the send buffer that have an `seq` strictly less than the `ack` of the received message.
 - Setting the `ack` for the current session to be `seq + 1` of the received message.
 
-When sending messages to the other side, the session associated with the connection SHOULD:
+When sending messages to the other side, the session associated with the connection MUST:
 
 - Increment the `seq` for the session by 1.
 


### PR DESCRIPTION
## Why

If we fail to increment `seq` the receiver will never process any subsequent message

## What changed

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
