### PR TITLE
Refactor ServiceContext as generic

### DIFF
--- a/__tests__/cancellation.test.ts
+++ b/__tests__/cancellation.test.ts
@@ -4,9 +4,9 @@ import {
   Err,
   Ok,
   Procedure,
-  ServiceSchema,
   ValidProcType,
   createClient,
+  createServiceSchema,
   createServer,
 } from '../router';
 import { testMatrix } from '../testUtil/fixtures/matrix';
@@ -67,7 +67,7 @@ describe.each(testMatrix())(
 
         const signalReceiver = vi.fn<(sig: AbortSignal) => void>();
         const services = {
-          service: ServiceSchema.defineWithContext()({
+          service: createServiceSchema().define({
             rpc: Procedure.rpc({
               requestInit: Type.Object({}),
               responseData: Type.Object({}),
@@ -111,7 +111,7 @@ describe.each(testMatrix())(
 
         const signalReceiver = vi.fn<(sig: AbortSignal) => void>();
         const services = {
-          service: ServiceSchema.defineWithContext()({
+          service: createServiceSchema().define({
             stream: Procedure.stream({
               requestInit: Type.Object({}),
               requestData: Type.Object({}),
@@ -165,7 +165,7 @@ describe.each(testMatrix())(
 
         const signalReceiver = vi.fn<(sig: AbortSignal) => void>();
         const services = {
-          service: ServiceSchema.defineWithContext()({
+          service: createServiceSchema().define({
             upload: Procedure.upload({
               requestInit: Type.Object({}),
               requestData: Type.Object({}),
@@ -215,7 +215,7 @@ describe.each(testMatrix())(
 
         const signalReceiver = vi.fn<(sig: AbortSignal) => void>();
         const services = {
-          service: ServiceSchema.defineWithContext()({
+          service: createServiceSchema().define({
             subscribe: Procedure.subscription({
               requestInit: Type.Object({}),
               responseData: Type.Object({}),
@@ -280,7 +280,7 @@ describe.each(testMatrix())(
         const serverTransport = getServerTransport();
         const handler = makeMockHandler('rpc');
         const services = {
-          service: ServiceSchema.defineWithContext()({
+          service: createServiceSchema().define({
             rpc: Procedure.rpc({
               requestInit: Type.Object({}),
               responseData: Type.Object({}),
@@ -338,7 +338,7 @@ describe.each(testMatrix())(
 
         const handler = makeMockHandler('stream');
         const services = {
-          service: ServiceSchema.defineWithContext()({
+          service: createServiceSchema().define({
             stream: Procedure.stream({
               requestInit: Type.Object({}),
               requestData: Type.Object({}),
@@ -412,7 +412,7 @@ describe.each(testMatrix())(
 
         const handler = makeMockHandler('upload');
         const services = {
-          service: ServiceSchema.defineWithContext()({
+          service: createServiceSchema().define({
             upload: Procedure.upload({
               requestInit: Type.Object({}),
               requestData: Type.Object({}),
@@ -483,7 +483,7 @@ describe.each(testMatrix())(
 
         const handler = makeMockHandler('subscription');
         const services = {
-          service: ServiceSchema.defineWithContext()({
+          service: createServiceSchema().define({
             subscribe: Procedure.subscription({
               requestInit: Type.Object({}),
               responseData: Type.Object({}),
@@ -570,7 +570,7 @@ describe.each(testMatrix())(
 
         const handler = makeMockHandler('rpc');
         const services = {
-          service: ServiceSchema.defineWithContext()({
+          service: createServiceSchema().define({
             rpc: Procedure.rpc({
               requestInit: Type.Object({}),
               responseData: Type.Object({}),
@@ -624,7 +624,7 @@ describe.each(testMatrix())(
 
         const handler = makeMockHandler('stream');
         const services = {
-          service: ServiceSchema.defineWithContext()({
+          service: createServiceSchema().define({
             stream: Procedure.stream({
               requestInit: Type.Object({}),
               requestData: Type.Object({}),
@@ -684,7 +684,7 @@ describe.each(testMatrix())(
 
         const handler = makeMockHandler('upload');
         const services = {
-          service: ServiceSchema.defineWithContext()({
+          service: createServiceSchema().define({
             upload: Procedure.upload({
               requestInit: Type.Object({}),
               requestData: Type.Object({}),
@@ -743,7 +743,7 @@ describe.each(testMatrix())(
 
         const handler = makeMockHandler('subscription');
         const services = {
-          service: ServiceSchema.defineWithContext()({
+          service: createServiceSchema().define({
             subscribe: Procedure.subscription({
               requestInit: Type.Object({}),
               responseData: Type.Object({}),
@@ -827,7 +827,7 @@ describe.each(testMatrix())(
         const rejectable = createRejectable();
         const handler = makeMockHandler('rpc', () => rejectable.promise);
         const services = {
-          service: ServiceSchema.defineWithContext()({
+          service: createServiceSchema().define({
             rpc: Procedure.rpc({
               requestInit: Type.Object({}),
               responseData: Type.Object({}),
@@ -880,7 +880,7 @@ describe.each(testMatrix())(
         const rejectable = createRejectable();
         const handler = makeMockHandler('stream', () => rejectable.promise);
         const services = {
-          service: ServiceSchema.defineWithContext()({
+          service: createServiceSchema().define({
             stream: Procedure.stream({
               requestInit: Type.Object({}),
               requestData: Type.Object({}),
@@ -942,7 +942,7 @@ describe.each(testMatrix())(
         const rejectable = createRejectable();
         const handler = makeMockHandler('upload', () => rejectable.promise);
         const services = {
-          service: ServiceSchema.defineWithContext()({
+          service: createServiceSchema().define({
             upload: Procedure.upload({
               requestInit: Type.Object({}),
               requestData: Type.Object({}),
@@ -1007,7 +1007,7 @@ describe.each(testMatrix())(
           () => rejectable.promise,
         );
         const services = {
-          service: ServiceSchema.defineWithContext()({
+          service: createServiceSchema().define({
             subscribe: Procedure.subscription({
               requestInit: Type.Object({}),
               responseData: Type.Object({}),

--- a/__tests__/cancellation.test.ts
+++ b/__tests__/cancellation.test.ts
@@ -29,7 +29,8 @@ function makeMockHandler<T extends ValidProcType>(
 ) {
   return vi.fn<
     Procedure<
-      Record<string, never>,
+      object,
+      object,
       T,
       TObject,
       TObject | null,
@@ -66,7 +67,7 @@ describe.each(testMatrix())(
 
         const signalReceiver = vi.fn<(sig: AbortSignal) => void>();
         const services = {
-          service: ServiceSchema.define({
+          service: ServiceSchema.defineWithContext()({
             rpc: Procedure.rpc({
               requestInit: Type.Object({}),
               responseData: Type.Object({}),
@@ -110,7 +111,7 @@ describe.each(testMatrix())(
 
         const signalReceiver = vi.fn<(sig: AbortSignal) => void>();
         const services = {
-          service: ServiceSchema.define({
+          service: ServiceSchema.defineWithContext()({
             stream: Procedure.stream({
               requestInit: Type.Object({}),
               requestData: Type.Object({}),
@@ -164,7 +165,7 @@ describe.each(testMatrix())(
 
         const signalReceiver = vi.fn<(sig: AbortSignal) => void>();
         const services = {
-          service: ServiceSchema.define({
+          service: ServiceSchema.defineWithContext()({
             upload: Procedure.upload({
               requestInit: Type.Object({}),
               requestData: Type.Object({}),
@@ -214,7 +215,7 @@ describe.each(testMatrix())(
 
         const signalReceiver = vi.fn<(sig: AbortSignal) => void>();
         const services = {
-          service: ServiceSchema.define({
+          service: ServiceSchema.defineWithContext()({
             subscribe: Procedure.subscription({
               requestInit: Type.Object({}),
               responseData: Type.Object({}),
@@ -279,7 +280,7 @@ describe.each(testMatrix())(
         const serverTransport = getServerTransport();
         const handler = makeMockHandler('rpc');
         const services = {
-          service: ServiceSchema.define({
+          service: ServiceSchema.defineWithContext()({
             rpc: Procedure.rpc({
               requestInit: Type.Object({}),
               responseData: Type.Object({}),
@@ -337,7 +338,7 @@ describe.each(testMatrix())(
 
         const handler = makeMockHandler('stream');
         const services = {
-          service: ServiceSchema.define({
+          service: ServiceSchema.defineWithContext()({
             stream: Procedure.stream({
               requestInit: Type.Object({}),
               requestData: Type.Object({}),
@@ -411,7 +412,7 @@ describe.each(testMatrix())(
 
         const handler = makeMockHandler('upload');
         const services = {
-          service: ServiceSchema.define({
+          service: ServiceSchema.defineWithContext()({
             upload: Procedure.upload({
               requestInit: Type.Object({}),
               requestData: Type.Object({}),
@@ -482,7 +483,7 @@ describe.each(testMatrix())(
 
         const handler = makeMockHandler('subscription');
         const services = {
-          service: ServiceSchema.define({
+          service: ServiceSchema.defineWithContext()({
             subscribe: Procedure.subscription({
               requestInit: Type.Object({}),
               responseData: Type.Object({}),
@@ -569,7 +570,7 @@ describe.each(testMatrix())(
 
         const handler = makeMockHandler('rpc');
         const services = {
-          service: ServiceSchema.define({
+          service: ServiceSchema.defineWithContext()({
             rpc: Procedure.rpc({
               requestInit: Type.Object({}),
               responseData: Type.Object({}),
@@ -623,7 +624,7 @@ describe.each(testMatrix())(
 
         const handler = makeMockHandler('stream');
         const services = {
-          service: ServiceSchema.define({
+          service: ServiceSchema.defineWithContext()({
             stream: Procedure.stream({
               requestInit: Type.Object({}),
               requestData: Type.Object({}),
@@ -683,7 +684,7 @@ describe.each(testMatrix())(
 
         const handler = makeMockHandler('upload');
         const services = {
-          service: ServiceSchema.define({
+          service: ServiceSchema.defineWithContext()({
             upload: Procedure.upload({
               requestInit: Type.Object({}),
               requestData: Type.Object({}),
@@ -742,7 +743,7 @@ describe.each(testMatrix())(
 
         const handler = makeMockHandler('subscription');
         const services = {
-          service: ServiceSchema.define({
+          service: ServiceSchema.defineWithContext()({
             subscribe: Procedure.subscription({
               requestInit: Type.Object({}),
               responseData: Type.Object({}),
@@ -826,7 +827,7 @@ describe.each(testMatrix())(
         const rejectable = createRejectable();
         const handler = makeMockHandler('rpc', () => rejectable.promise);
         const services = {
-          service: ServiceSchema.define({
+          service: ServiceSchema.defineWithContext()({
             rpc: Procedure.rpc({
               requestInit: Type.Object({}),
               responseData: Type.Object({}),
@@ -879,7 +880,7 @@ describe.each(testMatrix())(
         const rejectable = createRejectable();
         const handler = makeMockHandler('stream', () => rejectable.promise);
         const services = {
-          service: ServiceSchema.define({
+          service: ServiceSchema.defineWithContext()({
             stream: Procedure.stream({
               requestInit: Type.Object({}),
               requestData: Type.Object({}),
@@ -941,7 +942,7 @@ describe.each(testMatrix())(
         const rejectable = createRejectable();
         const handler = makeMockHandler('upload', () => rejectable.promise);
         const services = {
-          service: ServiceSchema.define({
+          service: ServiceSchema.defineWithContext()({
             upload: Procedure.upload({
               requestInit: Type.Object({}),
               requestData: Type.Object({}),
@@ -1006,7 +1007,7 @@ describe.each(testMatrix())(
           () => rejectable.promise,
         );
         const services = {
-          service: ServiceSchema.define({
+          service: ServiceSchema.defineWithContext()({
             subscribe: Procedure.subscription({
               requestInit: Type.Object({}),
               responseData: Type.Object({}),

--- a/__tests__/cancellation.test.ts
+++ b/__tests__/cancellation.test.ts
@@ -40,6 +40,8 @@ function makeMockHandler<T extends ValidProcType>(
   >(impl);
 }
 
+const ServiceSchema = createServiceSchema();
+
 describe.each(testMatrix())(
   'clean handler cancellation ($transport.name transport, $codec.name codec)',
 
@@ -67,7 +69,7 @@ describe.each(testMatrix())(
 
         const signalReceiver = vi.fn<(sig: AbortSignal) => void>();
         const services = {
-          service: createServiceSchema().define({
+          service: ServiceSchema.define({
             rpc: Procedure.rpc({
               requestInit: Type.Object({}),
               responseData: Type.Object({}),
@@ -111,7 +113,7 @@ describe.each(testMatrix())(
 
         const signalReceiver = vi.fn<(sig: AbortSignal) => void>();
         const services = {
-          service: createServiceSchema().define({
+          service: ServiceSchema.define({
             stream: Procedure.stream({
               requestInit: Type.Object({}),
               requestData: Type.Object({}),
@@ -165,7 +167,7 @@ describe.each(testMatrix())(
 
         const signalReceiver = vi.fn<(sig: AbortSignal) => void>();
         const services = {
-          service: createServiceSchema().define({
+          service: ServiceSchema.define({
             upload: Procedure.upload({
               requestInit: Type.Object({}),
               requestData: Type.Object({}),
@@ -215,7 +217,7 @@ describe.each(testMatrix())(
 
         const signalReceiver = vi.fn<(sig: AbortSignal) => void>();
         const services = {
-          service: createServiceSchema().define({
+          service: ServiceSchema.define({
             subscribe: Procedure.subscription({
               requestInit: Type.Object({}),
               responseData: Type.Object({}),
@@ -280,7 +282,7 @@ describe.each(testMatrix())(
         const serverTransport = getServerTransport();
         const handler = makeMockHandler('rpc');
         const services = {
-          service: createServiceSchema().define({
+          service: ServiceSchema.define({
             rpc: Procedure.rpc({
               requestInit: Type.Object({}),
               responseData: Type.Object({}),
@@ -338,7 +340,7 @@ describe.each(testMatrix())(
 
         const handler = makeMockHandler('stream');
         const services = {
-          service: createServiceSchema().define({
+          service: ServiceSchema.define({
             stream: Procedure.stream({
               requestInit: Type.Object({}),
               requestData: Type.Object({}),
@@ -412,7 +414,7 @@ describe.each(testMatrix())(
 
         const handler = makeMockHandler('upload');
         const services = {
-          service: createServiceSchema().define({
+          service: ServiceSchema.define({
             upload: Procedure.upload({
               requestInit: Type.Object({}),
               requestData: Type.Object({}),
@@ -483,7 +485,7 @@ describe.each(testMatrix())(
 
         const handler = makeMockHandler('subscription');
         const services = {
-          service: createServiceSchema().define({
+          service: ServiceSchema.define({
             subscribe: Procedure.subscription({
               requestInit: Type.Object({}),
               responseData: Type.Object({}),
@@ -570,7 +572,7 @@ describe.each(testMatrix())(
 
         const handler = makeMockHandler('rpc');
         const services = {
-          service: createServiceSchema().define({
+          service: ServiceSchema.define({
             rpc: Procedure.rpc({
               requestInit: Type.Object({}),
               responseData: Type.Object({}),
@@ -624,7 +626,7 @@ describe.each(testMatrix())(
 
         const handler = makeMockHandler('stream');
         const services = {
-          service: createServiceSchema().define({
+          service: ServiceSchema.define({
             stream: Procedure.stream({
               requestInit: Type.Object({}),
               requestData: Type.Object({}),
@@ -684,7 +686,7 @@ describe.each(testMatrix())(
 
         const handler = makeMockHandler('upload');
         const services = {
-          service: createServiceSchema().define({
+          service: ServiceSchema.define({
             upload: Procedure.upload({
               requestInit: Type.Object({}),
               requestData: Type.Object({}),
@@ -743,7 +745,7 @@ describe.each(testMatrix())(
 
         const handler = makeMockHandler('subscription');
         const services = {
-          service: createServiceSchema().define({
+          service: ServiceSchema.define({
             subscribe: Procedure.subscription({
               requestInit: Type.Object({}),
               responseData: Type.Object({}),
@@ -827,7 +829,7 @@ describe.each(testMatrix())(
         const rejectable = createRejectable();
         const handler = makeMockHandler('rpc', () => rejectable.promise);
         const services = {
-          service: createServiceSchema().define({
+          service: ServiceSchema.define({
             rpc: Procedure.rpc({
               requestInit: Type.Object({}),
               responseData: Type.Object({}),
@@ -880,7 +882,7 @@ describe.each(testMatrix())(
         const rejectable = createRejectable();
         const handler = makeMockHandler('stream', () => rejectable.promise);
         const services = {
-          service: createServiceSchema().define({
+          service: ServiceSchema.define({
             stream: Procedure.stream({
               requestInit: Type.Object({}),
               requestData: Type.Object({}),
@@ -942,7 +944,7 @@ describe.each(testMatrix())(
         const rejectable = createRejectable();
         const handler = makeMockHandler('upload', () => rejectable.promise);
         const services = {
-          service: createServiceSchema().define({
+          service: ServiceSchema.define({
             upload: Procedure.upload({
               requestInit: Type.Object({}),
               requestData: Type.Object({}),
@@ -1007,7 +1009,7 @@ describe.each(testMatrix())(
           () => rejectable.promise,
         );
         const services = {
-          service: createServiceSchema().define({
+          service: ServiceSchema.define({
             subscribe: Procedure.subscription({
               requestInit: Type.Object({}),
               responseData: Type.Object({}),

--- a/__tests__/cleanup.test.ts
+++ b/__tests__/cleanup.test.ts
@@ -509,7 +509,7 @@ describe('request finishing triggers signal onabort', async () => {
     const procedureName = procedureType;
 
     const services = {
-      [serviceName]: ServiceSchema.define({
+      [serviceName]: ServiceSchema.defineWithContext()({
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
         [procedureType]: (Procedure[procedureType] as any)({
           requestInit: Type.Object({}),

--- a/__tests__/cleanup.test.ts
+++ b/__tests__/cleanup.test.ts
@@ -15,8 +15,8 @@ import {
   Ok,
   Procedure,
   ProcedureHandlerContext,
-  ServiceSchema,
   createClient,
+  createServiceSchema,
   createServer,
 } from '../router';
 import {
@@ -503,13 +503,14 @@ describe('request finishing triggers signal onabort', async () => {
   ] as const)('handler aborts $procedureType', async ({ procedureType }) => {
     const clientTransport = getClientTransport('client');
     const serverTransport = getServerTransport();
-    const handler = vi.fn<(ctx: ProcedureHandlerContext<object>) => void>();
+    const handler =
+      vi.fn<(ctx: ProcedureHandlerContext<object, object>) => void>();
     const serverId = serverTransport.clientId;
     const serviceName = 'service';
     const procedureName = procedureType;
 
     const services = {
-      [serviceName]: ServiceSchema.defineWithContext()({
+      [serviceName]: createServiceSchema().define({
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
         [procedureType]: (Procedure[procedureType] as any)({
           requestInit: Type.Object({}),
@@ -519,7 +520,11 @@ describe('request finishing triggers signal onabort', async () => {
               }
             : {}),
           responseData: Type.Object({}),
-          async handler({ ctx }: { ctx: ProcedureHandlerContext<object> }) {
+          async handler({
+            ctx,
+          }: {
+            ctx: ProcedureHandlerContext<object, object>;
+          }) {
             handler(ctx);
 
             return new Promise(() => {

--- a/__tests__/context.test.ts
+++ b/__tests__/context.test.ts
@@ -43,10 +43,10 @@ describe('should handle incompatabilities', async () => {
       testctx: Math.random().toString(),
     };
 
-    const serviceSchema = createServiceSchema<ExtendedContext>();
+    const ServiceSchema = createServiceSchema<ExtendedContext>();
 
     const services = {
-      testservice: serviceSchema.define({
+      testservice: ServiceSchema.define({
         testrpc: Procedure.rpc({
           requestInit: Type.Object({}),
           responseData: Type.String(),
@@ -82,9 +82,9 @@ describe('should handle incompatabilities', async () => {
       testctx: string;
     }
 
-    const serviceSchema = createServiceSchema<ExtendedContext>();
+    const ServiceSchema = createServiceSchema<ExtendedContext>();
 
-    const TestServiceScaffold = serviceSchema.scaffold({
+    const TestServiceScaffold = ServiceSchema.scaffold({
       initializeState: (ctx) => ({
         fromctx: ctx.testctx,
       }),

--- a/__tests__/context.test.ts
+++ b/__tests__/context.test.ts
@@ -40,23 +40,30 @@ describe('should handle incompatabilities', async () => {
     // setup
     const clientTransport = getClientTransport('client');
     const serverTransport = getServerTransport();
+
+    interface ExtendedContext {
+      testctx: string;
+    }
+    const extendedContext: ExtendedContext = {
+      testctx: Math.random().toString(),
+    };
+
     const services = {
-      testservice: ServiceSchema.define({
+      testservice: ServiceSchema.defineWithContext<ExtendedContext>()({
         testrpc: Procedure.rpc({
           requestInit: Type.Object({}),
           responseData: Type.String(),
           handler: async ({ ctx }) => {
-            return Ok((ctx as unknown as typeof extendedContext).testctx);
+            return Ok(ctx.testctx);
           },
         }),
       }),
     };
 
-    const extendedContext = { testctx: Math.random().toString() };
     createServer(serverTransport, services, {
       extendedContext,
     });
-    const client = createClient<typeof services>(
+    const client = createClient<typeof services, ExtendedContext>(
       clientTransport,
       serverTransport.clientId,
     );

--- a/__tests__/context.test.ts
+++ b/__tests__/context.test.ts
@@ -40,7 +40,7 @@ describe('should handle incompatabilities', async () => {
       testctx: Math.random().toString(),
     };
 
-    const ServiceSchema = createServiceSchema(extendedContext);
+    const ServiceSchema = createServiceSchema<typeof extendedContext>();
 
     const services = {
       testservice: ServiceSchema.define({
@@ -77,7 +77,7 @@ describe('should handle incompatabilities', async () => {
 
     const extendedContext = { testctx: Math.random().toString() };
 
-    const ServiceSchema = createServiceSchema(extendedContext);
+    const ServiceSchema = createServiceSchema<typeof extendedContext>();
 
     const TestServiceScaffold = ServiceSchema.scaffold({
       initializeState: (ctx) => ({
@@ -121,7 +121,7 @@ describe('should handle incompatabilities', async () => {
 
     const extendedContext = { testctx: Math.random().toString() };
 
-    const ServiceSchema = createServiceSchema(extendedContext);
+    const ServiceSchema = createServiceSchema<typeof extendedContext>();
 
     const services = {
       testservice: ServiceSchema.define({

--- a/__tests__/context.test.ts
+++ b/__tests__/context.test.ts
@@ -36,14 +36,11 @@ describe('should handle incompatabilities', async () => {
     const clientTransport = getClientTransport('client');
     const serverTransport = getServerTransport();
 
-    interface ExtendedContext {
-      testctx: string;
-    }
-    const extendedContext: ExtendedContext = {
+    const extendedContext = {
       testctx: Math.random().toString(),
     };
 
-    const ServiceSchema = createServiceSchema<ExtendedContext>();
+    const ServiceSchema = createServiceSchema(extendedContext);
 
     const services = {
       testservice: ServiceSchema.define({
@@ -78,11 +75,9 @@ describe('should handle incompatabilities', async () => {
     const clientTransport = getClientTransport('client');
     const serverTransport = getServerTransport();
 
-    interface ExtendedContext {
-      testctx: string;
-    }
+    const extendedContext = { testctx: Math.random().toString() };
 
-    const ServiceSchema = createServiceSchema<ExtendedContext>();
+    const ServiceSchema = createServiceSchema(extendedContext);
 
     const TestServiceScaffold = ServiceSchema.scaffold({
       initializeState: (ctx) => ({
@@ -103,7 +98,6 @@ describe('should handle incompatabilities', async () => {
       }),
     };
 
-    const extendedContext = { testctx: Math.random().toString() };
     createServer(serverTransport, services, {
       extendedContext,
     });

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -31,7 +31,7 @@ import { testMatrix } from '../testUtil/fixtures/matrix';
 import { Type } from '@sinclair/typebox';
 import {
   Procedure,
-  ServiceSchema,
+  createServiceSchema,
   Ok,
   UNCAUGHT_ERROR_CODE,
   CANCEL_CODE,
@@ -949,7 +949,7 @@ describe.each(testMatrix())(
       });
 
       const services = {
-        test: ServiceSchema.defineWithContext()({
+        test: createServiceSchema().define({
           getData: Procedure.rpc({
             requestInit: Type.Object({}),
             responseData: Type.Object({

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -949,7 +949,7 @@ describe.each(testMatrix())(
       });
 
       const services = {
-        test: ServiceSchema.define({
+        test: ServiceSchema.defineWithContext()({
           getData: Procedure.rpc({
             requestInit: Type.Object({}),
             responseData: Type.Object({

--- a/__tests__/invalid-request.test.ts
+++ b/__tests__/invalid-request.test.ts
@@ -49,7 +49,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: ServiceSchema.define({
+      service: ServiceSchema.defineWithContext()({
         stream: Procedure.stream({
           requestInit: Type.Object({}),
           requestData: Type.Object({}),
@@ -99,7 +99,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: ServiceSchema.define({
+      service: ServiceSchema.defineWithContext()({
         stream: Procedure.stream({
           requestInit: Type.Object({}),
           requestData: Type.Object({}),
@@ -148,7 +148,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: ServiceSchema.define({
+      service: ServiceSchema.defineWithContext()({
         stream: Procedure.stream({
           requestInit: Type.Object({}),
           requestData: Type.Object({}),
@@ -197,7 +197,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: ServiceSchema.define({
+      service: ServiceSchema.defineWithContext()({
         stream: Procedure.stream({
           requestInit: Type.Object({}),
           requestData: Type.Object({}),
@@ -247,7 +247,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: ServiceSchema.define({
+      service: ServiceSchema.defineWithContext()({
         stream: Procedure.stream({
           requestInit: Type.Object({}),
           requestData: Type.Object({}),
@@ -299,7 +299,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: ServiceSchema.define({
+      service: ServiceSchema.defineWithContext()({
         stream: Procedure.stream({
           requestInit: Type.Object({ mustSendThings: Type.String() }),
           requestData: Type.Object({}),
@@ -349,7 +349,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: ServiceSchema.define({
+      service: ServiceSchema.defineWithContext()({
         stream: Procedure.stream({
           requestInit: Type.Object({}),
           requestData: Type.Object({ mustSendThings: Type.String() }),
@@ -417,7 +417,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: ServiceSchema.define({
+      service: ServiceSchema.defineWithContext()({
         rpc: Procedure.rpc({
           requestInit: Type.Object({}),
           responseData: Type.Object({}),
@@ -484,7 +484,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: ServiceSchema.define({
+      service: ServiceSchema.defineWithContext()({
         stream: Procedure.stream({
           requestInit: Type.Object({}),
           requestData: Type.Object({}),
@@ -548,7 +548,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: ServiceSchema.define({
+      service: ServiceSchema.defineWithContext()({
         rpc: Procedure.rpc({
           requestInit: Type.Object({}),
           responseData: Type.Object({}),
@@ -619,7 +619,7 @@ describe('cancels invalid request', () => {
       const serverId = serverTransport.clientId;
 
       const services = {
-        service: ServiceSchema.define({
+        service: ServiceSchema.defineWithContext()({
           stream: Procedure.stream({
             requestInit: Type.Object({}),
             requestData: Type.Object({}),
@@ -706,7 +706,7 @@ describe('cancels invalid request', () => {
       const serverId = serverTransport.clientId;
 
       const services = {
-        service: ServiceSchema.define({
+        service: ServiceSchema.defineWithContext()({
           stream: Procedure.stream({
             requestInit: Type.Object({}),
             requestData: Type.Object({}),
@@ -804,7 +804,7 @@ describe('cancels invalid request', () => {
       const serverId = serverTransport.clientId;
 
       const services = {
-        service: ServiceSchema.define({
+        service: ServiceSchema.defineWithContext()({
           stream: Procedure.stream({
             requestInit: Type.Object({}),
             requestData: Type.Object({}),

--- a/__tests__/invalid-request.test.ts
+++ b/__tests__/invalid-request.test.ts
@@ -22,6 +22,8 @@ import { TestSetupHelpers } from '../testUtil/fixtures/transports';
 import { nanoid } from 'nanoid';
 import { getClientSendFn } from '../testUtil';
 
+const ServiceSchema = createServiceSchema();
+
 describe('cancels invalid request', () => {
   const { transport, codec } = testMatrix()[0];
   const opts = { codec: codec.codec };
@@ -49,7 +51,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: createServiceSchema().define({
+      service: ServiceSchema.define({
         stream: Procedure.stream({
           requestInit: Type.Object({}),
           requestData: Type.Object({}),
@@ -99,7 +101,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: createServiceSchema().define({
+      service: ServiceSchema.define({
         stream: Procedure.stream({
           requestInit: Type.Object({}),
           requestData: Type.Object({}),
@@ -148,7 +150,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: createServiceSchema().define({
+      service: ServiceSchema.define({
         stream: Procedure.stream({
           requestInit: Type.Object({}),
           requestData: Type.Object({}),
@@ -197,7 +199,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: createServiceSchema().define({
+      service: ServiceSchema.define({
         stream: Procedure.stream({
           requestInit: Type.Object({}),
           requestData: Type.Object({}),
@@ -247,7 +249,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: createServiceSchema().define({
+      service: ServiceSchema.define({
         stream: Procedure.stream({
           requestInit: Type.Object({}),
           requestData: Type.Object({}),
@@ -299,7 +301,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: createServiceSchema().define({
+      service: ServiceSchema.define({
         stream: Procedure.stream({
           requestInit: Type.Object({ mustSendThings: Type.String() }),
           requestData: Type.Object({}),
@@ -349,7 +351,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: createServiceSchema().define({
+      service: ServiceSchema.define({
         stream: Procedure.stream({
           requestInit: Type.Object({}),
           requestData: Type.Object({ mustSendThings: Type.String() }),
@@ -417,7 +419,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: createServiceSchema().define({
+      service: ServiceSchema.define({
         rpc: Procedure.rpc({
           requestInit: Type.Object({}),
           responseData: Type.Object({}),
@@ -484,7 +486,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: createServiceSchema().define({
+      service: ServiceSchema.define({
         stream: Procedure.stream({
           requestInit: Type.Object({}),
           requestData: Type.Object({}),
@@ -548,7 +550,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: createServiceSchema().define({
+      service: ServiceSchema.define({
         rpc: Procedure.rpc({
           requestInit: Type.Object({}),
           responseData: Type.Object({}),
@@ -619,7 +621,7 @@ describe('cancels invalid request', () => {
       const serverId = serverTransport.clientId;
 
       const services = {
-        service: createServiceSchema().define({
+        service: ServiceSchema.define({
           stream: Procedure.stream({
             requestInit: Type.Object({}),
             requestData: Type.Object({}),
@@ -706,7 +708,7 @@ describe('cancels invalid request', () => {
       const serverId = serverTransport.clientId;
 
       const services = {
-        service: createServiceSchema().define({
+        service: ServiceSchema.define({
           stream: Procedure.stream({
             requestInit: Type.Object({}),
             requestData: Type.Object({}),
@@ -804,7 +806,7 @@ describe('cancels invalid request', () => {
       const serverId = serverTransport.clientId;
 
       const services = {
-        service: createServiceSchema().define({
+        service: ServiceSchema.define({
           stream: Procedure.stream({
             requestInit: Type.Object({}),
             requestData: Type.Object({}),

--- a/__tests__/invalid-request.test.ts
+++ b/__tests__/invalid-request.test.ts
@@ -5,8 +5,8 @@ import {
   Ok,
   OkResult,
   Procedure,
-  ServiceSchema,
   createClient,
+  createServiceSchema,
   createServer,
 } from '../router';
 import { testMatrix } from '../testUtil/fixtures/matrix';
@@ -49,7 +49,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: ServiceSchema.defineWithContext()({
+      service: createServiceSchema().define({
         stream: Procedure.stream({
           requestInit: Type.Object({}),
           requestData: Type.Object({}),
@@ -99,7 +99,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: ServiceSchema.defineWithContext()({
+      service: createServiceSchema().define({
         stream: Procedure.stream({
           requestInit: Type.Object({}),
           requestData: Type.Object({}),
@@ -148,7 +148,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: ServiceSchema.defineWithContext()({
+      service: createServiceSchema().define({
         stream: Procedure.stream({
           requestInit: Type.Object({}),
           requestData: Type.Object({}),
@@ -197,7 +197,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: ServiceSchema.defineWithContext()({
+      service: createServiceSchema().define({
         stream: Procedure.stream({
           requestInit: Type.Object({}),
           requestData: Type.Object({}),
@@ -247,7 +247,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: ServiceSchema.defineWithContext()({
+      service: createServiceSchema().define({
         stream: Procedure.stream({
           requestInit: Type.Object({}),
           requestData: Type.Object({}),
@@ -299,7 +299,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: ServiceSchema.defineWithContext()({
+      service: createServiceSchema().define({
         stream: Procedure.stream({
           requestInit: Type.Object({ mustSendThings: Type.String() }),
           requestData: Type.Object({}),
@@ -349,7 +349,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: ServiceSchema.defineWithContext()({
+      service: createServiceSchema().define({
         stream: Procedure.stream({
           requestInit: Type.Object({}),
           requestData: Type.Object({ mustSendThings: Type.String() }),
@@ -417,7 +417,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: ServiceSchema.defineWithContext()({
+      service: createServiceSchema().define({
         rpc: Procedure.rpc({
           requestInit: Type.Object({}),
           responseData: Type.Object({}),
@@ -484,7 +484,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: ServiceSchema.defineWithContext()({
+      service: createServiceSchema().define({
         stream: Procedure.stream({
           requestInit: Type.Object({}),
           requestData: Type.Object({}),
@@ -548,7 +548,7 @@ describe('cancels invalid request', () => {
     const serverId = serverTransport.clientId;
 
     const services = {
-      service: ServiceSchema.defineWithContext()({
+      service: createServiceSchema().define({
         rpc: Procedure.rpc({
           requestInit: Type.Object({}),
           responseData: Type.Object({}),
@@ -619,7 +619,7 @@ describe('cancels invalid request', () => {
       const serverId = serverTransport.clientId;
 
       const services = {
-        service: ServiceSchema.defineWithContext()({
+        service: createServiceSchema().define({
           stream: Procedure.stream({
             requestInit: Type.Object({}),
             requestData: Type.Object({}),
@@ -706,7 +706,7 @@ describe('cancels invalid request', () => {
       const serverId = serverTransport.clientId;
 
       const services = {
-        service: ServiceSchema.defineWithContext()({
+        service: createServiceSchema().define({
           stream: Procedure.stream({
             requestInit: Type.Object({}),
             requestData: Type.Object({}),
@@ -804,7 +804,7 @@ describe('cancels invalid request', () => {
       const serverId = serverTransport.clientId;
 
       const services = {
-        service: ServiceSchema.defineWithContext()({
+        service: createServiceSchema().define({
           stream: Procedure.stream({
             requestInit: Type.Object({}),
             requestData: Type.Object({}),

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -12,7 +12,7 @@ import {
   createServer,
   Ok,
   Procedure,
-  ServiceSchema,
+  createServiceSchema,
   Middleware,
 } from '../router';
 import { createMockTransportNetwork } from '../testUtil/fixtures/mockTransport';
@@ -244,7 +244,7 @@ describe('middleware test', () => {
       readByMiddlewareSignal: boolean;
     }>();
 
-    const AsyncStorageSchemas = ServiceSchema.defineWithContext()({
+    const AsyncStorageSchemas = createServiceSchema().define({
       gimmeStore: Procedure.rpc({
         requestInit: Type.Object({}),
         responseData: Type.Object({}),

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -244,7 +244,7 @@ describe('middleware test', () => {
       readByMiddlewareSignal: boolean;
     }>();
 
-    const AsyncStorageSchemas = ServiceSchema.define({
+    const AsyncStorageSchemas = ServiceSchema.defineWithContext()({
       gimmeStore: Procedure.rpc({
         requestInit: Type.Object({}),
         responseData: Type.Object({}),

--- a/__tests__/typescript-stress.test.ts
+++ b/__tests__/typescript-stress.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { Procedure } from '../router/procedures';
-import { ServiceSchema } from '../router/services';
+import { createServiceSchema } from '../router/services';
 import { Type } from '@sinclair/typebox';
 import { createServer } from '../router/server';
 import { createClient } from '../router/client';
@@ -64,7 +64,7 @@ const fnBody = Procedure.rpc<
 // typescript is limited to max 50 constraints
 // see: https://github.com/microsoft/TypeScript/issues/33541
 // we should be able to support more than that due to how we make services
-const StupidlyLargeServiceSchema = ServiceSchema.defineWithContext()({
+const StupidlyLargeServiceSchema = createServiceSchema().define({
   f1: fnBody,
   f2: fnBody,
   f3: fnBody,
@@ -210,7 +210,7 @@ describe("ensure typescript doesn't give up trying to infer the types for large 
 });
 
 const services = {
-  test: ServiceSchema.defineWithContext()({
+  test: createServiceSchema().define({
     rpc: Procedure.rpc({
       requestInit: Type.Object({ n: Type.Number() }),
       responseData: Type.Object({ n: Type.Number() }),

--- a/__tests__/typescript-stress.test.ts
+++ b/__tests__/typescript-stress.test.ts
@@ -70,7 +70,9 @@ const fnBody = Procedure.rpc<
 // typescript is limited to max 50 constraints
 // see: https://github.com/microsoft/TypeScript/issues/33541
 // we should be able to support more than that due to how we make services
-const StupidlyLargeServiceSchema = createServiceSchema(testContext).define({
+const StupidlyLargeServiceSchema = createServiceSchema<
+  typeof testContext
+>().define({
   f1: fnBody,
   f2: fnBody,
   f3: fnBody,

--- a/__tests__/typescript-stress.test.ts
+++ b/__tests__/typescript-stress.test.ts
@@ -42,6 +42,9 @@ const responseError = Type.Union([
 
 const fnBody = Procedure.rpc<
   Record<string, never>,
+  {
+    db: string;
+  },
   typeof requestData,
   typeof responseData,
   typeof responseError
@@ -61,7 +64,7 @@ const fnBody = Procedure.rpc<
 // typescript is limited to max 50 constraints
 // see: https://github.com/microsoft/TypeScript/issues/33541
 // we should be able to support more than that due to how we make services
-const StupidlyLargeServiceSchema = ServiceSchema.define({
+const StupidlyLargeServiceSchema = ServiceSchema.defineWithContext()({
   f1: fnBody,
   f2: fnBody,
   f3: fnBody,
@@ -207,7 +210,7 @@ describe("ensure typescript doesn't give up trying to infer the types for large 
 });
 
 const services = {
-  test: ServiceSchema.define({
+  test: ServiceSchema.defineWithContext()({
     rpc: Procedure.rpc({
       requestInit: Type.Object({ n: Type.Number() }),
       responseData: Type.Object({ n: Type.Number() }),

--- a/router/client.ts
+++ b/router/client.ts
@@ -140,12 +140,20 @@ type ServiceClient<Service extends AnyService> = {
  * @template Srv - The type of the server.
  */
 export type Client<
-  ServiceContext extends object,
-  Services extends AnyServiceSchemaMap<ServiceContext>,
+  // Context is a server-side implementation detail that doesn't affect the client interface
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Services extends AnyServiceSchemaMap<any>,
   IS extends InstantiatedServiceSchemaMap<
-    ServiceContext,
+    // Context is a server-side implementation detail that doesn't affect the client interface
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any,
     Services
-  > = InstantiatedServiceSchemaMap<ServiceContext, Services>,
+  > = InstantiatedServiceSchemaMap<
+    // Context is a server-side implementation detail that doesn't affect the client interface
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any,
+    Services
+  >,
 > = {
   [SvcName in keyof IS]: ServiceClient<IS[SvcName]>;
 };
@@ -207,10 +215,10 @@ const defaultClientOptions: ClientOptions = {
  * @param {Partial<ClientOptions>} providedClientOptions - The options for the client.
  * @returns The client for the server.
  */
-export function createClient<
-  ServiceSchemaMap extends AnyServiceSchemaMap<ServiceContext>,
-  ServiceContext extends object = object,
->(
+// We are using any here because the ServiceContext is a server-side implementation
+// detail that doesn't affect the client interface
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function createClient<ServiceSchemaMap extends AnyServiceSchemaMap<any>>(
   transport: ClientTransport<Connection>,
   serverId: TransportClientId,
   providedClientOptions: Partial<
@@ -218,7 +226,7 @@ export function createClient<
       handshakeOptions: ClientHandshakeOptions;
     }
   > = {},
-): Client<ServiceContext, ServiceSchemaMap> {
+): Client<ServiceSchemaMap> {
   if (providedClientOptions.handshakeOptions) {
     transport.extendHandshake(providedClientOptions.handshakeOptions);
   }
@@ -262,7 +270,7 @@ export function createClient<
       procName,
       callOptions ? (callOptions as CallOptions).signal : undefined,
     );
-  }, []) as Client<ServiceContext, ServiceSchemaMap>;
+  }, []) as Client<ServiceSchemaMap>;
 }
 
 type AnyProcReturn =

--- a/router/client.ts
+++ b/router/client.ts
@@ -140,9 +140,12 @@ type ServiceClient<Service extends AnyService> = {
  * @template Srv - The type of the server.
  */
 export type Client<
-  Services extends AnyServiceSchemaMap,
-  IS extends
-    InstantiatedServiceSchemaMap<Services> = InstantiatedServiceSchemaMap<Services>,
+  ServiceContext extends object,
+  Services extends AnyServiceSchemaMap<ServiceContext>,
+  IS extends InstantiatedServiceSchemaMap<
+    ServiceContext,
+    Services
+  > = InstantiatedServiceSchemaMap<ServiceContext, Services>,
 > = {
   [SvcName in keyof IS]: ServiceClient<IS[SvcName]>;
 };
@@ -204,7 +207,10 @@ const defaultClientOptions: ClientOptions = {
  * @param {Partial<ClientOptions>} providedClientOptions - The options for the client.
  * @returns The client for the server.
  */
-export function createClient<ServiceSchemaMap extends AnyServiceSchemaMap>(
+export function createClient<
+  ServiceSchemaMap extends AnyServiceSchemaMap<ServiceContext>,
+  ServiceContext extends object = object,
+>(
   transport: ClientTransport<Connection>,
   serverId: TransportClientId,
   providedClientOptions: Partial<
@@ -212,7 +218,7 @@ export function createClient<ServiceSchemaMap extends AnyServiceSchemaMap>(
       handshakeOptions: ClientHandshakeOptions;
     }
   > = {},
-): Client<ServiceSchemaMap> {
+): Client<ServiceContext, ServiceSchemaMap> {
   if (providedClientOptions.handshakeOptions) {
     transport.extendHandshake(providedClientOptions.handshakeOptions);
   }
@@ -256,7 +262,7 @@ export function createClient<ServiceSchemaMap extends AnyServiceSchemaMap>(
       procName,
       callOptions ? (callOptions as CallOptions).signal : undefined,
     );
-  }, []) as Client<ServiceSchemaMap>;
+  }, []) as Client<ServiceContext, ServiceSchemaMap>;
 }
 
 type AnyProcReturn =

--- a/router/context.ts
+++ b/router/context.ts
@@ -6,27 +6,6 @@ import { CancelErrorSchema } from './errors';
 import { Static } from '@sinclair/typebox';
 
 /**
- * ServiceContext exist for the purpose of declaration merging
- * to extend the context with additional properties.
- *
- * For example:
- *
- * ```ts
- * declare module '@replit/river' {
- *   interface ServiceContext {
- *     db: Database;
- *   }
- * }
- *
- * createServer(someTransport, myServices, { extendedContext: { db: myDb } });
- * ```
- *
- * Once you do this, your {@link ProcedureHandlerContext} will have `db` property on it.
- */
-/* eslint-disable-next-line @typescript-eslint/no-empty-interface */
-export interface ServiceContext {}
-
-/**
  * The parsed metadata schema for a service. This is the
  * return value of the {@link ServerHandshakeOptions.validate}
  * if the handshake extension is used.
@@ -49,7 +28,10 @@ export interface ParsedMetadata extends Record<string, unknown> {}
  * This is passed to every procedure handler and contains various context-level
  * information and utilities. This may be extended, see {@link ServiceContext}
  */
-export type ProcedureHandlerContext<State> = ServiceContext & {
+export type ProcedureHandlerContext<
+  State,
+  ServiceContext = object,
+> = ServiceContext & {
   /**
    * State for this service as defined by the service definition.
    */

--- a/router/context.ts
+++ b/router/context.ts
@@ -26,12 +26,9 @@ export interface ParsedMetadata extends Record<string, unknown> {}
 
 /**
  * This is passed to every procedure handler and contains various context-level
- * information and utilities. This may be extended, see {@link ServiceContext}
+ * information and utilities.
  */
-export type ProcedureHandlerContext<
-  State,
-  ServiceContext = object,
-> = ServiceContext & {
+export type ProcedureHandlerContext<State, Context> = Context & {
   /**
    * State for this service as defined by the service definition.
    */

--- a/router/index.ts
+++ b/router/index.ts
@@ -9,7 +9,7 @@ export type {
   ProcType,
 } from './services';
 export {
-  ServiceSchema,
+  createServiceSchema,
   serializeSchema,
   SerializedServerSchema,
   SerializedServiceSchema,

--- a/router/index.ts
+++ b/router/index.ts
@@ -49,11 +49,7 @@ export type {
   MiddlewareParam,
   MiddlewareContext,
 } from './server';
-export type {
-  ParsedMetadata,
-  ServiceContext,
-  ProcedureHandlerContext,
-} from './context';
+export type { ParsedMetadata, ProcedureHandlerContext } from './context';
 export { Ok, Err } from './result';
 export type {
   Result,

--- a/router/result.ts
+++ b/router/result.ts
@@ -99,7 +99,7 @@ export type ResponseData<
   ProcedureName extends keyof RiverClient[ServiceName],
   Procedure = RiverClient[ServiceName][ProcedureName],
   Fn extends (...args: never) => unknown = (...args: never) => unknown,
-> = RiverClient extends Client<infer __ServiceSchemaMap>
+> = RiverClient extends Client<infer __ServiceSchemaMap, infer __ServiceContext>
   ? Procedure extends object
     ? Procedure extends object & { rpc: infer RpcFn extends Fn }
       ? Awaited<ReturnType<RpcFn>>

--- a/router/result.ts
+++ b/router/result.ts
@@ -99,7 +99,7 @@ export type ResponseData<
   ProcedureName extends keyof RiverClient[ServiceName],
   Procedure = RiverClient[ServiceName][ProcedureName],
   Fn extends (...args: never) => unknown = (...args: never) => unknown,
-> = RiverClient extends Client<infer __ServiceSchemaMap, infer __ServiceContext>
+> = RiverClient extends Client<infer __ServiceSchemaMap>
   ? Procedure extends object
     ? Procedure extends object & { rpc: infer RpcFn extends Fn }
       ? Awaited<ReturnType<RpcFn>>

--- a/router/services.ts
+++ b/router/services.ts
@@ -301,7 +301,9 @@ export function serializeSchema(
  *
  * When defining procedures, always use the {@link Procedure} constructors to create them.
  */
-export function createServiceSchema<Context extends object>() {
+export function createServiceSchema<Context extends object>(
+  context = {} as Context,
+) {
   return class ServiceSchema<
     State extends object,
     Procedures extends ProcedureMap<Context, State>,
@@ -387,7 +389,7 @@ export function createServiceSchema<Context extends object>() {
     static scaffold<State extends object>(
       config: ServiceConfiguration<Context, State>,
     ) {
-      return new ServiceScaffold(config);
+      return new ServiceScaffold(config, context);
     }
 
     /**
@@ -619,11 +621,14 @@ class ServiceScaffold<Context extends object, State extends object> {
    */
   protected readonly config: ServiceConfiguration<Context, State>;
 
+  protected readonly context: Context;
+
   /**
    * @param config - The configuration for this service.
    */
-  constructor(config: ServiceConfiguration<Context, State>) {
+  constructor(config: ServiceConfiguration<Context, State>, context: Context) {
     this.config = config;
+    this.context = context;
   }
 
   /**
@@ -669,6 +674,6 @@ class ServiceScaffold<Context extends object, State extends object> {
    * ```
    */
   finalize<T extends BrandedProcedureMap<Context, State>>(procedures: T) {
-    return createServiceSchema<Context>().define(this.config, procedures);
+    return createServiceSchema(this.context).define(this.config, procedures);
   }
 }

--- a/router/services.ts
+++ b/router/services.ts
@@ -287,6 +287,13 @@ export function serializeSchema(
  *       return Ok({ result: init.a + init.b });
  *     }
  *   }),
+ *   getUserId: Procedure.rpc({
+ *     requestInit: Type.Object({}),
+ *     responseData: Type.Object({ id: Type.String() }),
+ *     async handler(ctx) {
+ *       return Ok({ id: ctx.userId });
+ *     }
+ *   }),
  * });
  * ```
  *
@@ -301,9 +308,7 @@ export function serializeSchema(
  *
  * When defining procedures, always use the {@link Procedure} constructors to create them.
  */
-export function createServiceSchema<Context extends object>(
-  context = {} as Context,
-) {
+export function createServiceSchema<Context extends object = object>() {
   return class ServiceSchema<
     State extends object,
     Procedures extends ProcedureMap<Context, State>,
@@ -389,7 +394,7 @@ export function createServiceSchema<Context extends object>(
     static scaffold<State extends object>(
       config: ServiceConfiguration<Context, State>,
     ) {
-      return new ServiceScaffold(config, context);
+      return new ServiceScaffold(config);
     }
 
     /**
@@ -621,14 +626,11 @@ class ServiceScaffold<Context extends object, State extends object> {
    */
   protected readonly config: ServiceConfiguration<Context, State>;
 
-  protected readonly context: Context;
-
   /**
    * @param config - The configuration for this service.
    */
-  constructor(config: ServiceConfiguration<Context, State>, context: Context) {
+  constructor(config: ServiceConfiguration<Context, State>) {
     this.config = config;
-    this.context = context;
   }
 
   /**
@@ -674,6 +676,6 @@ class ServiceScaffold<Context extends object, State extends object> {
    * ```
    */
   finalize<T extends BrandedProcedureMap<Context, State>>(procedures: T) {
-    return createServiceSchema(this.context).define(this.config, procedures);
+    return createServiceSchema<Context>().define(this.config, procedures);
   }
 }

--- a/router/services.ts
+++ b/router/services.ts
@@ -266,25 +266,42 @@ export function serializeSchema(
   return schema;
 }
 
+/**
+ * Creates a ServiceSchema class that can be used to define services with their initial state and procedures.
+ * This is a factory function that returns a ServiceSchema class constructor bound to the specified Context type.
+ *
+ * @template Context - The context type that will be available to all procedures in services created with this schema.
+ * @returns A ServiceSchema class constructor with static methods for defining services.
+ *
+ * @example
+ * ```ts
+ * // Create a ServiceSchema class for your context type
+ * const ServiceSchema = createServiceSchema<{ userId: string }>();
+ *
+ * // Define a simple stateless service
+ * const mathService = ServiceSchema.define({
+ *   add: Procedure.rpc({
+ *     requestInit: Type.Object({ a: Type.Number(), b: Type.Number() }),
+ *     responseData: Type.Object({ result: Type.Number() }),
+ *     async handler(ctx, init) {
+ *       return Ok({ result: init.a + init.b });
+ *     }
+ *   }),
+ * });
+ * ```
+ *
+ * There are two main ways to define services with the returned ServiceSchema class:
+ *
+ * 1. **ServiceSchema.define()** - Takes a configuration and procedures directly.
+ *    Use this for smaller services or when you want to define everything in one place.
+ *
+ * 2. **ServiceSchema.scaffold()** - Creates a scaffold that can be used to define
+ *    procedures separately from the configuration. Use this for larger services or
+ *    when you want to organize procedures across multiple files.
+ *
+ * When defining procedures, always use the {@link Procedure} constructors to create them.
+ */
 export function createServiceSchema<Context extends object>() {
-  /**
-   * The schema for a {@link Service}. This is used to define a service, specifically
-   * its initial state and procedures.
-   *
-   * There are two ways to define a service:
-   * 1. the {@link ServiceSchema.define} static method, which takes a configuration and
-   *    a list of procedures directly. Use this to ergonomically define a service schema
-   *    in one go. Good for smaller services, especially if they're stateless.
-   * 2. the {@link ServiceSchema.scaffold} static method, which creates a scaffold that
-   *    can be used to define procedures separately from the configuration. Use this to
-   *    better organize your service's definition, especially if it's a large service.
-   *    You can also use it in a builder pattern to define the service in a more
-   *    fluent way.
-   *
-   * See the static methods for more information and examples.
-   *
-   * When defining procedures, use the {@link Procedure} constructors to create them.
-   */
   return class ServiceSchema<
     State extends object,
     Procedures extends ProcedureMap<Context, State>,

--- a/testUtil/fixtures/cleanup.ts
+++ b/testUtil/fixtures/cleanup.ts
@@ -84,7 +84,9 @@ export async function ensureTransportBuffersAreEventuallyEmpty(
   );
 }
 
-export async function ensureServerIsClean(s: Server<AnyServiceSchemaMap>) {
+export async function ensureServerIsClean(
+  s: Server<object, AnyServiceSchemaMap>,
+) {
   return waitFor(() =>
     expect(
       s.streams,
@@ -111,7 +113,7 @@ export async function testFinishesCleanly({
 }: Partial<{
   clientTransports: Array<ClientTransport<Connection>>;
   serverTransport: ServerTransport<Connection>;
-  server: Server<AnyServiceSchemaMap>;
+  server: Server<object, AnyServiceSchemaMap>;
 }>) {
   // pre-close invariants
   // invariant check servers first as heartbeats are authoritative on their side

--- a/testUtil/fixtures/services.ts
+++ b/testUtil/fixtures/services.ts
@@ -4,13 +4,15 @@ import { Err, Ok, unwrapOrThrow } from '../../router/result';
 import { Observable } from '../observable/observable';
 import { Procedure } from '../../router';
 
+const ServiceSchema = createServiceSchema();
+
 export const EchoRequest = Type.Object({
   msg: Type.String(),
   ignore: Type.Boolean(),
 });
 export const EchoResponse = Type.Object({ response: Type.String() });
 
-const TestServiceScaffold = createServiceSchema().scaffold({
+const TestServiceScaffold = ServiceSchema.scaffold({
   initializeState: () => ({ count: 0 }),
 });
 
@@ -127,7 +129,7 @@ export const TestServiceSchema = TestServiceScaffold.finalize({
   ...testServiceProcedures,
 });
 
-export const OrderingServiceSchema = createServiceSchema().define(
+export const OrderingServiceSchema = ServiceSchema.define(
   {
     initializeState: () => ({ msgs: [] as Array<number> }),
   },
@@ -151,7 +153,7 @@ export const OrderingServiceSchema = createServiceSchema().define(
   },
 );
 
-export const BinaryFileServiceSchema = createServiceSchema().define({
+export const BinaryFileServiceSchema = ServiceSchema.define({
   getFile: Procedure.rpc({
     requestInit: Type.Object({ file: Type.String() }),
     responseData: Type.Object({ contents: Type.Uint8Array() }),
@@ -166,7 +168,7 @@ export const BinaryFileServiceSchema = createServiceSchema().define({
 export const DIV_BY_ZERO = 'DIV_BY_ZERO';
 export const STREAM_ERROR = 'STREAM_ERROR';
 
-export const FallibleServiceSchema = createServiceSchema().define({
+export const FallibleServiceSchema = ServiceSchema.define({
   divide: Procedure.rpc({
     requestInit: Type.Object({ a: Type.Number(), b: Type.Number() }),
     responseData: Type.Object({ result: Type.Number() }),
@@ -233,7 +235,7 @@ export const FallibleServiceSchema = createServiceSchema().define({
   }),
 });
 
-export const SubscribableServiceSchema = createServiceSchema().define(
+export const SubscribableServiceSchema = ServiceSchema.define(
   { initializeState: () => ({ count: new Observable(0) }) },
   {
     add: Procedure.rpc({
@@ -260,7 +262,7 @@ export const SubscribableServiceSchema = createServiceSchema().define(
   },
 );
 
-export const UploadableServiceSchema = createServiceSchema().define({
+export const UploadableServiceSchema = ServiceSchema.define({
   addMultiple: Procedure.upload({
     requestInit: Type.Object({}),
     requestData: Type.Object({ n: Type.Number() }),
@@ -316,7 +318,7 @@ const RecursivePayload = Type.Recursive((This) =>
   }),
 );
 
-export const NonObjectSchemas = createServiceSchema().define({
+export const NonObjectSchemas = ServiceSchema.define({
   add: Procedure.rpc({
     requestInit: Type.Number(),
     responseData: Type.Number(),
@@ -335,7 +337,7 @@ export const NonObjectSchemas = createServiceSchema().define({
 });
 
 export function SchemaWithDisposableState(dispose: () => void) {
-  return createServiceSchema().define(
+  return ServiceSchema.define(
     { initializeState: () => ({ [Symbol.dispose]: dispose }) },
     {
       add: Procedure.rpc({
@@ -352,7 +354,7 @@ export function SchemaWithDisposableState(dispose: () => void) {
 export function SchemaWithAsyncDisposableStateAndScaffold(
   dispose: () => Promise<void>,
 ) {
-  const scaffold = createServiceSchema().scaffold({
+  const scaffold = ServiceSchema.scaffold({
     initializeState: () => ({ [Symbol.asyncDispose]: dispose }),
   });
 

--- a/testUtil/fixtures/services.ts
+++ b/testUtil/fixtures/services.ts
@@ -129,6 +129,38 @@ export const TestServiceSchema = TestServiceScaffold.finalize({
   ...testServiceProcedures,
 });
 
+export const testContext = {
+  logger: {
+    info: (message: string) => {
+      console.log(message);
+    },
+  },
+};
+
+const TestServiceWithContextScaffold = createServiceSchema(
+  testContext,
+).scaffold({
+  initializeState: () => ({ count: 0 }),
+});
+
+const testServiceWithContextProcedures =
+  TestServiceWithContextScaffold.procedures({
+    add: Procedure.rpc({
+      requestInit: Type.Object({ n: Type.Number() }),
+      responseData: Type.Object({ result: Type.Number() }),
+      async handler({ ctx, reqInit: { n } }) {
+        ctx.state.count += n;
+
+        return Ok({ result: ctx.state.count });
+      },
+    }),
+  });
+
+export const TestServiceWithContextSchema =
+  TestServiceWithContextScaffold.finalize({
+    ...testServiceWithContextProcedures,
+  });
+
 export const OrderingServiceSchema = ServiceSchema.define(
   {
     initializeState: () => ({ msgs: [] as Array<number> }),

--- a/testUtil/fixtures/services.ts
+++ b/testUtil/fixtures/services.ts
@@ -1,5 +1,5 @@
 import { Type } from '@sinclair/typebox';
-import { ServiceSchema } from '../../router/services';
+import { createServiceSchema } from '../../router/services';
 import { Err, Ok, unwrapOrThrow } from '../../router/result';
 import { Observable } from '../observable/observable';
 import { Procedure } from '../../router';
@@ -10,7 +10,7 @@ export const EchoRequest = Type.Object({
 });
 export const EchoResponse = Type.Object({ response: Type.String() });
 
-const TestServiceScaffold = ServiceSchema.scaffold({
+const TestServiceScaffold = createServiceSchema().scaffold({
   initializeState: () => ({ count: 0 }),
 });
 
@@ -127,8 +127,10 @@ export const TestServiceSchema = TestServiceScaffold.finalize({
   ...testServiceProcedures,
 });
 
-export const OrderingServiceSchema = ServiceSchema.defineWithContext()(
-  { initializeState: () => ({ msgs: [] as Array<number> }) },
+export const OrderingServiceSchema = createServiceSchema().define(
+  {
+    initializeState: () => ({ msgs: [] as Array<number> }),
+  },
   {
     add: Procedure.rpc({
       requestInit: Type.Object({ n: Type.Number() }),
@@ -139,7 +141,6 @@ export const OrderingServiceSchema = ServiceSchema.defineWithContext()(
         return Ok({ n });
       },
     }),
-
     getAll: Procedure.rpc({
       requestInit: Type.Object({}),
       responseData: Type.Object({ msgs: Type.Array(Type.Number()) }),
@@ -150,7 +151,7 @@ export const OrderingServiceSchema = ServiceSchema.defineWithContext()(
   },
 );
 
-export const BinaryFileServiceSchema = ServiceSchema.defineWithContext()({
+export const BinaryFileServiceSchema = createServiceSchema().define({
   getFile: Procedure.rpc({
     requestInit: Type.Object({ file: Type.String() }),
     responseData: Type.Object({ contents: Type.Uint8Array() }),
@@ -165,7 +166,7 @@ export const BinaryFileServiceSchema = ServiceSchema.defineWithContext()({
 export const DIV_BY_ZERO = 'DIV_BY_ZERO';
 export const STREAM_ERROR = 'STREAM_ERROR';
 
-export const FallibleServiceSchema = ServiceSchema.defineWithContext()({
+export const FallibleServiceSchema = createServiceSchema().define({
   divide: Procedure.rpc({
     requestInit: Type.Object({ a: Type.Number(), b: Type.Number() }),
     responseData: Type.Object({ result: Type.Number() }),
@@ -232,7 +233,7 @@ export const FallibleServiceSchema = ServiceSchema.defineWithContext()({
   }),
 });
 
-export const SubscribableServiceSchema = ServiceSchema.defineWithContext()(
+export const SubscribableServiceSchema = createServiceSchema().define(
   { initializeState: () => ({ count: new Observable(0) }) },
   {
     add: Procedure.rpc({
@@ -259,7 +260,7 @@ export const SubscribableServiceSchema = ServiceSchema.defineWithContext()(
   },
 );
 
-export const UploadableServiceSchema = ServiceSchema.defineWithContext()({
+export const UploadableServiceSchema = createServiceSchema().define({
   addMultiple: Procedure.upload({
     requestInit: Type.Object({}),
     requestData: Type.Object({ n: Type.Number() }),
@@ -315,26 +316,7 @@ const RecursivePayload = Type.Recursive((This) =>
   }),
 );
 
-ServiceSchema.defineWithContext<{
-  db: string;
-}>()(
-  {
-    initializeState: () => ({ a: 'test' }),
-  },
-  {
-    add: Procedure.rpc({
-      requestInit: Type.Number(),
-      responseData: Type.Number(),
-      async handler({ ctx, reqInit }) {
-        ctx.db;
-
-        return Ok(reqInit + 1);
-      },
-    }),
-  },
-);
-
-export const NonObjectSchemas = ServiceSchema.defineWithContext()({
+export const NonObjectSchemas = createServiceSchema().define({
   add: Procedure.rpc({
     requestInit: Type.Number(),
     responseData: Type.Number(),
@@ -353,7 +335,7 @@ export const NonObjectSchemas = ServiceSchema.defineWithContext()({
 });
 
 export function SchemaWithDisposableState(dispose: () => void) {
-  return ServiceSchema.defineWithContext()(
+  return createServiceSchema().define(
     { initializeState: () => ({ [Symbol.dispose]: dispose }) },
     {
       add: Procedure.rpc({
@@ -370,7 +352,7 @@ export function SchemaWithDisposableState(dispose: () => void) {
 export function SchemaWithAsyncDisposableStateAndScaffold(
   dispose: () => Promise<void>,
 ) {
-  const scaffold = ServiceSchema.scaffold({
+  const scaffold = createServiceSchema().scaffold({
     initializeState: () => ({ [Symbol.asyncDispose]: dispose }),
   });
 

--- a/testUtil/fixtures/services.ts
+++ b/testUtil/fixtures/services.ts
@@ -135,6 +135,7 @@ export const testContext = {
       console.log(message);
     },
   },
+  add: (a: number, b: number) => a + b,
 };
 
 const TestServiceWithContextScaffold = createServiceSchema(

--- a/testUtil/fixtures/services.ts
+++ b/testUtil/fixtures/services.ts
@@ -127,7 +127,7 @@ export const TestServiceSchema = TestServiceScaffold.finalize({
   ...testServiceProcedures,
 });
 
-export const OrderingServiceSchema = ServiceSchema.define(
+export const OrderingServiceSchema = ServiceSchema.defineWithContext()(
   { initializeState: () => ({ msgs: [] as Array<number> }) },
   {
     add: Procedure.rpc({
@@ -150,7 +150,7 @@ export const OrderingServiceSchema = ServiceSchema.define(
   },
 );
 
-export const BinaryFileServiceSchema = ServiceSchema.define({
+export const BinaryFileServiceSchema = ServiceSchema.defineWithContext()({
   getFile: Procedure.rpc({
     requestInit: Type.Object({ file: Type.String() }),
     responseData: Type.Object({ contents: Type.Uint8Array() }),
@@ -165,7 +165,7 @@ export const BinaryFileServiceSchema = ServiceSchema.define({
 export const DIV_BY_ZERO = 'DIV_BY_ZERO';
 export const STREAM_ERROR = 'STREAM_ERROR';
 
-export const FallibleServiceSchema = ServiceSchema.define({
+export const FallibleServiceSchema = ServiceSchema.defineWithContext()({
   divide: Procedure.rpc({
     requestInit: Type.Object({ a: Type.Number(), b: Type.Number() }),
     responseData: Type.Object({ result: Type.Number() }),
@@ -232,7 +232,7 @@ export const FallibleServiceSchema = ServiceSchema.define({
   }),
 });
 
-export const SubscribableServiceSchema = ServiceSchema.define(
+export const SubscribableServiceSchema = ServiceSchema.defineWithContext()(
   { initializeState: () => ({ count: new Observable(0) }) },
   {
     add: Procedure.rpc({
@@ -259,7 +259,7 @@ export const SubscribableServiceSchema = ServiceSchema.define(
   },
 );
 
-export const UploadableServiceSchema = ServiceSchema.define({
+export const UploadableServiceSchema = ServiceSchema.defineWithContext()({
   addMultiple: Procedure.upload({
     requestInit: Type.Object({}),
     requestData: Type.Object({ n: Type.Number() }),
@@ -315,7 +315,26 @@ const RecursivePayload = Type.Recursive((This) =>
   }),
 );
 
-export const NonObjectSchemas = ServiceSchema.define({
+ServiceSchema.defineWithContext<{
+  db: string;
+}>()(
+  {
+    initializeState: () => ({ a: 'test' }),
+  },
+  {
+    add: Procedure.rpc({
+      requestInit: Type.Number(),
+      responseData: Type.Number(),
+      async handler({ ctx, reqInit }) {
+        ctx.db;
+
+        return Ok(reqInit + 1);
+      },
+    }),
+  },
+);
+
+export const NonObjectSchemas = ServiceSchema.defineWithContext()({
   add: Procedure.rpc({
     requestInit: Type.Number(),
     responseData: Type.Number(),
@@ -334,7 +353,7 @@ export const NonObjectSchemas = ServiceSchema.define({
 });
 
 export function SchemaWithDisposableState(dispose: () => void) {
-  return ServiceSchema.define(
+  return ServiceSchema.defineWithContext()(
     { initializeState: () => ({ [Symbol.dispose]: dispose }) },
     {
       add: Procedure.rpc({

--- a/testUtil/fixtures/services.ts
+++ b/testUtil/fixtures/services.ts
@@ -138,9 +138,9 @@ export const testContext = {
   add: (a: number, b: number) => a + b,
 };
 
-const TestServiceWithContextScaffold = createServiceSchema(
-  testContext,
-).scaffold({
+const TestServiceWithContextScaffold = createServiceSchema<
+  typeof testContext
+>().scaffold({
   initializeState: () => ({ count: 0 }),
 });
 


### PR DESCRIPTION
## Why

When we are creating a server using river, we have to declare the `ServiceContext` interface globally so TypeScript can infer the type for `ctx` within a procedure. 

```js
 declare module '@replit/river' {
   interface ServiceContext {
       db: Database;
   }
 }
```

However, it will be an issue in a mono repo setup where we want to create multiple servers with different `ServiceContext`. 

<!-- Describe what you are trying to accomplish with this pull request -->

## What changed

Use builder pattern for `ServiceSchema` so we can create a `ServiceSchema` with Context like 

`const ServiceSchema = createServiceSchema<Context>();`

Example: 

```js

const extendedContext = {
  testctx: Math.random().toString(),
};

const ServiceSchema = createServiceSchema<typeof extendedContext>();

const services = {
  testservice: ServiceSchema.define({
    testrpc: Procedure.rpc({
      requestInit: Type.Object({}),
      responseData: Type.String(),
      handler: async ({ ctx }) => {
        return Ok(ctx.testctx);
      },
    }),
  }),
};
```

When we create a server, it will perform type checking to make sure that all the services are expecting the same `ServiceContext` as the type of `extendedContext` in the config.

```js
createServer(serverTransport, services, {
  extendedContext,
});
```

There is no type-checking for `Context` in createClient(). We are using `any` to skip it behind the scene because it is a implementation detail on the server side.

```js
const client = createClient<typeof services>(
  clientTransport,
  serverTransport.clientId,
); 
```

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [x] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
