### PR TITLE
Fix Refine error messages and JSON Pointer escaping

### DIFF
--- a/customSchemas/index.ts
+++ b/customSchemas/index.ts
@@ -39,6 +39,15 @@ export function Uint8ArrayType(
 
       return true;
     },
+    (value) => {
+      if (!(value instanceof Uint8Array)) return 'expected Uint8Array';
+      if (min !== undefined && value.byteLength < min)
+        return `Uint8Array byteLength must be >= ${min}`;
+      if (max !== undefined && value.byteLength > max)
+        return `Uint8Array byteLength must be <= ${max}`;
+
+      return 'invalid Uint8Array';
+    },
   );
 
   uint8ArrayCache.set(key, schema);
@@ -85,6 +94,16 @@ export function DateType(
       if (typeof max === 'number' && value.getTime() > max) return false;
 
       return true;
+    },
+    (value) => {
+      if (!(value instanceof Date)) return 'expected Date';
+      if (isNaN((value as Date).getTime())) return 'expected valid Date';
+      if (typeof min === 'number' && (value as Date).getTime() < min)
+        return `Date timestamp must be >= ${min}`;
+      if (typeof max === 'number' && (value as Date).getTime() > max)
+        return `Date timestamp must be <= ${max}`;
+
+      return 'invalid Date';
     },
   );
 

--- a/customSchemas/index.ts
+++ b/customSchemas/index.ts
@@ -97,10 +97,10 @@ export function DateType(
     },
     (value) => {
       if (!(value instanceof Date)) return 'expected Date';
-      if (isNaN((value as Date).getTime())) return 'expected valid Date';
-      if (typeof min === 'number' && (value as Date).getTime() < min)
+      if (isNaN(value.getTime())) return 'expected valid Date';
+      if (typeof min === 'number' && value.getTime() < min)
         return `Date timestamp must be >= ${min}`;
-      if (typeof max === 'number' && (value as Date).getTime() > max)
+      if (typeof max === 'number' && value.getTime() > max)
         return `Date timestamp must be <= ${max}`;
 
       return 'invalid Date';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.217.0",
+  "version": "0.217.1",
   "type": "module",
   "exports": {
     ".": "./dist/router/index.js",

--- a/router/errors.ts
+++ b/router/errors.ts
@@ -90,7 +90,7 @@ export function validationErrorToRiverErrors(
 
   if (propertyNames) {
     return propertyNames.map((prop) => ({
-      path: `${error.instancePath}/${prop}`,
+      path: `${error.instancePath}/${prop.replace(/~/g, '~0').replace(/\//g, '~1')}`,
       message: error.message,
     }));
   }

--- a/router/errors.ts
+++ b/router/errors.ts
@@ -90,7 +90,9 @@ export function validationErrorToRiverErrors(
 
   if (propertyNames) {
     return propertyNames.map((prop) => ({
-      path: `${error.instancePath}/${prop.replace(/~/g, '~0').replace(/\//g, '~1')}`,
+      path: `${error.instancePath}/${prop
+        .replace(/~/g, '~0')
+        .replace(/\//g, '~1')}`,
       message: error.message,
     }));
   }


### PR DESCRIPTION
## Summary
- Add descriptive error callbacks to `Type.Refine()` for `Uint8ArrayType` and `DateType` — validation errors now report specific reasons (e.g. "expected Uint8Array", "Uint8Array byteLength must be >= 2") instead of generic "Refine Error"
- Escape `~` → `~0` and `/` → `~1` in property names when building JSON Pointer paths in `validationErrorToRiverErrors` per RFC 6901

## Test plan
- [x] All 709 existing tests pass
- [x] Type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)