### PR TITLE
Backport fatal connection attempt handling to 0.216.x

### DIFF
--- a/__tests__/negative.test.ts
+++ b/__tests__/negative.test.ts
@@ -107,6 +107,46 @@ describe('should handle incompatabilities', async () => {
     });
   });
 
+  test('fatal connection attempt error should prevent reconnection', async () => {
+    class FatalConnectionError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = 'FatalConnectionError';
+      }
+    }
+
+    const createClientSpy = vi.fn(() =>
+      Promise.reject(new FatalConnectionError('fake fatal connection failure')),
+    );
+    const clientTransport = new WebSocketClientTransport(
+      createClientSpy,
+      'client',
+      {
+        isFatalConnectionError: (err) => err instanceof FatalConnectionError,
+      },
+    );
+    const serverTransport = new WebSocketServerTransport(wss, 'SERVER');
+    const errMock = vi.fn();
+    clientTransport.addEventListener('protocolError', errMock);
+    addPostTestCleanup(async () => {
+      clientTransport.removeEventListener('protocolError', errMock);
+      await cleanupTransports([clientTransport, serverTransport]);
+    });
+
+    clientTransport.connect(serverTransport.clientId);
+    await vi.runAllTimersAsync();
+
+    expect(clientTransport.reconnectOnConnectionDrop).toBe(false);
+    expect(clientTransport.sessions.size).toBe(0);
+    expect(createClientSpy).toHaveBeenCalledTimes(1);
+    expect(errMock).not.toHaveBeenCalled();
+
+    await testFinishesCleanly({
+      clientTransports: [clientTransport],
+      serverTransport,
+    });
+  });
+
   test('calling connect consecutively should reuse the same connection', async () => {
     let connectCalls = 0;
     const clientTransport = new WebSocketClientTransport(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.216.2",
+  "version": "0.216.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.216.2",
+      "version": "0.216.3",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.216.2",
+  "version": "0.216.3",
   "type": "module",
   "exports": {
     ".": {

--- a/transport/client.ts
+++ b/transport/client.ts
@@ -132,8 +132,19 @@ export abstract class ClientTransport<
   }
 
   // listeners
-  protected onConnectingFailed(session: SessionConnecting<ConnType>) {
+  protected onConnectingFailed(
+    session: SessionConnecting<ConnType>,
+    error?: unknown,
+  ) {
     const noConnectionSession = super.onConnectingFailed(session);
+
+    if (error instanceof Error && this.options.isFatalConnectionError(error)) {
+      this.reconnectOnConnectionDrop = false;
+      this.deleteSession(noConnectionSession, { unhealthy: true });
+
+      return noConnectionSession;
+    }
+
     this.tryReconnecting(noConnectionSession.to);
 
     return noConnectionSession;
@@ -494,7 +505,7 @@ export abstract class ClientTransport<
               `error connecting to ${connectingSession.to}: ${errStr}`,
               connectingSession.loggingMetadata,
             );
-            this.onConnectingFailed(connectingSession);
+            this.onConnectingFailed(connectingSession, error);
           },
           onConnectionTimeout: () => {
             this.log?.error(


### PR DESCRIPTION
## Why
`@replit/river@0.219.0` includes the fatal connection-attempt fix, but repl-it-web cannot consume it yet because pid2 still uses the 0.216.x River/@sinclair/typebox service type surface. This backports the same retry decision behavior to the 0.216.x maintenance branch.

## What changed
- Pass the initial connection failure error into `onConnectingFailed`.
- Let `onConnectingFailed` delete the no-connection session and stop reconnecting when `isFatalConnectionError` returns true.
- Bump package metadata to `0.216.3`.
- Add a regression test for fatal initial connection attempts.

## Test plan
- `direnv exec . npm exec -- vitest run __tests__/negative.test.ts`
- `direnv exec . npm run check`
- `direnv exec . npm exec -- vitest run`