### PR TITLE
ci: remove pull_request_target trigger from release-drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,9 +10,6 @@ on:
   pull_request:
     # Only following types are handled by the action, but one can default to all as well
     types: [opened, reopened, synchronize]
-  # pull_request_target event is required for autolabeler to support PRs from forks
-  pull_request_target:
-    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why

The TanStack NPM supply-chain compromise ([postmortem](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem)) exploited a `pull_request_target` workflow. Per security policy, we're removing `pull_request_target` from all Replit-owned public repos as a precaution.

This workflow's current usage isn't immediately exploitable — it only runs the release-drafter action and never checks out PR head code — but the trust boundary is fragile and we'd rather not have any `pull_request_target` in public repos.

Slack thread: https://replit.slack.com/archives/C03FS477T17/p1778588219046429

## What changed

Removed the `pull_request_target` trigger block from `.github/workflows/release-drafter.yml`. The `workflow_dispatch`, `push`, and `pull_request` triggers all stay.

**Side-effect:** autolabeler will no longer run on PRs from forks. Release notes are still drafted on pushes/merges to `main`, so the only impact is that fork PRs won't get autolabeled until merged.

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

## Revertibility

Safe to revert — single-file CI workflow change with no runtime, data, or protocol impact.

---

~ written by Zerg :space_invader: ([warped-guardian-042e](https://zerg.zergrush.dev/chat?id=warped-guardian-042e))
