### PR TITLE
Refactor ParsedMetadata as generic

### DIFF
--- a/__tests__/cancellation.test.ts
+++ b/__tests__/cancellation.test.ts
@@ -31,6 +31,7 @@ function makeMockHandler<T extends ValidProcType>(
     Procedure<
       object,
       object,
+      object,
       T,
       TObject,
       TObject | null,

--- a/__tests__/cleanup.test.ts
+++ b/__tests__/cleanup.test.ts
@@ -504,7 +504,7 @@ describe('request finishing triggers signal onabort', async () => {
     const clientTransport = getClientTransport('client');
     const serverTransport = getServerTransport();
     const handler =
-      vi.fn<(ctx: ProcedureHandlerContext<object, object>) => void>();
+      vi.fn<(ctx: ProcedureHandlerContext<object, object, object>) => void>();
     const serverId = serverTransport.clientId;
     const serviceName = 'service';
     const procedureName = procedureType;
@@ -523,7 +523,7 @@ describe('request finishing triggers signal onabort', async () => {
           async handler({
             ctx,
           }: {
-            ctx: ProcedureHandlerContext<object, object>;
+            ctx: ProcedureHandlerContext<object, object, object>;
           }) {
             handler(ctx);
 

--- a/__tests__/e2e.test.ts
+++ b/__tests__/e2e.test.ts
@@ -931,6 +931,12 @@ describe.each(testMatrix())(
       const requestSchema = Type.Object({
         data: Type.String(),
       });
+
+      interface ParsedMetadata {
+        data: string;
+        extra: number;
+      }
+
       const clientTransport = getClientTransport(
         'client',
         createClientHandshakeOptions(requestSchema, () => ({ data: 'foobar' })),
@@ -949,7 +955,7 @@ describe.each(testMatrix())(
       });
 
       const services = {
-        test: createServiceSchema().define({
+        test: createServiceSchema<object, ParsedMetadata>().define({
           getData: Procedure.rpc({
             requestInit: Type.Object({}),
             responseData: Type.Object({
@@ -957,9 +963,7 @@ describe.each(testMatrix())(
               extra: Type.Number(),
             }),
             handler: async ({ ctx }) => {
-              // we haven't extended the interface
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              return Ok({ ...ctx.metadata } as { data: string; extra: number });
+              return Ok({ ...ctx.metadata });
             },
           }),
         }),

--- a/__tests__/typescript-stress.test.ts
+++ b/__tests__/typescript-stress.test.ts
@@ -49,6 +49,7 @@ const fnBody = Procedure.rpc<
   {
     db: string;
   },
+  object,
   typeof requestData,
   typeof responseData,
   typeof responseError
@@ -429,18 +430,22 @@ describe('Handshake', () => {
       },
     );
 
-    createServer(mockTransportNetwork.getServerTransport(), services, {
-      handshakeOptions: createServerHandshakeOptions(
-        schema,
-        (metadata, _prev) => {
-          if (metadata.token !== '123') {
-            return false;
-          }
+    createServer(
+      mockTransportNetwork.getServerTransport<typeof schema>(),
+      services,
+      {
+        handshakeOptions: createServerHandshakeOptions(
+          schema,
+          (metadata, _prev) => {
+            if (metadata.token !== '123') {
+              return false;
+            }
 
-          return {};
-        },
-      ),
-    });
+            return {};
+          },
+        ),
+      },
+    );
   });
 });
 

--- a/router/client.ts
+++ b/router/client.ts
@@ -147,9 +147,13 @@ export type Client<
     // Context is a server-side implementation detail that doesn't affect the client interface
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any,
     Services
   > = InstantiatedServiceSchemaMap<
     // Context is a server-side implementation detail that doesn't affect the client interface
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     any,
     Services

--- a/router/context.ts
+++ b/router/context.ts
@@ -6,77 +6,59 @@ import { CancelErrorSchema } from './errors';
 import { Static } from '@sinclair/typebox';
 
 /**
- * The parsed metadata schema for a service. This is the
- * return value of the {@link ServerHandshakeOptions.validate}
- * if the handshake extension is used.
- *
- * You should use declaration merging to extend this interface
- * with the sanitized metadata.
- *
- * ```ts
- * declare module '@replit/river' {
- *   interface ParsedMetadata {
- *     userId: number;
- *   }
- * }
- * ```
- */
-/* eslint-disable-next-line @typescript-eslint/no-empty-interface */
-export interface ParsedMetadata extends Record<string, unknown> {}
-
-/**
  * This is passed to every procedure handler and contains various context-level
  * information and utilities.
  */
-export type ProcedureHandlerContext<State, Context> = Context & {
-  /**
-   * State for this service as defined by the service definition.
-   */
-  state: State;
-  /**
-   * The span for this procedure call. You can use this to add attributes, events, and
-   * links to the span.
-   */
-  span: Span;
-  /**
-   * Metadata parsed on the server. See {@link ParsedMetadata}
-   */
-  metadata: ParsedMetadata;
-  /**
-   * The ID of the session that sent this request.
-   */
-  sessionId: SessionId;
-  /**
-   * The ID of the client that sent this request. There may be multiple sessions per client.
-   */
-  from: TransportClientId;
-  /**
-   * This is used to cancel the procedure call from the handler and notify the client that the
-   * call was cancelled.
-   *
-   * Cancelling is not the same as closing procedure calls gracefully, please refer to
-   * the river documentation to understand the difference between the two concepts.
-   */
-  cancel: (message?: string) => ErrResult<Static<typeof CancelErrorSchema>>;
-  /**
-   * This signal is a standard [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
-   * triggered when the procedure invocation is done. This signal tracks the invocation/request finishing
-   * for _any_ reason, for example:
-   * - client explicit cancellation
-   * - procedure handler explicit cancellation via {@link cancel}
-   * - client session disconnect
-   * - server cancellation due to client invalid payload
-   * - invocation finishes cleanly, this depends on the type of the procedure (i.e. rpc handler return, or in a stream after the client-side has closed the request writable and the server-side has closed the response writable)
-   *
-   * You can use this to pass it on to asynchronous operations (such as fetch).
-   *
-   * You may also want to explicitly register callbacks on the
-   * ['abort' event](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/abort_event)
-   * as a way to cleanup after the request is finished.
-   *
-   * Note that (per standard AbortSignals) callbacks registered _after_ the procedure invocation
-   * is done are not triggered. In such cases, you can check the "aborted" property and cleanup
-   * immediately if needed.
-   */
-  signal: AbortSignal;
-};
+export type ProcedureHandlerContext<State, Context, ParsedMetadata> =
+  Context & {
+    /**
+     * State for this service as defined by the service definition.
+     */
+    state: State;
+    /**
+     * The span for this procedure call. You can use this to add attributes, events, and
+     * links to the span.
+     */
+    span: Span;
+    /**
+     * Metadata parsed on the server. See {@link createServerHandshakeOptions}
+     */
+    metadata: ParsedMetadata;
+    /**
+     * The ID of the session that sent this request.
+     */
+    sessionId: SessionId;
+    /**
+     * The ID of the client that sent this request. There may be multiple sessions per client.
+     */
+    from: TransportClientId;
+    /**
+     * This is used to cancel the procedure call from the handler and notify the client that the
+     * call was cancelled.
+     *
+     * Cancelling is not the same as closing procedure calls gracefully, please refer to
+     * the river documentation to understand the difference between the two concepts.
+     */
+    cancel: (message?: string) => ErrResult<Static<typeof CancelErrorSchema>>;
+    /**
+     * This signal is a standard [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
+     * triggered when the procedure invocation is done. This signal tracks the invocation/request finishing
+     * for _any_ reason, for example:
+     * - client explicit cancellation
+     * - procedure handler explicit cancellation via {@link cancel}
+     * - client session disconnect
+     * - server cancellation due to client invalid payload
+     * - invocation finishes cleanly, this depends on the type of the procedure (i.e. rpc handler return, or in a stream after the client-side has closed the request writable and the server-side has closed the response writable)
+     *
+     * You can use this to pass it on to asynchronous operations (such as fetch).
+     *
+     * You may also want to explicitly register callbacks on the
+     * ['abort' event](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/abort_event)
+     * as a way to cleanup after the request is finished.
+     *
+     * Note that (per standard AbortSignals) callbacks registered _after_ the procedure invocation
+     * is done are not triggered. In such cases, you can check the "aborted" property and cleanup
+     * immediately if needed.
+     */
+    signal: AbortSignal;
+  };

--- a/router/handshake.ts
+++ b/router/handshake.ts
@@ -1,12 +1,11 @@
 import { Static, TSchema } from '@sinclair/typebox';
-import { ParsedMetadata } from './context';
 import { HandshakeErrorCustomHandlerFatalResponseCodes } from '../transport/message';
 
 type ConstructHandshake<T extends TSchema> = () =>
   | Static<T>
   | Promise<Static<T>>;
 
-type ValidateHandshake<T extends TSchema> = (
+type ValidateHandshake<T extends TSchema, ParsedMetadata> = (
   metadata: Static<T>,
   previousParsedMetadata?: ParsedMetadata,
 ) =>
@@ -34,6 +33,7 @@ export interface ClientHandshakeOptions<
 
 export interface ServerHandshakeOptions<
   MetadataSchema extends TSchema = TSchema,
+  ParsedMetadata extends object = object,
 > {
   /**
    * Schema for the metadata that the server receives from the client
@@ -52,7 +52,7 @@ export interface ServerHandshakeOptions<
    * @param isReconnect - Whether the client is reconnecting to the session,
    *                      or if this is a new session.
    */
-  validate: ValidateHandshake<MetadataSchema>;
+  validate: ValidateHandshake<MetadataSchema, ParsedMetadata>;
 }
 
 export function createClientHandshakeOptions<
@@ -66,9 +66,10 @@ export function createClientHandshakeOptions<
 
 export function createServerHandshakeOptions<
   MetadataSchema extends TSchema = TSchema,
+  ParsedMetadata extends object = object,
 >(
   schema: MetadataSchema,
-  validate: ValidateHandshake<MetadataSchema>,
-): ServerHandshakeOptions {
-  return { schema, validate: validate as ValidateHandshake<TSchema> };
+  validate: ValidateHandshake<MetadataSchema, ParsedMetadata>,
+): ServerHandshakeOptions<MetadataSchema, ParsedMetadata> {
+  return { schema, validate };
 }

--- a/router/index.ts
+++ b/router/index.ts
@@ -49,7 +49,7 @@ export type {
   MiddlewareParam,
   MiddlewareContext,
 } from './server';
-export type { ParsedMetadata, ProcedureHandlerContext } from './context';
+export type { ProcedureHandlerContext } from './context';
 export { Ok, Err } from './result';
 export type {
   Result,

--- a/testUtil/fixtures/cleanup.ts
+++ b/testUtil/fixtures/cleanup.ts
@@ -85,7 +85,7 @@ export async function ensureTransportBuffersAreEventuallyEmpty(
 }
 
 export async function ensureServerIsClean(
-  s: Server<object, AnyServiceSchemaMap>,
+  s: Server<object, object, AnyServiceSchemaMap>,
 ) {
   return waitFor(() =>
     expect(
@@ -112,8 +112,11 @@ export async function testFinishesCleanly({
   server,
 }: Partial<{
   clientTransports: Array<ClientTransport<Connection>>;
-  serverTransport: ServerTransport<Connection>;
-  server: Server<object, AnyServiceSchemaMap>;
+  // MetadataSchema and ParsedMetadata are not used in this test,
+  // so we can safely use any here
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  serverTransport: ServerTransport<Connection, any, any>;
+  server: Server<object, object, AnyServiceSchemaMap>;
 }>) {
   // pre-close invariants
   // invariant check servers first as heartbeats are authoritative on their side

--- a/transport/impls/ws/server.ts
+++ b/transport/impls/ws/server.ts
@@ -5,6 +5,7 @@ import { WsLike } from './wslike';
 import { ServerTransport } from '../../server';
 import { ProvidedServerTransportOptions } from '../../options';
 import { type IncomingMessage } from 'http';
+import { TSchema } from '@sinclair/typebox';
 
 function cleanHeaders(
   headers: IncomingMessage['headers'],
@@ -21,7 +22,10 @@ function cleanHeaders(
   return cleanedHeaders;
 }
 
-export class WebSocketServerTransport extends ServerTransport<WebSocketConnection> {
+export class WebSocketServerTransport<
+  MetadataSchema extends TSchema = TSchema,
+  ParsedMetadata extends object = object,
+> extends ServerTransport<WebSocketConnection, MetadataSchema, ParsedMetadata> {
   wss: WebSocketServer;
 
   constructor(

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -29,7 +29,6 @@ import {
   ProvidedClientTransportOptions,
   ProvidedTransportOptions,
 } from './options';
-import { ParsedMetadata } from '../router';
 
 describe.each(testMatrix())(
   'transport connection behaviour tests ($transport.name transport, $codec.name codec)',
@@ -881,7 +880,7 @@ describe.each(testMatrix())(
       const get = vi.fn();
 
       const parse = vi.fn(() => {
-        const promise = new Promise<ParsedMetadata>(() => {
+        const promise = new Promise<object>(() => {
           // noop we never want this to return
         });
 
@@ -1492,10 +1491,13 @@ describe.each(testMatrix())(
         kept: Type.String(),
         discarded: Type.String(),
       });
+
+      interface Metadata {
+        kept: string;
+      }
+
       const get = vi.fn(async () => ({ kept: 'kept', discarded: 'discarded' }));
-      const parse = vi.fn(async (metadata: unknown) => ({
-        // @ts-expect-error - we haven't extended the global type here
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const parse = vi.fn(async (metadata: Metadata) => ({
         kept: metadata.kept,
       }));
 
@@ -1537,10 +1539,13 @@ describe.each(testMatrix())(
       const schema = Type.Object({
         foo: Type.String(),
       });
+
+      interface Metadata {
+        foo: string;
+      }
+
       const get = vi.fn(async () => ({ foo: false }));
-      const parse = vi.fn(async (metadata: unknown) => ({
-        // @ts-expect-error - we haven't extended the global type here
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const parse = vi.fn(async (metadata: Metadata) => ({
         foo: metadata.foo,
       }));
 
@@ -1593,10 +1598,12 @@ describe.each(testMatrix())(
         foo: Type.Boolean(),
       });
 
+      interface Metadata {
+        foo: boolean;
+      }
+
       const get = vi.fn(async () => ({ foo: 123 }));
-      const parse = vi.fn(async (metadata: unknown) => ({
-        // @ts-expect-error - we haven't extended the global type here
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const parse = vi.fn(async (metadata: Metadata) => ({
         foo: metadata.foo,
       }));
 
@@ -1661,11 +1668,16 @@ describe.each(testMatrix())(
         discarded: 'discarded',
       }));
 
-      const validate = vi.fn(async (metadata: unknown, _previous: unknown) => ({
-        // @ts-expect-error - we haven't extended the global type here
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        kept: metadata.kept,
-      }));
+      interface Metadata {
+        kept: string;
+        discarded: string;
+      }
+
+      const validate = vi.fn(
+        async (metadata: Metadata, _previous: unknown) => ({
+          kept: metadata.kept,
+        }),
+      );
 
       const serverTransport = getServerTransport('SERVER', {
         schema,


### PR DESCRIPTION
## Why

This PR makes the `ParsedMetadata` type a generic parameter rather than a global interface that requires declaration merging. This allows for having multiple `ParsedMetadata` for different projects in a monorepo

## What changed

- Changed `ParsedMetadata` from a global interface to a generic parameter in relevant types
- Updated `ProcedureHandlerContext` to accept a generic `ParsedMetadata` parameter
- Modified `ServerHandshakeOptions` to accept a generic `ParsedMetadata` parameter
- Updated `ServerTransport` to accept generic parameters for metadata schema and parsed metadata
- Update type parameters to procedure types (rpc, upload, subscription, stream)
- Updated tests to use the new generic parameters

Example:

```js
      const requestSchema = Type.Object({
        data: Type.String(),
      });

      interface ParsedMetadata {
        data: string;
        extra: number;
      }

      const clientTransport = getClientTransport(
        'client',
        createClientHandshakeOptions(requestSchema, () => ({ data: 'foobar' })),
      );
      const serverTransport = getServerTransport(
        'SERVER',
        createServerHandshakeOptions(requestSchema, (metadata) => {
          return {
            data: metadata.data,
            extra: 42,
          };
        }),
      );

      const services = {
        test: createServiceSchema<object, ParsedMetadata>().define({
          getData: Procedure.rpc({
            requestInit: Type.Object({}),
            responseData: Type.Object({
              data: Type.String(),
              extra: Type.Number(),
            }),
            handler: async ({ ctx }) => {
              return Ok({ ...ctx.metadata });
            },
          }),
        }),
      };
      const server = createServer(serverTransport, services);
      const client = createClient<typeof services>(
        clientTransport,
        serverTransport.clientId,
      );
```

## Versioning

- [ ] Breaking protocol change
- [x] Breaking ts/js API change