### PR TITLE
Add `ctx.uncaught` for emitting uncaught errors, particularly in streams

### DIFF
--- a/router/context.ts
+++ b/router/context.ts
@@ -2,7 +2,7 @@ import { Span } from '@opentelemetry/api';
 import { TransportClientId } from '../transport/message';
 import { SessionId } from '../transport/sessionStateMachine/common';
 import { ErrResult } from './result';
-import { CancelErrorSchema } from './errors';
+import { CancelErrorSchema, UncaughtErrorSchema } from './errors';
 import { Static } from '@sinclair/typebox';
 
 /**
@@ -40,6 +40,15 @@ export type ProcedureHandlerContext<State, Context, ParsedMetadata> =
      * the river documentation to understand the difference between the two concepts.
      */
     cancel: (message?: string) => ErrResult<Static<typeof CancelErrorSchema>>;
+    /**
+     * This emits an uncaught error in the same way that throwing an error in a handler
+     * would. You should minimize the amount of work you do after calling this function
+     * as this will start a cleanup of the entire procedure call.
+     *
+     * You'll typically want to use this for streaming procedures, as in e.g. an RPC
+     * you can just throw instead.
+     */
+    uncaught: (err?: unknown) => ErrResult<Static<typeof UncaughtErrorSchema>>;
     /**
      * This signal is a standard [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
      * triggered when the procedure invocation is done. This signal tracks the invocation/request finishing

--- a/router/errors.ts
+++ b/router/errors.ts
@@ -73,6 +73,16 @@ export function castTypeboxValueErrors(
 }
 
 /**
+ * A schema for unexpected errors in handlers
+ */
+export const UncaughtErrorSchema = Type.Object({
+  code: Type.Literal(UNCAUGHT_ERROR_CODE),
+  message: Type.String(),
+});
+
+export const UncaughtResultSchema = ErrResultSchema(UncaughtErrorSchema);
+
+/**
  * A schema for cancel payloads sent from the client
  */
 export const CancelErrorSchema = Type.Object({
@@ -88,6 +98,7 @@ export const CancelResultSchema = ErrResultSchema(CancelErrorSchema);
  * on the client).
  */
 export const ReaderErrorSchema = Type.Union([
+  UncaughtErrorSchema,
   Type.Object({
     code: Type.Literal(UNCAUGHT_ERROR_CODE),
     message: Type.String(),


### PR DESCRIPTION
## Why

Fixes https://github.com/replit/river/issues/333

In streaming procedures, you often need to push an uncaught error into the stream _outside_ of the scope of the handler. This is tricky since all you're left with doing is manually returning an uncaught error rather than using any of the machinery River has built in.

## What changed

Added `ctx.uncaught` which works a lot like `ctx.cancel` except that it uses `UNCAUGHT_ERROR` rather than the cancel code. It uses the exact same mechanism as the normal procedure error handler and yields you an error result that you can return if needed. It accepts anything as an argument so that you can use it ergonomically in a try catch.

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
