### PR TITLE
add isFatalConnectionError (closes #282)

### DIFF
--- a/__tests__/negative.test.ts
+++ b/__tests__/negative.test.ts
@@ -1,6 +1,7 @@
 import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
 import http from 'node:http';
 import {
+  advanceFakeTimersBySessionGrace,
   cleanupTransports,
   testFinishesCleanly,
   waitFor,
@@ -25,6 +26,7 @@ import { ProtocolError } from '../transport/events';
 import NodeWs from 'ws';
 import { createPostTestCleanups } from '../testUtil/fixtures/cleanup';
 import { generateId } from '../transport/id';
+import { SessionState } from '../transport/sessionStateMachine/common';
 
 describe('should handle incompatabilities', async () => {
   let server: http.Server;
@@ -281,6 +283,54 @@ describe('should handle incompatabilities', async () => {
 
     await testFinishesCleanly({
       clientTransports: [],
+      serverTransport,
+    });
+  });
+
+  test('fatal connection error should prevent reconnection', async () => {
+    class FatalConnectionError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = 'FatalConnectionError';
+      }
+    }
+
+    const createClientSpy = vi.fn(() => Promise.resolve(createLocalWebSocketClient(port)));
+    const clientTransport = new WebSocketClientTransport(
+      createClientSpy,
+      'client',
+      {
+        isFatalConnectionError: (err) => err instanceof FatalConnectionError,
+      },
+    );
+    const serverTransport = new WebSocketServerTransport(wss, 'SERVER');
+
+    addPostTestCleanup(async () => {
+      await cleanupTransports([clientTransport, serverTransport]);
+    });
+
+    clientTransport.connect(serverTransport.clientId);
+    await waitFor(() => expect(numberOfConnections(clientTransport)).toBe(1));
+    await waitFor(() => expect(numberOfConnections(serverTransport)).toBe(1));
+
+
+    expect(clientTransport.reconnectOnConnectionDrop).toBe(true);
+    const session = Array.from(clientTransport.sessions.values())[0];
+    assert(session);
+    assert(session.state === SessionState.Connected);
+
+    const fatalError = new FatalConnectionError('simulated fatal connection error');
+    session.conn.onError(fatalError);
+    session.conn.onClose();
+
+    await advanceFakeTimersBySessionGrace();
+    expect(numberOfConnections(clientTransport)).toBe(0);
+    expect(clientTransport.reconnectOnConnectionDrop).toBe(false);
+    expect(clientTransport.sessions.size).toBe(0);
+    expect(createClientSpy).toHaveBeenCalledTimes(1);
+
+    await testFinishesCleanly({
+      clientTransports: [clientTransport],
       serverTransport,
     });
   });

--- a/__tests__/negative.test.ts
+++ b/__tests__/negative.test.ts
@@ -295,7 +295,9 @@ describe('should handle incompatabilities', async () => {
       }
     }
 
-    const createClientSpy = vi.fn(() => Promise.resolve(createLocalWebSocketClient(port)));
+    const createClientSpy = vi.fn(() =>
+      Promise.resolve(createLocalWebSocketClient(port)),
+    );
     const clientTransport = new WebSocketClientTransport(
       createClientSpy,
       'client',
@@ -313,13 +315,14 @@ describe('should handle incompatabilities', async () => {
     await waitFor(() => expect(numberOfConnections(clientTransport)).toBe(1));
     await waitFor(() => expect(numberOfConnections(serverTransport)).toBe(1));
 
-
     expect(clientTransport.reconnectOnConnectionDrop).toBe(true);
     const session = Array.from(clientTransport.sessions.values())[0];
     assert(session);
     assert(session.state === SessionState.Connected);
 
-    const fatalError = new FatalConnectionError('simulated fatal connection error');
+    const fatalError = new FatalConnectionError(
+      'simulated fatal connection error',
+    );
     session.conn.onError(fatalError);
     session.conn.onClose();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.209.3",
+  "version": "0.209.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.209.3",
+      "version": "0.209.4",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.209.3",
+  "version": "0.209.4",
   "type": "module",
   "exports": {
     ".": {

--- a/transport/client.ts
+++ b/transport/client.ts
@@ -276,10 +276,23 @@ export abstract class ClientTransport<
         onConnectionErrored: (err) => {
           // just log, when we error we also emit close
           const errStr = coerceErrorString(err);
-          this.log?.warn(
-            `connection to ${connectedSession.to} errored: ${errStr}`,
-            connectedSession.loggingMetadata,
-          );
+
+          if (
+            err instanceof Error &&
+            this.options.isFatalConnectionError(err)
+          ) {
+            this.log?.warn(
+              `connection to ${connectedSession.to} fatally errored: ${errStr}`,
+              connectedSession.loggingMetadata,
+            );
+
+            this.reconnectOnConnectionDrop = false;
+          } else {
+            this.log?.warn(
+              `connection to ${connectedSession.to} errored: ${errStr}`,
+              connectedSession.loggingMetadata,
+            );
+          }
         },
         onConnectionClosed: () => {
           this.log?.info(

--- a/transport/impls/ws/connection.ts
+++ b/transport/impls/ws/connection.ts
@@ -7,6 +7,17 @@ interface ConnectionInfoExtras extends Record<string, unknown> {
 
 const WS_HEALTHY_CLOSE_CODE = 1000;
 
+export class WebSocketCloseError extends Error {
+  code: number;
+  reason: string;
+
+  constructor(code: number, reason: string) {
+    super(`websocket closed with code and reason: ${code} - ${reason}`);
+    this.code = code;
+    this.reason = reason;
+  }
+}
+
 export class WebSocketConnection extends Connection {
   ws: WsLike;
   extras?: ConnectionInfoExtras;
@@ -36,10 +47,7 @@ export class WebSocketConnection extends Connection {
 
     this.ws.onclose = ({ code, reason }) => {
       if (didError) {
-        const err = new Error(
-          `websocket closed with code and reason: ${code} - ${reason}`,
-        );
-
+        const err = new WebSocketCloseError(code, reason);
         this.onError(err);
       }
 

--- a/transport/options.ts
+++ b/transport/options.ts
@@ -26,6 +26,7 @@ const defaultConnectionRetryOptions: ConnectionRetryOptions = {
   maxBackoffMs: 32_000,
   attemptBudgetCapacity: 5,
   budgetRestoreIntervalMs: 200,
+  isFatalConnectionError: () => false,
 };
 
 export const defaultClientTransportOptions: ClientTransportOptions = {

--- a/transport/rateLimit.test.ts
+++ b/transport/rateLimit.test.ts
@@ -3,9 +3,11 @@ import {
   ConnectionRetryOptions,
 } from '../transport/rateLimit';
 import { describe, test, expect, vi } from 'vitest';
+import { defaultClientTransportOptions } from './options';
 
 describe('LeakyBucketRateLimit', () => {
   const options: ConnectionRetryOptions = {
+    ...defaultClientTransportOptions,
     attemptBudgetCapacity: 10,
     budgetRestoreIntervalMs: 1000,
     baseIntervalMs: 100,

--- a/transport/rateLimit.ts
+++ b/transport/rateLimit.ts
@@ -38,6 +38,12 @@ export interface ConnectionRetryOptions {
    * After a successful connection attempt, how long to wait before we restore a single budget.
    */
   budgetRestoreIntervalMs: number;
+
+  /**
+   * A function to determine whether an error is fatal and should not be retried.
+   * If this function returns true, the client transport will not attempt to reconnect.
+   */
+  isFatalConnectionError: (err: Error) => boolean;
 }
 
 export class LeakyBucketRateLimit {


### PR DESCRIPTION
## Why

there are cases we dont want to reconnect!

## What changed

add a client option to determine what errors are 'fatal' and should not be considered retriable

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
