### PR TITLE
Bump version to v0.208.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.208.3",
+  "version": "0.208.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.208.3",
+      "version": "0.208.4",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.208.3",
+  "version": "0.208.4",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Why

Bump river version to `v0.208.4` before merging the `ServiceContext` and `ParsedMetadata` PR.

## What changed

- Bump river version to `v0.208.4`

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
