### PR TITLE
[logging] use debug logging for `invoked ...`

### DIFF
--- a/tracing/index.ts
+++ b/tracing/index.ts
@@ -130,7 +130,7 @@ export function createProcTelemetryInfo(
     };
   }
 
-  session.log?.info(`invoked ${serviceName}.${procedureName}`, metadata);
+  session.log?.debug(`invoked ${serviceName}.${procedureName}`, metadata);
 
   return { span, ctx };
 }

--- a/tracing/tracing.test.ts
+++ b/tracing/tracing.test.ts
@@ -126,7 +126,7 @@ describe.each(testMatrix())(
       // setup
       const clientTransport = getClientTransport('client');
       const clientMockLogger = vi.fn<LogFn>();
-      clientTransport.bindLogger(clientMockLogger);
+      clientTransport.bindLogger(clientMockLogger, 'debug');
       const serverTransport = getServerTransport();
       const serverMockLogger = vi.fn<LogFn>();
       serverTransport.bindLogger(serverMockLogger);


### PR DESCRIPTION
## Why

Very noisy log

## What changed

change `invoked ...` log to debug

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
