### PR TITLE
bump to 0.215.1, add resetBudget test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.216.0",
+  "version": "0.215.1",
   "type": "module",
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.215.0",
+  "version": "0.216.0",
   "type": "module",
   "exports": {
     ".": {

--- a/transport/rateLimit.test.ts
+++ b/transport/rateLimit.test.ts
@@ -89,6 +89,26 @@ describe('LeakyBucketRateLimit', () => {
     expect(backoffMs3).toBeGreaterThan(backoffMs2);
   });
 
+  test('resetBudget zeroes consumed budget and stops restore', () => {
+    const rateLimit = new LeakyBucketRateLimit(options);
+    rateLimit.consumeBudget();
+    rateLimit.consumeBudget();
+    rateLimit.consumeBudget();
+    expect(rateLimit.getBudgetConsumed()).toBe(3);
+    expect(rateLimit.hasBudget()).toBe(true);
+
+    rateLimit.startRestoringBudget();
+
+    rateLimit.resetBudget();
+    expect(rateLimit.getBudgetConsumed()).toBe(0);
+    expect(rateLimit.hasBudget()).toBe(true);
+    expect(rateLimit.getBackoffMs()).toBe(0);
+
+    // restore interval should be stopped — advancing time shouldn't change anything
+    vi.advanceTimersByTime(options.budgetRestoreIntervalMs * 5);
+    expect(rateLimit.getBudgetConsumed()).toBe(0);
+  });
+
   test('reports remaining budget correctly', () => {
     const maxAttempts = 3;
     const rateLimit = new LeakyBucketRateLimit({


### PR DESCRIPTION
## Summary
- Bumps version to 0.216.0 (includes `resetBudget()` from #369)
- Adds test for `resetBudget`: verifies it zeroes consumed budget, resets backoff to 0, and stops the restore interval

## Test plan
- All rate limit tests pass (9/9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)