### PR TITLE
Set up npm trusted publishing

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,31 +2,38 @@ name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 categories:
   - title: '🚀 Features'
-    labels:
-      - 'feature'
-      - 'enhancement'
+    when:
+      labels:
+        - 'feature'
+        - 'enhancement'
   - title: '🐛 Bug Fixes'
-    labels:
-      - 'fix'
-      - 'bugfix'
-      - 'bug'
+    when:
+      labels:
+        - 'fix'
+        - 'bugfix'
+        - 'bug'
   - title: '🧰 Maintenance'
-    label: 'chore'
+    when:
+      label: 'chore'
   - title: '🤖 Dependencies'
-    label: 'dependencies'
+    when:
+      label: 'dependencies'
+  - type: 'version-resolver'
+    semver-increment: 'major'
+    when:
+      label: 'major'
+  - type: 'version-resolver'
+    semver-increment: 'minor'
+    when:
+      label: 'minor'
+  - type: 'version-resolver'
+    semver-increment: 'patch'
+    when:
+      label: 'patch'
+  - type: 'version-resolver'
+    semver-increment: 'patch'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-version-resolver:
-  major:
-    labels:
-      - 'major'
-  minor:
-    labels:
-      - 'minor'
-  patch:
-    labels:
-      - 'patch'
-  default: patch
 template: |
   ## Changes
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,24 +5,27 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    environment: npm
     steps:
       - name: Checkout code
-        # This checks out the code at the specific tag that triggered the workflow
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://registry.npmjs.org/'
+          package-manager-cache: false
 
-      - name: Install dependencies and build
+      - name: Install dependencies
         run: npm ci
 
       - name: Publish to npm
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_AUTH_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,13 +3,8 @@ name: Release Drafter
 on:
   workflow_dispatch: {}
   push:
-    # branches to consider in the event; optional, defaults to all
     branches:
       - main
-  # pull_request event is required only for autolabeler
-  pull_request:
-    # Only following types are handled by the action, but one can default to all as well
-    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read
@@ -17,14 +12,8 @@ permissions:
 jobs:
   update_release_draft:
     permissions:
-      # write permission is required to create a github release
       contents: write
-      # write permission is required for autolabeler
-      # otherwise, read permission is required at least
-      pull-requests: write
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: release-drafter/release-drafter@v7

--- a/README.md
+++ b/README.md
@@ -810,16 +810,7 @@ You can find more service examples in the [E2E test fixtures](https://github.com
 
 ## Releasing
 
-River uses [Release Drafter](https://github.com/release-drafter/release-drafter) for GitHub release notes and npm trusted publishing for NPM publishing.
-
-The npm package should have a trusted publisher configured with these values:
-
-- Publisher: GitHub Actions
-- Organization or user: `replit`
-- Repository: `river`
-- Workflow filename: `publish.yml`
-- Environment name: `npm`
-- Allowed actions: `npm publish`
+River uses [Release Drafter](https://github.com/release-drafter/release-drafter) for GitHub release notes and a GitHub Actions workflow for NPM publishing.
 
 ### Automated Release Process (Recommended)
 
@@ -847,7 +838,7 @@ The npm package should have a trusted publisher configured with these values:
 4. **Automation takes over**:
 
    - Publishing the release automatically triggers the "Build and Publish" workflow
-   - The workflow runs in the `npm` GitHub environment and publishes `@replit/river` to NPM without a long-lived npm token
+   - The workflow publishes `@replit/river` to NPM
 
 5. **If publishing fails**:
    - Fix the workflow or package issue, then re-run the failed GitHub Actions job

--- a/README.md
+++ b/README.md
@@ -806,11 +806,20 @@ You can find more service examples in the [E2E test fixtures](https://github.com
 - `npm run check` -- lint
 - `npm run format` -- format
 - `npm run test` -- run tests
-- `npm run release` -- cut a new release (should bump version in package.json first)
+- `npm run build` -- build the package
 
 ## Releasing
 
-River uses an automated release process with [Release Drafter](https://github.com/release-drafter/release-drafter) for version management and NPM publishing.
+River uses [Release Drafter](https://github.com/release-drafter/release-drafter) for GitHub release notes and npm trusted publishing for NPM publishing.
+
+The npm package should have a trusted publisher configured with these values:
+
+- Publisher: GitHub Actions
+- Organization or user: `replit`
+- Repository: `river`
+- Workflow filename: `publish.yml`
+- Environment name: `npm`
+- Allowed actions: `npm publish`
 
 ### Automated Release Process (Recommended)
 
@@ -821,7 +830,7 @@ River uses an automated release process with [Release Drafter](https://github.co
 
 2. **When ready to release, create a version bump PR**:
 
-   - Create a PR that bumps the version in `package.json` and `package-lock.json`. You can run `pnpm version --no-git-tag-version <version>` to bump the version.
+   - Create a PR that bumps the version in `package.json` and `package-lock.json`. You can run `npm version --no-git-tag-version <version>` to bump the version.
    - Use semantic versioning:
      - `patch` - Bug fixes, small improvements (e.g., 0.208.4 → 0.208.5)
      - `minor` - New features, backwards compatible (e.g., 0.208.4 → 0.209.0)
@@ -838,7 +847,8 @@ River uses an automated release process with [Release Drafter](https://github.co
 4. **Automation takes over**:
 
    - Publishing the release automatically triggers the "Build and Publish" workflow
-   - The `river` package is published to NPM
+   - The workflow runs in the `npm` GitHub environment and publishes `@replit/river` to NPM without a long-lived npm token
 
-5. **Manual npm release**:
-   - If the auto-publish workflow failed, you can run `npm run release` locally
+5. **If publishing fails**:
+   - Fix the workflow or package issue, then re-run the failed GitHub Actions job
+   - Local `npm run release` is only a break-glass fallback for maintainers with npm publish access

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
   "version": "0.219.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/replit/river.git"
+  },
   "type": "module",
   "exports": {
     ".": "./dist/router/index.js",


### PR DESCRIPTION
## Summary
- configure npm publish workflow for trusted publishing via GitHub Actions OIDC
- add repository metadata required for npm package provenance/trusted publishing
- update Release Drafter workflow/config to v7 syntax
- refresh README release instructions without exposing trusted publisher setup details

## Testing
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts f }' .github/workflows/publish.yml .github/workflows/release-drafter.yml .github/release-drafter.yml
- nix shell nixpkgs#actionlint --command actionlint
- nix develop . --command npm pkg get name repository
- git diff --check