### PR TITLE
reexport ws conn related

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.209.4",
+  "version": "0.209.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.209.4",
+      "version": "0.209.5",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.209.4",
+  "version": "0.209.5",
   "type": "module",
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -28,14 +28,6 @@
       "import": "./dist/transport/impls/ws/server.js",
       "require": "./dist/transport/impls/ws/server.cjs"
     },
-    "./transport/uds/client": {
-      "import": "./dist/transport/impls/uds/client.js",
-      "require": "./dist/transport/impls/uds/client.cjs"
-    },
-    "./transport/uds/server": {
-      "import": "./dist/transport/impls/uds/server.js",
-      "require": "./dist/transport/impls/uds/server.cjs"
-    },
     "./test-util": {
       "import": "./dist/testUtil/index.js",
       "require": "./dist/testUtil/index.cjs"

--- a/transport/index.ts
+++ b/transport/index.ts
@@ -18,6 +18,10 @@ export {
 } from './sessionStateMachine';
 export { Connection } from './connection';
 export {
+  WebSocketCloseError,
+  WebSocketConnection,
+} from './impls/ws/connection';
+export {
   TransportMessageSchema,
   OpaqueTransportMessageSchema,
 } from './message';


### PR DESCRIPTION
## Why

for isFatalConnectionError to be useful for websocket errors, we need to do an instanceof check on WebSocketCloseError but its not available :(

## What changed

- re-export WebSocketCloseError and WebSocketConnection from `/transport`
- remove unused uds exports

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
