### PR TITLE
Pass ParsedMetadata to SeviceSchema.scaffold()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.209.0",
+  "version": "0.209.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.209.0",
+      "version": "0.209.1",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.209.0",
+  "version": "0.209.1",
   "type": "module",
   "exports": {
     ".": {

--- a/router/services.ts
+++ b/router/services.ts
@@ -407,7 +407,7 @@ export function createServiceSchema<
     static scaffold<State extends object>(
       config: ServiceConfiguration<Context, State>,
     ) {
-      return new ServiceScaffold(config);
+      return new ServiceScaffold<Context, State, ParsedMetadata>(config);
     }
 
     /**


### PR DESCRIPTION
## Why

I should have pass `ParsedMetadata` to `SeviceSchema.scaffold()`. Otherwise, the `ServiceScaffold` always sets `ParsedMetadata` as `object` by default

## What changed

- pass `ParsedMetadata` to `SeviceSchema.scaffold()`
- update tests 

<!-- Describe the changes you made in this pull request or pointers for the reviewer -->

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
