### PR TITLE
Remove GitHub Release publishing step from workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,10 +26,3 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_AUTH_TOKEN }}
-
-      - name: Publish GitHub Release
-        uses: release-drafter/release-drafter@v5
-        with:
-          publish: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why?

The publish workflow is wrong right now. It is creating another empty release after a release is published...

https://github.com/replit/river/releases/tag/v0.209.2

## What changed

- Deleted the `Publish GitHub Release` step from the `publish.yml` because we are publishing it by clicking on the draft release.

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed --> 
