### PR TITLE
Replace per-message heartbeat timeout with a watchdog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.220.0",
+  "version": "0.220.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.220.0",
+      "version": "0.220.1",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.220.0",
+  "version": "0.220.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/replit/river.git"

--- a/transport/sessionStateMachine/SessionConnected.ts
+++ b/transport/sessionStateMachine/SessionConnected.ts
@@ -55,7 +55,8 @@ export class SessionConnected<
   listeners: SessionConnectedListeners;
 
   private heartbeatHandle?: ReturnType<typeof setInterval> | undefined;
-  private heartbeatMissTimeout?: ReturnType<typeof setTimeout> | undefined;
+  private heartbeatWatchdog?: ReturnType<typeof setInterval> | undefined;
+  private lastInboundAt = Date.now();
   private isActivelyHeartbeating = false;
   private rehandshakeTimer?: ReturnType<typeof setTimeout> | undefined;
   private credentialExpiry?: number | undefined;
@@ -63,16 +64,11 @@ export class SessionConnected<
   updateBookkeeping(ack: number, seq: number) {
     this.sendBuffer = this.sendBuffer.filter((unacked) => unacked.seq >= ack);
     this.ack = seq + 1;
+    this.lastInboundAt = Date.now();
 
     if (this.sendBuffer.length < this.options.sendBufferHighWaterMark) {
       this.notifySendBufferDrain();
     }
-
-    if (this.heartbeatMissTimeout) {
-      clearTimeout(this.heartbeatMissTimeout);
-    }
-
-    this.startMissingHeartbeatTimeout();
   }
 
   private assertSendOrdering(encodedMsg: EncodedTransportMessage) {
@@ -163,10 +159,26 @@ export class SessionConnected<
     };
   }
 
-  startMissingHeartbeatTimeout() {
+  /**
+   * Arms the watchdog that closes the connection once the peer stops sending.
+   *
+   * A single interval for the lifetime of the session compares wall time against
+   * the last inbound message, so a busy session does not allocate a timer per
+   * frame. Elapsed time comes from {@link Date.now}, thus a throttled or suspended
+   * timer can only delay detection of a dead connection, never report a heartbeat
+   * as missed while messages keep arriving.
+   */
+  startHeartbeatWatchdog() {
     const maxMisses = this.options.heartbeatsUntilDead;
     const missDuration = maxMisses * this.options.heartbeatIntervalMs;
-    this.heartbeatMissTimeout = setTimeout(() => {
+    this.heartbeatWatchdog = setInterval(() => {
+      if (Date.now() - this.lastInboundAt < missDuration) {
+        return;
+      }
+
+      // the peer is gone, so nothing will refresh the deadline: stop checking
+      this.clearHeartbeatWatchdog();
+
       this.log?.info(
         `closing connection to ${this.to} due to inactivity (missed ${maxMisses} heartbeats which is ${missDuration}ms)`,
         this.loggingMetadata,
@@ -176,7 +188,14 @@ export class SessionConnected<
       );
 
       this.conn.close();
-    }, missDuration);
+    }, this.options.heartbeatIntervalMs);
+  }
+
+  private clearHeartbeatWatchdog() {
+    if (this.heartbeatWatchdog) {
+      clearInterval(this.heartbeatWatchdog);
+      this.heartbeatWatchdog = undefined;
+    }
   }
 
   startActiveHeartbeat() {
@@ -369,11 +388,7 @@ export class SessionConnected<
       this.heartbeatHandle = undefined;
     }
 
-    if (this.heartbeatMissTimeout) {
-      clearTimeout(this.heartbeatMissTimeout);
-      this.heartbeatMissTimeout = undefined;
-    }
-
+    this.clearHeartbeatWatchdog();
     this.clearRehandshakeTimer();
   }
 

--- a/transport/sessionStateMachine/stateMachine.test.ts
+++ b/transport/sessionStateMachine/stateMachine.test.ts
@@ -2046,6 +2046,52 @@ describe('session state machine', () => {
       });
     });
 
+    test('closes the connection once nothing arrives before the deadline', async () => {
+      const sessionHandle = await createSessionConnected();
+      const missDuration =
+        testingSessionOptions.heartbeatsUntilDead *
+        testingSessionOptions.heartbeatIntervalMs;
+
+      await vi.advanceTimersByTimeAsync(missDuration - 1);
+      expect(sessionHandle.onConnectionClosed).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(
+        testingSessionOptions.heartbeatIntervalMs,
+      );
+      expect(sessionHandle.onConnectionClosed).toHaveBeenCalledTimes(1);
+    });
+
+    test('inbound messages keep the connection past the deadline', async () => {
+      const sessionHandle = await createSessionConnected();
+      const session = sessionHandle.session;
+
+      // stay quiet for just under the deadline between each message, so the
+      // session only survives if every message pushes the deadline out
+      const missDuration =
+        testingSessionOptions.heartbeatsUntilDead *
+        testingSessionOptions.heartbeatIntervalMs;
+      for (let seq = 0; seq < 5; seq++) {
+        session.conn.onData(
+          session.options.codec.toBuffer({
+            id: `msgid-${seq}`,
+            to: session.from,
+            from: session.to,
+            seq,
+            ack: 0,
+            streamId: 'heartbeat',
+            controlFlags: ControlFlags.AckBit,
+            payload: {
+              type: 'ACK',
+            } satisfies Static<typeof ControlMessageAckSchema>,
+          }),
+        );
+
+        await vi.advanceTimersByTimeAsync(missDuration - 1);
+      }
+
+      expect(sessionHandle.onConnectionClosed).not.toHaveBeenCalled();
+    });
+
     test('does not dispatch acks', async () => {
       const sessionHandle = await createSessionConnected();
       const session = sessionHandle.session;

--- a/transport/sessionStateMachine/stateMachine.test.ts
+++ b/transport/sessionStateMachine/stateMachine.test.ts
@@ -3,7 +3,11 @@ import {
   payloadToTransportMessage,
   testingSessionOptions,
 } from '../../testUtil';
-import { waitFor } from '../../testUtil/fixtures/cleanup';
+import {
+  advanceFakeTimersByDisconnectGrace,
+  advanceFakeTimersByHeartbeat,
+  waitFor,
+} from '../../testUtil/fixtures/cleanup';
 import {
   ControlFlags,
   ControlMessageAckSchema,
@@ -2048,16 +2052,15 @@ describe('session state machine', () => {
 
     test('closes the connection once nothing arrives before the deadline', async () => {
       const sessionHandle = await createSessionConnected();
-      const missDuration =
-        testingSessionOptions.heartbeatsUntilDead *
-        testingSessionOptions.heartbeatIntervalMs;
 
-      await vi.advanceTimersByTimeAsync(missDuration - 1);
+      // a heartbeat of silence is still well inside the deadline
+      await advanceFakeTimersByHeartbeat();
       expect(sessionHandle.onConnectionClosed).not.toHaveBeenCalled();
 
-      await vi.advanceTimersByTimeAsync(
-        testingSessionOptions.heartbeatIntervalMs,
-      );
+      await advanceFakeTimersByDisconnectGrace();
+
+      // the watchdog stops itself once it fires, so the peer is only declared
+      // dead once rather than on every subsequent check
       expect(sessionHandle.onConnectionClosed).toHaveBeenCalledTimes(1);
     });
 
@@ -2065,11 +2068,8 @@ describe('session state machine', () => {
       const sessionHandle = await createSessionConnected();
       const session = sessionHandle.session;
 
-      // stay quiet for just under the deadline between each message, so the
-      // session only survives if every message pushes the deadline out
-      const missDuration =
-        testingSessionOptions.heartbeatsUntilDead *
-        testingSessionOptions.heartbeatIntervalMs;
+      // a message every heartbeat for well past the deadline: the session only
+      // survives if each one pushes the deadline out
       for (let seq = 0; seq < 5; seq++) {
         session.conn.onData(
           session.options.codec.toBuffer({
@@ -2086,7 +2086,7 @@ describe('session state machine', () => {
           }),
         );
 
-        await vi.advanceTimersByTimeAsync(missDuration - 1);
+        await advanceFakeTimersByHeartbeat();
       }
 
       expect(sessionHandle.onConnectionClosed).not.toHaveBeenCalled();

--- a/transport/sessionStateMachine/transitions.ts
+++ b/transport/sessionStateMachine/transitions.ts
@@ -234,7 +234,7 @@ export const SessionStateGraph = {
         ...carriedState,
       });
 
-      session.startMissingHeartbeatTimeout();
+      session.startHeartbeatWatchdog();
 
       session.log?.info(
         `session ${session.id} transition from Handshaking to Connected`,
@@ -293,7 +293,7 @@ export const SessionStateGraph = {
         ...carriedState,
       });
 
-      session.startMissingHeartbeatTimeout();
+      session.startHeartbeatWatchdog();
 
       conn.telemetry = createConnectionTelemetryInfo(
         session.tracer,


### PR DESCRIPTION
## Why

`SessionConnected` tracked its inactivity deadline by clearing and re-arming a `setTimeout` on every valid inbound frame, inside `updateBookkeeping()`. That means a timer and a closure allocated per message. On high-throughput browser sessions this is significant allocation churn, and each cleared timer becomes garbage whose callback captures `this`, briefly retaining the session graph. Browser profiling on a downstream consumer attributed hundreds of megabytes to this path.

Note that even an idle session churns here, since heartbeat traffic alone re-arms the timeout every `heartbeatIntervalMs`.

The per-message timeout dates to #302, which moved away from an interval plus a miss counter because browser background throttling made counting interval executions unreliable. This keeps that fix while dropping the allocation.

## What changed

The session now records a `lastInboundAt` timestamp on each inbound frame and runs a single interval for its lifetime that closes the connection once `Date.now() - lastInboundAt` passes the deadline. Inbound messages no longer allocate any timer. Detection stays correct under browser throttling because it compares actual elapsed wall time instead of counting interval executions, so a delayed or suspended timer can only postpone noticing a dead connection, never invent a missed heartbeat.

Reviewer pointers:

- `startMissingHeartbeatTimeout()` is renamed to `startHeartbeatWatchdog()`, since it no longer arms a timeout. Both call sites are in `transitions.ts`. Teardown moved to a private `clearHeartbeatWatchdog()`, mirroring the existing `clearRehandshakeTimer()`, and is still called from `_handleStateExit()`.
- The watchdog clears itself before calling `conn.close()`. An interval would otherwise keep ticking and re-closing while the connection's close event propagates asynchronously; the old timeout fired exactly once, and this preserves that.

### One behavioral difference

Detection is now quantized to the check interval. A dead connection is noticed between `deadlineMs` and `deadlineMs + heartbeatIntervalMs` after the last frame, rather than exactly at `deadlineMs`. With the defaults (1s interval, 2 heartbeats until dead) that is 2s to 3s instead of exactly 2s. This is inherent to polling, and erring late is the safe direction.

If the extra timer per session is ever a concern at high session counts, the natural follow-up is one transport-level watchdog scanning every session's `lastInboundAt`. That was deliberately left out here to keep the change small.

## Testing

The `heartbeats` describe block had no coverage of the death path itself, so this adds two tests: the connection closes after silence, and a message arriving just under the deadline keeps pushing the deadline out. I confirmed both are meaningful by removing the `lastInboundAt` update and watching them fail.

Full suite passes (770 passed, 1 skipped), and `npm run check` is clean. Since this changes timing behavior, I also ran the four timing-sensitive suites (`disconnects`, `transport`, `stateMachine`, `cleanup`) 12 times consecutively with no flakes.

The second commit fixes the two new tests, which failed on the Ubuntu runner in the first push. They originally asserted the session was still alive 1ms before the deadline. The suite runs with `shouldAdvanceTime`, so the fake clock also moves with real time, and on a contended runner that 1ms margin was crossed and the watchdog fired before the assertion. They now use the existing `advanceFakeTimersByHeartbeat` and `advanceFakeTimersByDisconnectGrace` helpers, which leave a full heartbeat interval of slack on either side of the deadline, matching how the rest of the suite handles heartbeat timing. This was purely a test bug; production behavior is unchanged, and both tests still fail if an inbound message stops refreshing the timestamp.

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

No wire format change, so a client on either version interoperates with a server on the other. Bumped to 0.220.1.

Worth a second opinion on the API checkbox: `SessionConnected` is exported as a type from `./transport`, so the `startMissingHeartbeatTimeout()` rename is technically visible to anyone who typed against it and called that method. Nothing outside the state machine has any reason to call it, so I left the box unchecked, but say the word and I will restore the old name or keep it as an alias.
