### PR TITLE
Handle fatal connection attempt errors

### DIFF
--- a/__tests__/negative.test.ts
+++ b/__tests__/negative.test.ts
@@ -107,6 +107,46 @@ describe('should handle incompatabilities', async () => {
     });
   });
 
+  test('fatal connection attempt error should prevent reconnection', async () => {
+    class FatalConnectionError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = 'FatalConnectionError';
+      }
+    }
+
+    const createClientSpy = vi.fn(() =>
+      Promise.reject(new FatalConnectionError('fake fatal connection failure')),
+    );
+    const clientTransport = new WebSocketClientTransport(
+      createClientSpy,
+      'client',
+      {
+        isFatalConnectionError: (err) => err instanceof FatalConnectionError,
+      },
+    );
+    const serverTransport = new WebSocketServerTransport(wss, 'SERVER');
+    const errMock = vi.fn();
+    clientTransport.addEventListener('protocolError', errMock);
+    addPostTestCleanup(async () => {
+      clientTransport.removeEventListener('protocolError', errMock);
+      await cleanupTransports([clientTransport, serverTransport]);
+    });
+
+    clientTransport.connect(serverTransport.clientId);
+    await vi.runAllTimersAsync();
+
+    expect(clientTransport.reconnectOnConnectionDrop).toBe(false);
+    expect(clientTransport.sessions.size).toBe(0);
+    expect(createClientSpy).toHaveBeenCalledTimes(1);
+    expect(errMock).not.toHaveBeenCalled();
+
+    await testFinishesCleanly({
+      clientTransports: [clientTransport],
+      serverTransport,
+    });
+  });
+
   test('calling connect consecutively should reuse the same connection', async () => {
     let connectCalls = 0;
     const clientTransport = new WebSocketClientTransport(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.217.2",
+  "version": "0.219.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.217.2",
+      "version": "0.219.0",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.218.0",
+  "version": "0.219.0",
   "type": "module",
   "exports": {
     ".": "./dist/router/index.js",

--- a/transport/client.ts
+++ b/transport/client.ts
@@ -238,8 +238,19 @@ export abstract class ClientTransport<
   }
 
   // listeners
-  protected onConnectingFailed(session: SessionConnecting<ConnType>) {
+  protected onConnectingFailed(
+    session: SessionConnecting<ConnType>,
+    error?: unknown,
+  ) {
     const noConnectionSession = super.onConnectingFailed(session);
+
+    if (error instanceof Error && this.options.isFatalConnectionError(error)) {
+      this.reconnectOnConnectionDrop = false;
+      this.deleteSession(noConnectionSession, { unhealthy: true });
+
+      return noConnectionSession;
+    }
+
     this.tryReconnecting(noConnectionSession.to);
 
     return noConnectionSession;
@@ -613,7 +624,7 @@ export abstract class ClientTransport<
               `error connecting to ${connectingSession.to}: ${errStr}`,
               connectingSession.loggingMetadata,
             );
-            this.onConnectingFailed(connectingSession);
+            this.onConnectingFailed(connectingSession, error);
           },
           onConnectionTimeout: () => {
             this.log?.error(


### PR DESCRIPTION
## Why

River exposes `isFatalConnectionError` so callers can stop retrying connection failures that are permanent. That hook was only honored after a connection had been established, so fatal failures during the initial connection attempt still retried until the retry budget or session grace behavior kicked in.

This is needed for pid2 auth failures where the target repl is gone: callers can classify that as fatal and avoid the noisy retry loop.

## What changed

- Honor `isFatalConnectionError` in the initial `onConnectionFailed` path.
- Disable reconnects and delete the unhealthy pending session when the initial connection error is fatal.
- Add a regression test covering fatal initial connection failures.
- Bump `@replit/river` to `0.219.0`.

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

## Test plan

- `direnv exec . npm run check`
- `direnv exec . npm exec -- vitest run`
