### PR TITLE
Make AsyncDiposables match TypeScript's built-in interface

### DIFF
--- a/router/services.ts
+++ b/router/services.ts
@@ -25,7 +25,7 @@ export interface Service<
 > {
   readonly state: State;
   readonly procedures: Procs;
-  [Symbol.asyncDispose]: () => Promise<void>;
+  [Symbol.asyncDispose]: () => PromiseLike<void>;
 }
 
 /**
@@ -158,7 +158,7 @@ type BrandedProcedureMap<Context, State, ParsedMetadata> = Record<
 >;
 
 type MaybeDisposable<State extends object> = State & {
-  [Symbol.asyncDispose]?: () => Promise<void>;
+  [Symbol.asyncDispose]?: () => PromiseLike<void>;
   [Symbol.dispose]?: () => void;
 };
 


### PR DESCRIPTION
## Why

`AsyncDisposable` in TypeScript has a signature of `[Symbol.asyncDispose]: () => PromiseLike<void>;`, ours expects a return of `Promise<void>` meaning we don't accept interfaces that extend `AsyncDisposable`.

## What changed

Make AsyncDiposables match TypeScript's built-in interface

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
