### PR TITLE
make sure ReadableIterator conforms to async iterator protocol

### DIFF
--- a/__tests__/streams.test.ts
+++ b/__tests__/streams.test.ts
@@ -32,6 +32,18 @@ describe('Readable unit', () => {
     readable._triggerClose();
   });
 
+  it('should be able to use the raw iter from Symbol.asyncIterator', async () => {
+    const readable = new ReadableImpl<number, SomeError>();
+    const iter = readable[Symbol.asyncIterator]();
+
+    const iterNext = iter.next();
+    readable._pushValue(Ok(1));
+    expect(await iterNext).toEqual({ value: Ok(1), done: false });
+    const iterNext2 = iter.next();
+    readable._triggerClose();
+    expect(await iterNext2).toEqual({ value: undefined, done: true });
+  });
+
   it('should synchronously lock the stream when collect() is called', () => {
     const readable = new ReadableImpl<number, SomeError>();
     void readable.collect();

--- a/router/streams.ts
+++ b/router/streams.ts
@@ -20,7 +20,8 @@ export type ReadableResult<T, E extends Static<BaseErrorSchemaType>> = Result<
  * that doesn't have a the extra "return" and "throw" methods, and
  * the doesn't have a "done value" (TReturn).
  */
-export interface ReadableIterator<T, E extends Static<BaseErrorSchemaType>> {
+export interface ReadableIterator<T, E extends Static<BaseErrorSchemaType>>
+  extends AsyncIterator<ReadableResult<T, E>> {
   next(): Promise<
     | {
         done: false;
@@ -184,7 +185,12 @@ export class ReadableImpl<T, E extends Static<BaseErrorSchemaType>>
    * should check for the next value.
    */
   private next: PromiseWithResolvers<void> | null = null;
-  public [Symbol.asyncIterator]() {
+
+  /**
+   * Consumes the {@link Readable} and returns an {@link AsyncIterator} that can be used
+   * to iterate over the values in the {@link Readable}.
+   */
+  public [Symbol.asyncIterator](): ReadableIterator<T, E> {
     if (this.locked) {
       throw new TypeError('Readable is already locked');
     }
@@ -248,7 +254,7 @@ export class ReadableImpl<T, E extends Static<BaseErrorSchemaType>>
 
         return { done: false, value } as const;
       },
-      return: () => {
+      return: async () => {
         this.break();
 
         return { done: true, value: undefined } as const;


### PR DESCRIPTION
## Why

I was getting a type error as the async iter protocol expects `return` to return a Promise but we returned a bar object

## What changed

- extend the AsyncIterator interface to ensure conformity
- added a test with a type assignment 

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
