### PR TITLE
export ReadableBrokenError, RawReadable, ReadableResult

### DIFF
--- a/router/index.ts
+++ b/router/index.ts
@@ -28,12 +28,8 @@ export type {
   SubscriptionProcedure,
   StreamProcedure,
 } from './procedures';
-export type { Writable, Readable } from './streams';
-export {
-  ReadableBrokenError,
-  ReadableImpl as RawReadable,
-  WritableImpl as RawWritable,
-} from './streams';
+export type { Writable, Readable, ReadableResult } from './streams';
+export { ReadableBrokenError, ReadableImpl as RawReadable } from './streams';
 export { Procedure } from './procedures';
 export {
   ProcedureErrorSchemaType,


### PR DESCRIPTION
## Why

- nice to have these for tests instead of importing `it-pushable`
- missed a type export

## What changed

- re-export above types

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
