### PR TITLE
Add River RPC span classification attributes

### DIFF
--- a/tracing/index.ts
+++ b/tracing/index.ts
@@ -25,6 +25,26 @@ export interface TelemetryInfo {
   ctx: Context;
 }
 
+function createProcedureAttributes(
+  kind: ValidProcType,
+  serviceName: string,
+  procedureName: string,
+  streamId: string,
+) {
+  return {
+    component: 'river',
+    'rpc.system': 'river',
+    'rpc.service': serviceName,
+    'rpc.method': procedureName,
+    'river.method.kind': kind,
+    'river.method.service': serviceName,
+    'river.method.name': procedureName,
+    'river.rpc.kind': kind,
+    'river.rpc.streaming': kind !== 'rpc',
+    'river.streamId': streamId,
+  };
+}
+
 export function getPropagationContext(
   ctx: Context,
 ): PropagationContext | undefined {
@@ -101,11 +121,12 @@ export function createProcTelemetryInfo(
     `river.client.${serviceName}.${procedureName}`,
     {
       attributes: {
-        component: 'river',
-        'river.method.kind': kind,
-        'river.method.service': serviceName,
-        'river.method.name': procedureName,
-        'river.streamId': streamId,
+        ...createProcedureAttributes(
+          kind,
+          serviceName,
+          procedureName,
+          streamId,
+        ),
         'span.kind': 'client',
       },
       links: [{ context: session.telemetry.span.spanContext() }],
@@ -153,11 +174,12 @@ export function createHandlerSpan<Fn extends (span: Span) => unknown>(
     `river.server.${serviceName}.${procedureName}`,
     {
       attributes: {
-        component: 'river',
-        'river.method.kind': kind,
-        'river.method.service': serviceName,
-        'river.method.name': procedureName,
-        'river.streamId': streamId,
+        ...createProcedureAttributes(
+          kind,
+          serviceName,
+          procedureName,
+          streamId,
+        ),
         'span.kind': 'server',
       },
       links: [{ context: session.telemetry.span.spanContext() }],

--- a/tracing/tracing.test.ts
+++ b/tracing/tracing.test.ts
@@ -15,7 +15,12 @@ import {
 } from '@opentelemetry/sdk-trace-base';
 import { W3CTraceContextPropagator } from '@opentelemetry/core';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
-import { createSessionTelemetryInfo, getPropagationContext } from './index';
+import {
+  createHandlerSpan,
+  createProcTelemetryInfo,
+  createSessionTelemetryInfo,
+  getPropagationContext,
+} from './index';
 import { testMatrix } from '../testUtil/fixtures/matrix';
 import {
   cleanupTransports,
@@ -64,6 +69,64 @@ describe('Basic tracing tests', () => {
         Symbol.for('OpenTelemetry Context Key SPAN'),
       ) as Span,
     ).toBeTruthy();
+  });
+
+  test('procedure spans include rpc classification attributes', () => {
+    spanExporter.reset();
+    const tracer = trace.getTracer('test');
+    const session = dummySession();
+
+    const { span: clientSpan } = createProcTelemetryInfo(
+      tracer,
+      session,
+      'subscription',
+      'example',
+      'watch',
+      'client-stream-id',
+    );
+    clientSpan.end();
+
+    createHandlerSpan(
+      tracer,
+      session,
+      'stream',
+      'example',
+      'chat',
+      'server-stream-id',
+      undefined,
+      (span) => {
+        span.end();
+      },
+    );
+
+    const spans = spanExporter.getFinishedSpans();
+    const clientProcSpan = spans.find(
+      (span) => span.name === 'river.client.example.watch',
+    );
+    const serverProcSpan = spans.find(
+      (span) => span.name === 'river.server.example.chat',
+    );
+
+    expect(clientProcSpan?.attributes).toMatchObject({
+      'rpc.system': 'river',
+      'rpc.service': 'example',
+      'rpc.method': 'watch',
+      'river.method.kind': 'subscription',
+      'river.rpc.kind': 'subscription',
+      'river.rpc.streaming': true,
+      'river.streamId': 'client-stream-id',
+      'span.kind': 'client',
+    });
+    expect(serverProcSpan?.attributes).toMatchObject({
+      'rpc.system': 'river',
+      'rpc.service': 'example',
+      'rpc.method': 'chat',
+      'river.method.kind': 'stream',
+      'river.rpc.kind': 'stream',
+      'river.rpc.streaming': true,
+      'river.streamId': 'server-stream-id',
+      'span.kind': 'server',
+    });
   });
 });
 


### PR DESCRIPTION
## Why

River spans already identify procedure type through `river.method.kind`, but the attribute is easy to miss when building Datadog queries and does not include standard RPC semantic fields. Adding explicit RPC classification attributes makes it easier to distinguish unary calls from subscriptions and streams in trace analysis and span-based metrics.

## What changed

- Added shared procedure span attributes for both client and server River spans.
- Preserved the existing `river.method.*` attributes for compatibility.
- Added `rpc.system`, `rpc.service`, and `rpc.method` semantic attributes.
- Added `river.rpc.kind` with the River procedure kind: `rpc`, `upload`, `subscription`, or `stream`.
- Added `river.rpc.streaming` so callers can filter streaming procedures with one low-cardinality boolean.
- Covered client and server span attributes in tracing tests.

## Test plan

Verified by CI (no reviewer action needed):
- `npm run test:single -- tracing/tracing.test.ts` passes locally and validates the emitted client/server span attributes.

For the reviewer to verify:
- [ ] Confirm the new attribute names work for Datadog span queries and future span-based metrics.

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

## Revertibility

Safe to revert. This only adds span attributes and a test; it does not change protocol behavior or public TypeScript APIs.

~ written by Zerg :space_invader: ([mutated-zealot-0503](https://zerg.zergrush.dev/chat?id=mutated-zealot-0503))