### PR TITLE
add bigint support to msgpack codec

### DIFF
--- a/codec/binary.ts
+++ b/codec/binary.ts
@@ -1,5 +1,33 @@
-import { decode, encode } from '@msgpack/msgpack';
+import { DecodeError, ExtensionCodec, decode, encode } from '@msgpack/msgpack';
 import { Codec } from './types';
+
+const BIGINT_EXT_TYPE = 0;
+const extensionCodec = new ExtensionCodec();
+extensionCodec.register({
+  type: BIGINT_EXT_TYPE,
+  encode(input: unknown): Uint8Array | null {
+    if (typeof input === 'bigint') {
+      if (
+        input <= Number.MAX_SAFE_INTEGER &&
+        input >= Number.MIN_SAFE_INTEGER
+      ) {
+        return encode(Number(input));
+      } else {
+        return encode(String(input));
+      }
+    } else {
+      return null;
+    }
+  },
+  decode(data: Uint8Array): bigint {
+    const val = decode(data);
+    if (!(typeof val === 'string' || typeof val === 'number')) {
+      throw new DecodeError(`unexpected BigInt source: ${typeof val}`);
+    }
+
+    return BigInt(val);
+  },
+});
 
 /**
  * Binary codec, uses [msgpack](https://www.npmjs.com/package/@msgpack/msgpack) under the hood

--- a/codec/binary.ts
+++ b/codec/binary.ts
@@ -35,10 +35,10 @@ extensionCodec.register({
  */
 export const BinaryCodec: Codec = {
   toBuffer(obj) {
-    return encode(obj, { ignoreUndefined: true });
+    return encode(obj, { ignoreUndefined: true, extensionCodec });
   },
   fromBuffer: (buff: Uint8Array) => {
-    const res = decode(buff);
+    const res = decode(buff, { extensionCodec });
     if (typeof res !== 'object' || res === null) {
       throw new Error('unpacked msg is not an object');
     }

--- a/codec/codec.test.ts
+++ b/codec/codec.test.ts
@@ -27,6 +27,11 @@ describe.each(codecs)('codec -- $name', ({ codec }) => {
     expect(codec.fromBuffer(codec.toBuffer(msg))).toStrictEqual({});
   });
 
+  test('encodes bigint properly', () => {
+    const msg = { big: BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1) };
+    expect(codec.fromBuffer(codec.toBuffer(msg))).toStrictEqual(msg);
+  });
+
   test('deeply nested test', () => {
     const msg = {
       array: [{ object: true }],

--- a/codec/json.ts
+++ b/codec/json.ts
@@ -28,6 +28,10 @@ interface Base64EncodedValue {
   $t: string;
 }
 
+interface BigIntEncodedValue {
+  $b: string;
+}
+
 /**
  * Naive JSON codec implementation using JSON.stringify and JSON.parse.
  * @type {Codec}
@@ -41,6 +45,8 @@ export const NaiveJsonCodec: Codec = {
         const val = this[key];
         if (val instanceof Uint8Array) {
           return { $t: uint8ArrayToBase64(val) } satisfies Base64EncodedValue;
+        } else if (typeof val === 'bigint') {
+          return { $b: val.toString() } satisfies BigIntEncodedValue;
         } else {
           return val;
         }
@@ -53,12 +59,13 @@ export const NaiveJsonCodec: Codec = {
       function reviver(_key, val: unknown) {
         if ((val as Base64EncodedValue | undefined)?.$t !== undefined) {
           return base64ToUint8Array((val as Base64EncodedValue).$t);
+        } else if ((val as BigIntEncodedValue | undefined)?.$b !== undefined) {
+          return BigInt((val as BigIntEncodedValue).$b);
         } else {
           return val;
         }
       },
     ) as unknown;
-
     if (typeof parsed !== 'object' || parsed === null) {
       throw new Error('unpacked msg is not an object');
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.209.5",
+  "version": "0.209.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.209.5",
+      "version": "0.209.6",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "^3.0.0-beta2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.209.5",
+  "version": "0.209.6",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Why

we are seeing `failed to send message: Unrecognized object: [object BigInt]` in production

from msgpack docs:

```
This library does not handle BigInt by default, but you have two options to handle it:

1. Set useBigInt64: true to map bigint to MessagePack's int64/uint64
2. Define a custom ExtensionCodec to map bigint to a MessagePack's extension type
```

## What changed

- do option 2 of the above for binary codec
- add custom extension for json codec

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

<!-- Kind reminder to add tests and updated documentation if needed -->
