### PR TITLE
[AGI-1740] Explore application-typed handshake rejection codes

### DIFF
--- a/__tests__/properties/session.property.test.ts
+++ b/__tests__/properties/session.property.test.ts
@@ -15,6 +15,9 @@ import {
 } from '../../router/handshake';
 import { createClient } from '../../router/client';
 import { createServer } from '../../router/server';
+import type { ClientTransport } from '../../transport/client';
+import type { Connection } from '../../transport/connection';
+import type { ServerTransport } from '../../transport/server';
 import { closeAllConnections, numberOfConnections } from '../../testUtil';
 import { createMockTransportNetwork } from '../../testUtil/fixtures/mockTransport';
 import type { TestTransportOptions } from '../../testUtil/fixtures/transports';
@@ -152,12 +155,8 @@ const multiplexedSchedules: gs.Generator<MultiplexedSchedule> = gs.composite(
 
 function setup(opts?: TestTransportOptions): {
   network: ReturnType<typeof createMockTransportNetwork>;
-  clientTransport: ReturnType<
-    ReturnType<typeof createMockTransportNetwork>['getClientTransport']
-  >;
-  serverTransport: ReturnType<
-    ReturnType<typeof createMockTransportNetwork>['getServerTransport']
-  >;
+  clientTransport: ClientTransport<Connection>;
+  serverTransport: ServerTransport<Connection>;
   client: ReturnType<typeof createClient<typeof services>>;
   violations: Array<string>;
 } {
@@ -536,11 +535,8 @@ describe('re-handshake under faults', () => {
     throw new Error(`timed out waiting for ${what}`);
   }
 
-  const isConnected = (
-    transport: ReturnType<
-      ReturnType<typeof createMockTransportNetwork>['getClientTransport']
-    >,
-  ) => numberOfConnections(transport) === 1;
+  const isConnected = (transport: ClientTransport<Connection>) =>
+    numberOfConnections(transport) === 1;
 
   const handshakeSchema = Type.Object({ token: Type.String() });
 

--- a/__tests__/protobuf.test.ts
+++ b/__tests__/protobuf.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument */
 import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { Type } from 'typebox';
 import { BinaryCodec, NaiveJsonCodec } from '../codec';
 import {
   type ClientError,
@@ -298,25 +299,29 @@ describe.each(protobufRouterMatrix)(
     });
 
     test('protobuf handshake metadata is decoded through the router helpers', async () => {
+      const rejectionCodeSchema = Type.Union([Type.Literal('TOKEN_EXPIRED')]);
       const clientHandshakeOptions = createClientHandshakeOptions(
         AuthHandshakeSchema,
         () => ({ token: 'let-me-in' }),
+        undefined,
+        rejectionCodeSchema,
       );
       const serverHandshakeOptions = createServerHandshakeOptions(
         AuthHandshakeSchema,
         (metadata) => ({
           token: metadata.token,
         }),
+        undefined,
+        rejectionCodeSchema,
       );
 
-      const clientTransport = getClientTransport(
-        'client',
-        clientHandshakeOptions,
-      );
-      const serverTransport = getServerTransport(
-        'SERVER',
-        serverHandshakeOptions,
-      );
+      const clientTransport =
+        getClientTransport<typeof rejectionCodeSchema>('client');
+      const serverTransport = getServerTransport<
+        (typeof serverHandshakeOptions)['schema'],
+        { token: string },
+        typeof rejectionCodeSchema
+      >('SERVER', undefined);
       const TypedProtoService = createProtoService<object, { token: string }>();
       const testSvc = TypedProtoService.define(TestService, {
         echo: (request, ctx) =>
@@ -335,6 +340,7 @@ describe.each(protobufRouterMatrix)(
         TestService,
         clientTransport,
         serverTransport.clientId,
+        { handshakeOptions: clientHandshakeOptions },
       );
 
       await expect(client.echo({ text: 'hello' })).resolves.toMatchObject({

--- a/protobuf/client.ts
+++ b/protobuf/client.ts
@@ -6,6 +6,7 @@ import type {
   MessageInitShape,
   MessageShape,
 } from '@bufbuild/protobuf';
+import type { TSchema } from 'typebox';
 import { Value } from 'typebox/value';
 import { ClientTransport } from '../transport/client';
 import { Connection } from '../transport/connection';
@@ -13,6 +14,7 @@ import { EventMap } from '../transport/events';
 import {
   ControlFlags,
   ControlMessageCloseSchema,
+  type CustomHandshakeErrorCodeSchema,
   OpaqueTransportMessage,
   TransportClientId,
   cancelMessage,
@@ -75,13 +77,16 @@ interface StartedMethodCall<
 /**
  * Creates a protobuf client for a single protobuf service descriptor.
  */
-export function createClient<Service extends DescService>(
+export function createClient<
+  Service extends DescService,
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema = never,
+>(
   service: Service,
-  transport: ClientTransport<Connection>,
+  transport: ClientTransport<Connection, RejectionCodeSchema>,
   serverId: TransportClientId,
   providedClientOptions: Partial<
     ClientOptions & {
-      handshakeOptions: ClientHandshakeOptions;
+      handshakeOptions: ClientHandshakeOptions<TSchema, RejectionCodeSchema>;
     }
   > = {},
 ): ProtobufClient<Service> {
@@ -111,10 +116,13 @@ export function createClient<Service extends DescService>(
   return client as ProtobufClient<Service>;
 }
 
-function createMethodCaller<Method extends DescMethod>(
+function createMethodCaller<
+  Method extends DescMethod,
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema,
+>(
   service: DescService,
   method: Method,
-  transport: ClientTransport<Connection>,
+  transport: ClientTransport<Connection, RejectionCodeSchema>,
   serverId: TransportClientId,
   clientOptions: ClientOptions,
 ): ClientMethod<Method> {
@@ -235,9 +243,11 @@ function createMethodCaller<Method extends DescMethod>(
   }
 }
 
-function connectOnInvokeIfNeeded(
+function connectOnInvokeIfNeeded<
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema,
+>(
   clientOptions: ClientOptions,
-  transport: ClientTransport<Connection>,
+  transport: ClientTransport<Connection, RejectionCodeSchema>,
   serverId: TransportClientId,
 ) {
   if (clientOptions.connectOnInvoke && !transport.sessions.has(serverId)) {
@@ -245,10 +255,13 @@ function connectOnInvokeIfNeeded(
   }
 }
 
-function startMethodCall<Method extends DescMethod>(
+function startMethodCall<
+  Method extends DescMethod,
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema,
+>(
   service: DescService,
   method: Method,
-  transport: ClientTransport<Connection>,
+  transport: ClientTransport<Connection, RejectionCodeSchema>,
   serverId: TransportClientId,
   initialPayload: Uint8Array,
   procClosesWithInit: boolean,

--- a/protobuf/handshake.ts
+++ b/protobuf/handshake.ts
@@ -27,23 +27,34 @@ type ConstructHandshake<Schema extends DescMessage> = () =>
   | MessageInitShape<Schema>
   | Promise<MessageInitShape<Schema>>;
 
-type ValidateHandshake<Schema extends DescMessage, ParsedMetadata> = (
+type ValidateHandshake<
+  Schema extends DescMessage,
+  ParsedMetadata,
+  ApplicationErrorCode extends string = never,
+> = (
   metadata: MessageShape<Schema>,
   previousParsedMetadata?: ParsedMetadata,
   from?: TransportClientId,
 ) =>
   | ParsedMetadata
   | ProtobufHandshakeFailureCode
-  | Promise<ParsedMetadata | ProtobufHandshakeFailureCode>;
+  | ApplicationErrorCode
+  | Promise<
+      ParsedMetadata | ProtobufHandshakeFailureCode | ApplicationErrorCode
+    >;
 
 /**
  * Create client-side handshake options backed by a protobuf message type.
  */
-export function createClientHandshakeOptions<Schema extends DescMessage>(
+export function createClientHandshakeOptions<
+  Schema extends DescMessage,
+  ApplicationErrorCode extends string = never,
+>(
   schema: Schema,
   construct: ConstructHandshake<Schema>,
   eager?: boolean,
-): ClientHandshakeOptions<typeof HandshakeBytesSchema> {
+  rejectionCodes?: ReadonlyArray<ApplicationErrorCode>,
+): ClientHandshakeOptions<typeof HandshakeBytesSchema, ApplicationErrorCode> {
   return createTransportClientHandshakeOptions(
     HandshakeBytesSchema,
     async () => {
@@ -52,6 +63,7 @@ export function createClientHandshakeOptions<Schema extends DescMessage>(
       return encodeMessageBytes(schema, metadata);
     },
     eager,
+    rejectionCodes,
   );
 }
 
@@ -61,11 +73,17 @@ export function createClientHandshakeOptions<Schema extends DescMessage>(
 export function createServerHandshakeOptions<
   Schema extends DescMessage,
   ParsedMetadata extends object = object,
+  ApplicationErrorCode extends string = never,
 >(
   schema: Schema,
-  validate: ValidateHandshake<Schema, ParsedMetadata>,
+  validate: ValidateHandshake<Schema, ParsedMetadata, ApplicationErrorCode>,
   expiry?: (parsedMetadata: ParsedMetadata) => Date | undefined,
-): ServerHandshakeOptions<typeof HandshakeBytesSchema, ParsedMetadata> {
+  rejectionCodes?: ReadonlyArray<ApplicationErrorCode>,
+): ServerHandshakeOptions<
+  typeof HandshakeBytesSchema,
+  ParsedMetadata,
+  ApplicationErrorCode
+> {
   return createTransportServerHandshakeOptions(
     HandshakeBytesSchema,
     async (metadata, previousParsedMetadata, from) => {
@@ -79,5 +97,6 @@ export function createServerHandshakeOptions<
       return await validate(decoded, previousParsedMetadata, from);
     },
     expiry,
+    rejectionCodes,
   );
 }

--- a/protobuf/handshake.ts
+++ b/protobuf/handshake.ts
@@ -76,7 +76,11 @@ export function createServerHandshakeOptions<
   ApplicationErrorCode extends string = never,
 >(
   schema: Schema,
-  validate: ValidateHandshake<Schema, ParsedMetadata, ApplicationErrorCode>,
+  validate: ValidateHandshake<
+    Schema,
+    ParsedMetadata,
+    NoInfer<ApplicationErrorCode>
+  >,
   expiry?: (parsedMetadata: ParsedMetadata) => Date | undefined,
   rejectionCodes?: ReadonlyArray<ApplicationErrorCode>,
 ): ServerHandshakeOptions<

--- a/protobuf/handshake.ts
+++ b/protobuf/handshake.ts
@@ -11,9 +11,9 @@ import {
   type ServerHandshakeOptions,
 } from '../router/handshake';
 import {
+  type ApplicationErrorCode,
+  type ApplicationErrorCodeSchemas,
   HandshakeErrorCustomHandlerFatalResponseCodes,
-  type LiteralErrorCode,
-  type LiteralErrorCodeSchemas,
   type TransportClientId,
 } from '../transport/message';
 import { decodeMessageBytes, encodeMessageBytes } from './shared';
@@ -32,7 +32,7 @@ type ConstructHandshake<Schema extends DescMessage> = () =>
 type ValidateHandshake<
   Schema extends DescMessage,
   ParsedMetadata,
-  ApplicationErrorCode extends string = never,
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
 > = (
   metadata: MessageShape<Schema>,
   previousParsedMetadata?: ParsedMetadata,
@@ -40,11 +40,11 @@ type ValidateHandshake<
 ) =>
   | ParsedMetadata
   | ProtobufHandshakeFailureCode
-  | LiteralErrorCode<ApplicationErrorCode>
+  | ApplicationErrorCode<RejectionCodeSchemas>
   | Promise<
       | ParsedMetadata
       | ProtobufHandshakeFailureCode
-      | LiteralErrorCode<ApplicationErrorCode>
+      | ApplicationErrorCode<RejectionCodeSchemas>
     >;
 
 /**
@@ -52,13 +52,13 @@ type ValidateHandshake<
  */
 export function createClientHandshakeOptions<
   Schema extends DescMessage,
-  const ApplicationErrorCode extends string = never,
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
 >(
   schema: Schema,
   construct: ConstructHandshake<Schema>,
   eager?: boolean,
-  rejectionCodeSchemas?: LiteralErrorCodeSchemas<ApplicationErrorCode>,
-): ClientHandshakeOptions<typeof HandshakeBytesSchema, ApplicationErrorCode> {
+  rejectionCodeSchemas?: RejectionCodeSchemas,
+): ClientHandshakeOptions<typeof HandshakeBytesSchema, RejectionCodeSchemas> {
   return createTransportClientHandshakeOptions(
     HandshakeBytesSchema,
     async () => {
@@ -77,20 +77,20 @@ export function createClientHandshakeOptions<
 export function createServerHandshakeOptions<
   Schema extends DescMessage,
   ParsedMetadata extends object = object,
-  const ApplicationErrorCode extends string = never,
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
 >(
   schema: Schema,
   validate: ValidateHandshake<
     Schema,
     ParsedMetadata,
-    NoInfer<ApplicationErrorCode>
+    NoInfer<RejectionCodeSchemas>
   >,
   expiry?: (parsedMetadata: ParsedMetadata) => Date | undefined,
-  rejectionCodeSchemas?: LiteralErrorCodeSchemas<ApplicationErrorCode>,
+  rejectionCodeSchemas?: RejectionCodeSchemas,
 ): ServerHandshakeOptions<
   typeof HandshakeBytesSchema,
   ParsedMetadata,
-  ApplicationErrorCode
+  RejectionCodeSchemas
 > {
   return createTransportServerHandshakeOptions(
     HandshakeBytesSchema,

--- a/protobuf/handshake.ts
+++ b/protobuf/handshake.ts
@@ -13,7 +13,7 @@ import {
 import {
   HandshakeErrorCustomHandlerFatalResponseCodes,
   type LiteralErrorCode,
-  type LiteralErrorCodes,
+  type LiteralErrorCodeSchemas,
   type TransportClientId,
 } from '../transport/message';
 import { decodeMessageBytes, encodeMessageBytes } from './shared';
@@ -57,7 +57,7 @@ export function createClientHandshakeOptions<
   schema: Schema,
   construct: ConstructHandshake<Schema>,
   eager?: boolean,
-  rejectionCodes?: LiteralErrorCodes<ApplicationErrorCode>,
+  rejectionCodeSchemas?: LiteralErrorCodeSchemas<ApplicationErrorCode>,
 ): ClientHandshakeOptions<typeof HandshakeBytesSchema, ApplicationErrorCode> {
   return createTransportClientHandshakeOptions(
     HandshakeBytesSchema,
@@ -67,7 +67,7 @@ export function createClientHandshakeOptions<
       return encodeMessageBytes(schema, metadata);
     },
     eager,
-    rejectionCodes,
+    rejectionCodeSchemas,
   );
 }
 
@@ -86,7 +86,7 @@ export function createServerHandshakeOptions<
     NoInfer<ApplicationErrorCode>
   >,
   expiry?: (parsedMetadata: ParsedMetadata) => Date | undefined,
-  rejectionCodes?: LiteralErrorCodes<ApplicationErrorCode>,
+  rejectionCodeSchemas?: LiteralErrorCodeSchemas<ApplicationErrorCode>,
 ): ServerHandshakeOptions<
   typeof HandshakeBytesSchema,
   ParsedMetadata,
@@ -105,6 +105,6 @@ export function createServerHandshakeOptions<
       return await validate(decoded, previousParsedMetadata, from);
     },
     expiry,
-    rejectionCodes,
+    rejectionCodeSchemas,
   );
 }

--- a/protobuf/handshake.ts
+++ b/protobuf/handshake.ts
@@ -12,6 +12,8 @@ import {
 } from '../router/handshake';
 import {
   HandshakeErrorCustomHandlerFatalResponseCodes,
+  type LiteralErrorCode,
+  type LiteralErrorCodes,
   type TransportClientId,
 } from '../transport/message';
 import { decodeMessageBytes, encodeMessageBytes } from './shared';
@@ -38,9 +40,11 @@ type ValidateHandshake<
 ) =>
   | ParsedMetadata
   | ProtobufHandshakeFailureCode
-  | ApplicationErrorCode
+  | LiteralErrorCode<ApplicationErrorCode>
   | Promise<
-      ParsedMetadata | ProtobufHandshakeFailureCode | ApplicationErrorCode
+      | ParsedMetadata
+      | ProtobufHandshakeFailureCode
+      | LiteralErrorCode<ApplicationErrorCode>
     >;
 
 /**
@@ -48,12 +52,12 @@ type ValidateHandshake<
  */
 export function createClientHandshakeOptions<
   Schema extends DescMessage,
-  ApplicationErrorCode extends string = never,
+  const ApplicationErrorCode extends string = never,
 >(
   schema: Schema,
   construct: ConstructHandshake<Schema>,
   eager?: boolean,
-  rejectionCodes?: ReadonlyArray<ApplicationErrorCode>,
+  rejectionCodes?: LiteralErrorCodes<ApplicationErrorCode>,
 ): ClientHandshakeOptions<typeof HandshakeBytesSchema, ApplicationErrorCode> {
   return createTransportClientHandshakeOptions(
     HandshakeBytesSchema,
@@ -73,7 +77,7 @@ export function createClientHandshakeOptions<
 export function createServerHandshakeOptions<
   Schema extends DescMessage,
   ParsedMetadata extends object = object,
-  ApplicationErrorCode extends string = never,
+  const ApplicationErrorCode extends string = never,
 >(
   schema: Schema,
   validate: ValidateHandshake<
@@ -82,7 +86,7 @@ export function createServerHandshakeOptions<
     NoInfer<ApplicationErrorCode>
   >,
   expiry?: (parsedMetadata: ParsedMetadata) => Date | undefined,
-  rejectionCodes?: ReadonlyArray<ApplicationErrorCode>,
+  rejectionCodes?: LiteralErrorCodes<ApplicationErrorCode>,
 ): ServerHandshakeOptions<
   typeof HandshakeBytesSchema,
   ParsedMetadata,

--- a/protobuf/handshake.ts
+++ b/protobuf/handshake.ts
@@ -11,8 +11,8 @@ import {
   type ServerHandshakeOptions,
 } from '../router/handshake';
 import {
-  type ApplicationErrorCode,
-  type ApplicationErrorCodeSchemas,
+  type CustomHandshakeErrorCode,
+  type CustomHandshakeErrorCodeSchema,
   HandshakeErrorCustomHandlerFatalResponseCodes,
   type TransportClientId,
 } from '../transport/message';
@@ -32,7 +32,7 @@ type ConstructHandshake<Schema extends DescMessage> = () =>
 type ValidateHandshake<
   Schema extends DescMessage,
   ParsedMetadata,
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema,
 > = (
   metadata: MessageShape<Schema>,
   previousParsedMetadata?: ParsedMetadata,
@@ -40,11 +40,11 @@ type ValidateHandshake<
 ) =>
   | ParsedMetadata
   | ProtobufHandshakeFailureCode
-  | ApplicationErrorCode<RejectionCodeSchemas>
+  | CustomHandshakeErrorCode<RejectionCodeSchema>
   | Promise<
       | ParsedMetadata
       | ProtobufHandshakeFailureCode
-      | ApplicationErrorCode<RejectionCodeSchemas>
+      | CustomHandshakeErrorCode<RejectionCodeSchema>
     >;
 
 /**
@@ -52,13 +52,13 @@ type ValidateHandshake<
  */
 export function createClientHandshakeOptions<
   Schema extends DescMessage,
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema = never,
 >(
   schema: Schema,
   construct: ConstructHandshake<Schema>,
   eager?: boolean,
-  rejectionCodeSchemas?: RejectionCodeSchemas,
-): ClientHandshakeOptions<typeof HandshakeBytesSchema, RejectionCodeSchemas> {
+  rejectionCodeSchema?: RejectionCodeSchema,
+): ClientHandshakeOptions<typeof HandshakeBytesSchema, RejectionCodeSchema> {
   return createTransportClientHandshakeOptions(
     HandshakeBytesSchema,
     async () => {
@@ -67,7 +67,7 @@ export function createClientHandshakeOptions<
       return encodeMessageBytes(schema, metadata);
     },
     eager,
-    rejectionCodeSchemas,
+    rejectionCodeSchema,
   );
 }
 
@@ -77,20 +77,20 @@ export function createClientHandshakeOptions<
 export function createServerHandshakeOptions<
   Schema extends DescMessage,
   ParsedMetadata extends object = object,
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema = never,
 >(
   schema: Schema,
   validate: ValidateHandshake<
     Schema,
     ParsedMetadata,
-    NoInfer<RejectionCodeSchemas>
+    NoInfer<RejectionCodeSchema>
   >,
   expiry?: (parsedMetadata: ParsedMetadata) => Date | undefined,
-  rejectionCodeSchemas?: RejectionCodeSchemas,
+  rejectionCodeSchema?: RejectionCodeSchema,
 ): ServerHandshakeOptions<
   typeof HandshakeBytesSchema,
   ParsedMetadata,
-  RejectionCodeSchemas
+  RejectionCodeSchema
 > {
   return createTransportServerHandshakeOptions(
     HandshakeBytesSchema,
@@ -105,6 +105,6 @@ export function createServerHandshakeOptions<
       return await validate(decoded, previousParsedMetadata, from);
     },
     expiry,
-    rejectionCodeSchemas,
+    rejectionCodeSchema,
   );
 }

--- a/protobuf/server.ts
+++ b/protobuf/server.ts
@@ -16,6 +16,7 @@ import { EventMap } from '../transport/events';
 import {
   ControlFlags,
   ControlMessageCloseSchema,
+  type CustomHandshakeErrorCodeSchema,
   OpaqueTransportMessage,
   TransportClientId,
   cancelMessage,
@@ -133,11 +134,13 @@ export type Middleware<ParsedMetadata extends object = object> = (
 export interface ServerOptions<
   MetadataSchema extends TSchema,
   ParsedMetadata extends object,
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema = never,
 > {
   readonly extendedContext?: object;
   readonly handshakeOptions?: ServerHandshakeOptions<
     MetadataSchema,
-    ParsedMetadata
+    ParsedMetadata,
+    RejectionCodeSchema
   >;
   readonly middlewares?: Array<Middleware<ParsedMetadata>>;
   readonly maxCancelledStreamTombstonesPerSession?: number;
@@ -146,6 +149,7 @@ export interface ServerOptions<
 class ProtobufServer<
   MetadataSchema extends TSchema,
   ParsedMetadata extends object,
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema,
 > implements Server
 {
   readonly streams: Map<StreamId, ProcStream>;
@@ -153,7 +157,8 @@ class ProtobufServer<
   private readonly transport: ServerTransport<
     Connection,
     MetadataSchema,
-    ParsedMetadata
+    ParsedMetadata,
+    RejectionCodeSchema
   >;
 
   private readonly methods: Map<string, RegisteredMethod>;
@@ -171,9 +176,18 @@ class ProtobufServer<
   private unregisterTransportListeners: () => void;
 
   constructor(
-    transport: ServerTransport<Connection, MetadataSchema, ParsedMetadata>,
+    transport: ServerTransport<
+      Connection,
+      MetadataSchema,
+      ParsedMetadata,
+      RejectionCodeSchema
+    >,
     services: ReadonlyArray<AnyProtoService>,
-    options: ServerOptions<MetadataSchema, ParsedMetadata> = {},
+    options: ServerOptions<
+      MetadataSchema,
+      ParsedMetadata,
+      RejectionCodeSchema
+    > = {},
   ) {
     this.transport = transport;
     this.log = transport.log;
@@ -979,10 +993,16 @@ class LRUSet<T> {
 export function createServer<
   MetadataSchema extends TSchema,
   ParsedMetadata extends object,
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema = never,
 >(
-  transport: ServerTransport<Connection, MetadataSchema, ParsedMetadata>,
+  transport: ServerTransport<
+    Connection,
+    MetadataSchema,
+    ParsedMetadata,
+    RejectionCodeSchema
+  >,
   services: ReadonlyArray<AnyProtoService>,
-  options?: ServerOptions<MetadataSchema, ParsedMetadata>,
+  options?: ServerOptions<MetadataSchema, ParsedMetadata, RejectionCodeSchema>,
 ): Server {
   return new ProtobufServer(transport, services, options);
 }

--- a/router/client.ts
+++ b/router/client.ts
@@ -17,6 +17,7 @@ import {
   isStreamCancel,
   closeStreamMessage,
   cancelMessage,
+  type ApplicationErrorCodeSchemas,
 } from '../transport/message';
 import type { Static, TSchema } from 'typebox';
 import { Err, Result, AnyResultSchema } from './result';
@@ -244,13 +245,13 @@ const defaultClientOptions: ClientOptions = {
 export function createClient<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ServiceSchemaMap extends AnyServiceSchemaMap<any>,
-  ApplicationErrorCode extends string = never,
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
 >(
-  transport: ClientTransport<Connection, ApplicationErrorCode>,
+  transport: ClientTransport<Connection, RejectionCodeSchemas>,
   serverId: TransportClientId,
   providedClientOptions: Partial<
     ClientOptions & {
-      handshakeOptions: ClientHandshakeOptions<TSchema, ApplicationErrorCode>;
+      handshakeOptions: ClientHandshakeOptions<TSchema, RejectionCodeSchemas>;
     }
   > = {},
 ): Client<ServiceSchemaMap> {
@@ -321,9 +322,11 @@ type AnyProcReturn =
   | ReturnType<StreamFn<AnyService, string>>
   | ReturnType<SubscriptionFn<AnyService, string>>;
 
-function handleProc<ApplicationErrorCode extends string = never>(
+function handleProc<
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+>(
   procType: ValidProcType,
-  transport: ClientTransport<Connection, ApplicationErrorCode>,
+  transport: ClientTransport<Connection, RejectionCodeSchemas>,
   serverId: TransportClientId,
   init: Static<PayloadType>,
   serviceName: string,

--- a/router/client.ts
+++ b/router/client.ts
@@ -18,7 +18,7 @@ import {
   closeStreamMessage,
   cancelMessage,
 } from '../transport/message';
-import type { Static } from 'typebox';
+import type { Static, TSchema } from 'typebox';
 import { Err, Result, AnyResultSchema } from './result';
 import { EventMap } from '../transport/events';
 import { Connection } from '../transport/connection';
@@ -241,12 +241,16 @@ const defaultClientOptions: ClientOptions = {
 // We are using any here because the ServiceContext is a server-side implementation
 // detail that doesn't affect the client interface
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function createClient<ServiceSchemaMap extends AnyServiceSchemaMap<any>>(
-  transport: ClientTransport<Connection>,
+export function createClient<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ServiceSchemaMap extends AnyServiceSchemaMap<any>,
+  ApplicationErrorCode extends string = never,
+>(
+  transport: ClientTransport<Connection, ApplicationErrorCode>,
   serverId: TransportClientId,
   providedClientOptions: Partial<
     ClientOptions & {
-      handshakeOptions: ClientHandshakeOptions;
+      handshakeOptions: ClientHandshakeOptions<TSchema, ApplicationErrorCode>;
     }
   > = {},
 ): Client<ServiceSchemaMap> {
@@ -305,7 +309,8 @@ function mergeCallOptions(
   defaults: ClientOptions['defaultCallOptions'],
   caller: CallOptions | undefined,
 ): CallOptions {
-  const resolved = typeof defaults === 'function' ? defaults() : defaults ?? {};
+  const resolved =
+    typeof defaults === 'function' ? defaults() : (defaults ?? {});
 
   // Caller fields win: spread defaults first, caller second.
   return { ...resolved, ...caller };
@@ -317,9 +322,9 @@ type AnyProcReturn =
   | ReturnType<StreamFn<AnyService, string>>
   | ReturnType<SubscriptionFn<AnyService, string>>;
 
-function handleProc(
+function handleProc<ApplicationErrorCode extends string = never>(
   procType: ValidProcType,
-  transport: ClientTransport<Connection>,
+  transport: ClientTransport<Connection, ApplicationErrorCode>,
   serverId: TransportClientId,
   init: Static<PayloadType>,
   serviceName: string,

--- a/router/client.ts
+++ b/router/client.ts
@@ -17,7 +17,7 @@ import {
   isStreamCancel,
   closeStreamMessage,
   cancelMessage,
-  type ApplicationErrorCodeSchemas,
+  type CustomHandshakeErrorCodeSchema,
 } from '../transport/message';
 import type { Static, TSchema } from 'typebox';
 import { Err, Result, AnyResultSchema } from './result';
@@ -245,13 +245,13 @@ const defaultClientOptions: ClientOptions = {
 export function createClient<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ServiceSchemaMap extends AnyServiceSchemaMap<any>,
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema = never,
 >(
-  transport: ClientTransport<Connection, RejectionCodeSchemas>,
+  transport: ClientTransport<Connection, RejectionCodeSchema>,
   serverId: TransportClientId,
   providedClientOptions: Partial<
     ClientOptions & {
-      handshakeOptions: ClientHandshakeOptions<TSchema, RejectionCodeSchemas>;
+      handshakeOptions: ClientHandshakeOptions<TSchema, RejectionCodeSchema>;
     }
   > = {},
 ): Client<ServiceSchemaMap> {
@@ -322,11 +322,9 @@ type AnyProcReturn =
   | ReturnType<StreamFn<AnyService, string>>
   | ReturnType<SubscriptionFn<AnyService, string>>;
 
-function handleProc<
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
->(
+function handleProc<RejectionCodeSchema extends CustomHandshakeErrorCodeSchema>(
   procType: ValidProcType,
-  transport: ClientTransport<Connection, RejectionCodeSchemas>,
+  transport: ClientTransport<Connection, RejectionCodeSchema>,
   serverId: TransportClientId,
   init: Static<PayloadType>,
   serviceName: string,

--- a/router/client.ts
+++ b/router/client.ts
@@ -309,8 +309,7 @@ function mergeCallOptions(
   defaults: ClientOptions['defaultCallOptions'],
   caller: CallOptions | undefined,
 ): CallOptions {
-  const resolved =
-    typeof defaults === 'function' ? defaults() : (defaults ?? {});
+  const resolved = typeof defaults === 'function' ? defaults() : defaults ?? {};
 
   // Caller fields win: spread defaults first, caller second.
   return { ...resolved, ...caller };

--- a/router/handshake.ts
+++ b/router/handshake.ts
@@ -95,7 +95,7 @@ export interface ServerHandshakeOptions<
   validate: ValidateHandshake<
     MetadataSchema,
     ParsedMetadata,
-    ApplicationErrorCode
+    NoInfer<ApplicationErrorCode>
   >;
 
   /**
@@ -132,7 +132,7 @@ export function createServerHandshakeOptions<
   validate: ValidateHandshake<
     MetadataSchema,
     ParsedMetadata,
-    ApplicationErrorCode
+    NoInfer<ApplicationErrorCode>
   >,
   expiry?: (parsedMetadata: ParsedMetadata) => Date | undefined,
   rejectionCodes?: ReadonlyArray<ApplicationErrorCode>,

--- a/router/handshake.ts
+++ b/router/handshake.ts
@@ -1,7 +1,7 @@
 import type { Static, TSchema } from 'typebox';
 import {
-  type ApplicationErrorCode,
-  type ApplicationErrorCodeSchemas,
+  type CustomHandshakeErrorCode,
+  type CustomHandshakeErrorCodeSchema,
   HandshakeErrorCustomHandlerFatalResponseCodes,
   type TransportClientId,
 } from '../transport/message';
@@ -13,24 +13,24 @@ type ConstructHandshake<T extends TSchema> = () =>
 type ValidateHandshake<
   T extends TSchema,
   ParsedMetadata,
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema,
 > = (
   metadata: Static<T>,
   previousParsedMetadata?: ParsedMetadata,
   from?: TransportClientId,
 ) =>
   | Static<typeof HandshakeErrorCustomHandlerFatalResponseCodes>
-  | ApplicationErrorCode<RejectionCodeSchemas>
+  | CustomHandshakeErrorCode<RejectionCodeSchema>
   | ParsedMetadata
   | Promise<
       | Static<typeof HandshakeErrorCustomHandlerFatalResponseCodes>
-      | ApplicationErrorCode<RejectionCodeSchemas>
+      | CustomHandshakeErrorCode<RejectionCodeSchema>
       | ParsedMetadata
     >;
 
 export interface ClientHandshakeOptions<
   MetadataSchema extends TSchema = TSchema,
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema = never,
 > {
   /**
    * Schema for the metadata that the client sends to the server
@@ -39,13 +39,13 @@ export interface ClientHandshakeOptions<
   schema: MetadataSchema;
 
   /**
-   * Application-defined rejection codes the server may answer the handshake
+   * Custom rejection codes the server may answer the handshake
    * with, sent in the response's `code` field. Must match the server's
-   * {@link ServerHandshakeOptions.rejectionCodeSchemas}: an unconfigured code
-   * is rejected as a malformed handshake response. Pass a tuple of TypeBox
-   * literals (`Type.Literal(...)`) with `as const`.
+   * {@link ServerHandshakeOptions.rejectionCodeSchema}: an unconfigured code
+   * is rejected as a malformed handshake response. Pass a TypeBox union of
+   * literals.
    */
-  rejectionCodeSchemas?: RejectionCodeSchemas;
+  rejectionCodeSchema?: RejectionCodeSchema;
 
   /**
    * Gets the {@link HandshakeRequestMetadata} to send to the server.
@@ -66,7 +66,7 @@ export interface ClientHandshakeOptions<
 export interface ServerHandshakeOptions<
   MetadataSchema extends TSchema = TSchema,
   ParsedMetadata extends object = object,
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema = never,
 > {
   /**
    * Schema for the metadata that the server receives from the client
@@ -75,14 +75,13 @@ export interface ServerHandshakeOptions<
   schema: MetadataSchema;
 
   /**
-   * Application-defined rejection codes that {@link validate} may return.
+   * Custom rejection codes that {@link validate} may return.
    * They travel in the handshake response's `code` field and are fatal like
    * the built-in custom-handler codes. Clients must register the same codes
-   * in {@link ClientHandshakeOptions.rejectionCodeSchemas} or they reject the
-   * response as malformed. Pass a tuple of TypeBox literals
-   * (`Type.Literal(...)`) with `as const`.
+   * in {@link ClientHandshakeOptions.rejectionCodeSchema} or they reject the
+   * response as malformed. Pass a TypeBox union of literals.
    */
-  rejectionCodeSchemas?: RejectionCodeSchemas;
+  rejectionCodeSchema?: RejectionCodeSchema;
 
   /**
    * Parses the metadata sent by the client during the handshake into the
@@ -99,7 +98,7 @@ export interface ServerHandshakeOptions<
   validate: ValidateHandshake<
     MetadataSchema,
     ParsedMetadata,
-    NoInfer<RejectionCodeSchemas>
+    NoInfer<RejectionCodeSchema>
   >;
 
   /**
@@ -117,33 +116,29 @@ export interface ServerHandshakeOptions<
 
 export function createClientHandshakeOptions<
   MetadataSchema extends TSchema = TSchema,
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema = never,
 >(
   schema: MetadataSchema,
   construct: ConstructHandshake<MetadataSchema>,
   eager?: boolean,
-  rejectionCodeSchemas?: RejectionCodeSchemas,
-): ClientHandshakeOptions<MetadataSchema, RejectionCodeSchemas> {
-  return { schema, construct, eager, rejectionCodeSchemas };
+  rejectionCodeSchema?: RejectionCodeSchema,
+): ClientHandshakeOptions<MetadataSchema, RejectionCodeSchema> {
+  return { schema, construct, eager, rejectionCodeSchema };
 }
 
 export function createServerHandshakeOptions<
   MetadataSchema extends TSchema = TSchema,
   ParsedMetadata extends object = object,
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema = never,
 >(
   schema: MetadataSchema,
   validate: ValidateHandshake<
     MetadataSchema,
     ParsedMetadata,
-    NoInfer<RejectionCodeSchemas>
+    NoInfer<RejectionCodeSchema>
   >,
   expiry?: (parsedMetadata: ParsedMetadata) => Date | undefined,
-  rejectionCodeSchemas?: RejectionCodeSchemas,
-): ServerHandshakeOptions<
-  MetadataSchema,
-  ParsedMetadata,
-  RejectionCodeSchemas
-> {
-  return { schema, validate, expiry, rejectionCodeSchemas };
+  rejectionCodeSchema?: RejectionCodeSchema,
+): ServerHandshakeOptions<MetadataSchema, ParsedMetadata, RejectionCodeSchema> {
+  return { schema, validate, expiry, rejectionCodeSchema };
 }

--- a/router/handshake.ts
+++ b/router/handshake.ts
@@ -2,7 +2,7 @@ import type { Static, TSchema } from 'typebox';
 import {
   HandshakeErrorCustomHandlerFatalResponseCodes,
   type LiteralErrorCode,
-  type LiteralErrorCodes,
+  type LiteralErrorCodeSchemas,
   type TransportClientId,
 } from '../transport/message';
 
@@ -41,11 +41,11 @@ export interface ClientHandshakeOptions<
   /**
    * Application-defined rejection codes the server may answer the handshake
    * with, sent in the response's `code` field. Must match the server's
-   * {@link ServerHandshakeOptions.rejectionCodes}: an unconfigured code is
-   * rejected as a malformed handshake response. Pass a literal tuple (`as
-   * const`); broad `string[]` values are rejected by the type system.
+   * {@link ServerHandshakeOptions.rejectionCodeSchemas}: an unconfigured code
+   * is rejected as a malformed handshake response. Pass a tuple of TypeBox
+   * literals (`Type.Literal(...)`) with `as const`.
    */
-  rejectionCodes?: LiteralErrorCodes<ApplicationErrorCode>;
+  rejectionCodeSchemas?: LiteralErrorCodeSchemas<ApplicationErrorCode>;
 
   /**
    * Gets the {@link HandshakeRequestMetadata} to send to the server.
@@ -78,11 +78,11 @@ export interface ServerHandshakeOptions<
    * Application-defined rejection codes that {@link validate} may return.
    * They travel in the handshake response's `code` field and are fatal like
    * the built-in custom-handler codes. Clients must register the same codes
-   * in {@link ClientHandshakeOptions.rejectionCodes} or they reject the
-   * response as malformed. Pass a literal tuple (`as const`); broad `string[]`
-   * values are rejected by the type system.
+   * in {@link ClientHandshakeOptions.rejectionCodeSchemas} or they reject the
+   * response as malformed. Pass a tuple of TypeBox literals
+   * (`Type.Literal(...)`) with `as const`.
    */
-  rejectionCodes?: LiteralErrorCodes<ApplicationErrorCode>;
+  rejectionCodeSchemas?: LiteralErrorCodeSchemas<ApplicationErrorCode>;
 
   /**
    * Parses the metadata sent by the client during the handshake into the
@@ -122,9 +122,9 @@ export function createClientHandshakeOptions<
   schema: MetadataSchema,
   construct: ConstructHandshake<MetadataSchema>,
   eager?: boolean,
-  rejectionCodes?: LiteralErrorCodes<ApplicationErrorCode>,
+  rejectionCodeSchemas?: LiteralErrorCodeSchemas<ApplicationErrorCode>,
 ): ClientHandshakeOptions<MetadataSchema, ApplicationErrorCode> {
-  return { schema, construct, eager, rejectionCodes };
+  return { schema, construct, eager, rejectionCodeSchemas };
 }
 
 export function createServerHandshakeOptions<
@@ -139,11 +139,11 @@ export function createServerHandshakeOptions<
     NoInfer<ApplicationErrorCode>
   >,
   expiry?: (parsedMetadata: ParsedMetadata) => Date | undefined,
-  rejectionCodes?: LiteralErrorCodes<ApplicationErrorCode>,
+  rejectionCodeSchemas?: LiteralErrorCodeSchemas<ApplicationErrorCode>,
 ): ServerHandshakeOptions<
   MetadataSchema,
   ParsedMetadata,
   ApplicationErrorCode
 > {
-  return { schema, validate, expiry, rejectionCodes };
+  return { schema, validate, expiry, rejectionCodeSchemas };
 }

--- a/router/handshake.ts
+++ b/router/handshake.ts
@@ -1,6 +1,8 @@
 import type { Static, TSchema } from 'typebox';
 import {
   HandshakeErrorCustomHandlerFatalResponseCodes,
+  type LiteralErrorCode,
+  type LiteralErrorCodes,
   type TransportClientId,
 } from '../transport/message';
 
@@ -18,11 +20,11 @@ type ValidateHandshake<
   from?: TransportClientId,
 ) =>
   | Static<typeof HandshakeErrorCustomHandlerFatalResponseCodes>
-  | ApplicationErrorCode
+  | LiteralErrorCode<ApplicationErrorCode>
   | ParsedMetadata
   | Promise<
       | Static<typeof HandshakeErrorCustomHandlerFatalResponseCodes>
-      | ApplicationErrorCode
+      | LiteralErrorCode<ApplicationErrorCode>
       | ParsedMetadata
     >;
 
@@ -40,9 +42,10 @@ export interface ClientHandshakeOptions<
    * Application-defined rejection codes the server may answer the handshake
    * with, sent in the response's `code` field. Must match the server's
    * {@link ServerHandshakeOptions.rejectionCodes}: an unconfigured code is
-   * rejected as a malformed handshake response.
+   * rejected as a malformed handshake response. Pass a literal tuple (`as
+   * const`); broad `string[]` values are rejected by the type system.
    */
-  rejectionCodes?: ReadonlyArray<ApplicationErrorCode>;
+  rejectionCodes?: LiteralErrorCodes<ApplicationErrorCode>;
 
   /**
    * Gets the {@link HandshakeRequestMetadata} to send to the server.
@@ -76,9 +79,10 @@ export interface ServerHandshakeOptions<
    * They travel in the handshake response's `code` field and are fatal like
    * the built-in custom-handler codes. Clients must register the same codes
    * in {@link ClientHandshakeOptions.rejectionCodes} or they reject the
-   * response as malformed.
+   * response as malformed. Pass a literal tuple (`as const`); broad `string[]`
+   * values are rejected by the type system.
    */
-  rejectionCodes?: ReadonlyArray<ApplicationErrorCode>;
+  rejectionCodes?: LiteralErrorCodes<ApplicationErrorCode>;
 
   /**
    * Parses the metadata sent by the client during the handshake into the
@@ -113,12 +117,12 @@ export interface ServerHandshakeOptions<
 
 export function createClientHandshakeOptions<
   MetadataSchema extends TSchema = TSchema,
-  ApplicationErrorCode extends string = never,
+  const ApplicationErrorCode extends string = never,
 >(
   schema: MetadataSchema,
   construct: ConstructHandshake<MetadataSchema>,
   eager?: boolean,
-  rejectionCodes?: ReadonlyArray<ApplicationErrorCode>,
+  rejectionCodes?: LiteralErrorCodes<ApplicationErrorCode>,
 ): ClientHandshakeOptions<MetadataSchema, ApplicationErrorCode> {
   return { schema, construct, eager, rejectionCodes };
 }
@@ -126,7 +130,7 @@ export function createClientHandshakeOptions<
 export function createServerHandshakeOptions<
   MetadataSchema extends TSchema = TSchema,
   ParsedMetadata extends object = object,
-  ApplicationErrorCode extends string = never,
+  const ApplicationErrorCode extends string = never,
 >(
   schema: MetadataSchema,
   validate: ValidateHandshake<
@@ -135,7 +139,7 @@ export function createServerHandshakeOptions<
     NoInfer<ApplicationErrorCode>
   >,
   expiry?: (parsedMetadata: ParsedMetadata) => Date | undefined,
-  rejectionCodes?: ReadonlyArray<ApplicationErrorCode>,
+  rejectionCodes?: LiteralErrorCodes<ApplicationErrorCode>,
 ): ServerHandshakeOptions<
   MetadataSchema,
   ParsedMetadata,

--- a/router/handshake.ts
+++ b/router/handshake.ts
@@ -1,8 +1,8 @@
 import type { Static, TSchema } from 'typebox';
 import {
+  type ApplicationErrorCode,
+  type ApplicationErrorCodeSchemas,
   HandshakeErrorCustomHandlerFatalResponseCodes,
-  type LiteralErrorCode,
-  type LiteralErrorCodeSchemas,
   type TransportClientId,
 } from '../transport/message';
 
@@ -13,24 +13,24 @@ type ConstructHandshake<T extends TSchema> = () =>
 type ValidateHandshake<
   T extends TSchema,
   ParsedMetadata,
-  ApplicationErrorCode extends string = never,
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
 > = (
   metadata: Static<T>,
   previousParsedMetadata?: ParsedMetadata,
   from?: TransportClientId,
 ) =>
   | Static<typeof HandshakeErrorCustomHandlerFatalResponseCodes>
-  | LiteralErrorCode<ApplicationErrorCode>
+  | ApplicationErrorCode<RejectionCodeSchemas>
   | ParsedMetadata
   | Promise<
       | Static<typeof HandshakeErrorCustomHandlerFatalResponseCodes>
-      | LiteralErrorCode<ApplicationErrorCode>
+      | ApplicationErrorCode<RejectionCodeSchemas>
       | ParsedMetadata
     >;
 
 export interface ClientHandshakeOptions<
   MetadataSchema extends TSchema = TSchema,
-  ApplicationErrorCode extends string = never,
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
 > {
   /**
    * Schema for the metadata that the client sends to the server
@@ -45,7 +45,7 @@ export interface ClientHandshakeOptions<
    * is rejected as a malformed handshake response. Pass a tuple of TypeBox
    * literals (`Type.Literal(...)`) with `as const`.
    */
-  rejectionCodeSchemas?: LiteralErrorCodeSchemas<ApplicationErrorCode>;
+  rejectionCodeSchemas?: RejectionCodeSchemas;
 
   /**
    * Gets the {@link HandshakeRequestMetadata} to send to the server.
@@ -66,7 +66,7 @@ export interface ClientHandshakeOptions<
 export interface ServerHandshakeOptions<
   MetadataSchema extends TSchema = TSchema,
   ParsedMetadata extends object = object,
-  ApplicationErrorCode extends string = never,
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
 > {
   /**
    * Schema for the metadata that the server receives from the client
@@ -82,7 +82,7 @@ export interface ServerHandshakeOptions<
    * response as malformed. Pass a tuple of TypeBox literals
    * (`Type.Literal(...)`) with `as const`.
    */
-  rejectionCodeSchemas?: LiteralErrorCodeSchemas<ApplicationErrorCode>;
+  rejectionCodeSchemas?: RejectionCodeSchemas;
 
   /**
    * Parses the metadata sent by the client during the handshake into the
@@ -99,7 +99,7 @@ export interface ServerHandshakeOptions<
   validate: ValidateHandshake<
     MetadataSchema,
     ParsedMetadata,
-    NoInfer<ApplicationErrorCode>
+    NoInfer<RejectionCodeSchemas>
   >;
 
   /**
@@ -117,33 +117,33 @@ export interface ServerHandshakeOptions<
 
 export function createClientHandshakeOptions<
   MetadataSchema extends TSchema = TSchema,
-  const ApplicationErrorCode extends string = never,
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
 >(
   schema: MetadataSchema,
   construct: ConstructHandshake<MetadataSchema>,
   eager?: boolean,
-  rejectionCodeSchemas?: LiteralErrorCodeSchemas<ApplicationErrorCode>,
-): ClientHandshakeOptions<MetadataSchema, ApplicationErrorCode> {
+  rejectionCodeSchemas?: RejectionCodeSchemas,
+): ClientHandshakeOptions<MetadataSchema, RejectionCodeSchemas> {
   return { schema, construct, eager, rejectionCodeSchemas };
 }
 
 export function createServerHandshakeOptions<
   MetadataSchema extends TSchema = TSchema,
   ParsedMetadata extends object = object,
-  const ApplicationErrorCode extends string = never,
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
 >(
   schema: MetadataSchema,
   validate: ValidateHandshake<
     MetadataSchema,
     ParsedMetadata,
-    NoInfer<ApplicationErrorCode>
+    NoInfer<RejectionCodeSchemas>
   >,
   expiry?: (parsedMetadata: ParsedMetadata) => Date | undefined,
-  rejectionCodeSchemas?: LiteralErrorCodeSchemas<ApplicationErrorCode>,
+  rejectionCodeSchemas?: RejectionCodeSchemas,
 ): ServerHandshakeOptions<
   MetadataSchema,
   ParsedMetadata,
-  ApplicationErrorCode
+  RejectionCodeSchemas
 > {
   return { schema, validate, expiry, rejectionCodeSchemas };
 }

--- a/router/handshake.ts
+++ b/router/handshake.ts
@@ -8,26 +8,41 @@ type ConstructHandshake<T extends TSchema> = () =>
   | Static<T>
   | Promise<Static<T>>;
 
-type ValidateHandshake<T extends TSchema, ParsedMetadata> = (
+type ValidateHandshake<
+  T extends TSchema,
+  ParsedMetadata,
+  ApplicationErrorCode extends string = never,
+> = (
   metadata: Static<T>,
   previousParsedMetadata?: ParsedMetadata,
   from?: TransportClientId,
 ) =>
   | Static<typeof HandshakeErrorCustomHandlerFatalResponseCodes>
+  | ApplicationErrorCode
   | ParsedMetadata
   | Promise<
       | Static<typeof HandshakeErrorCustomHandlerFatalResponseCodes>
+      | ApplicationErrorCode
       | ParsedMetadata
     >;
 
 export interface ClientHandshakeOptions<
   MetadataSchema extends TSchema = TSchema,
+  ApplicationErrorCode extends string = never,
 > {
   /**
    * Schema for the metadata that the client sends to the server
    * during the handshake.
    */
   schema: MetadataSchema;
+
+  /**
+   * Application-defined rejection codes the server may answer the handshake
+   * with, sent in the response's `code` field. Must match the server's
+   * {@link ServerHandshakeOptions.rejectionCodes}: an unconfigured code is
+   * rejected as a malformed handshake response.
+   */
+  rejectionCodes?: ReadonlyArray<ApplicationErrorCode>;
 
   /**
    * Gets the {@link HandshakeRequestMetadata} to send to the server.
@@ -48,12 +63,22 @@ export interface ClientHandshakeOptions<
 export interface ServerHandshakeOptions<
   MetadataSchema extends TSchema = TSchema,
   ParsedMetadata extends object = object,
+  ApplicationErrorCode extends string = never,
 > {
   /**
    * Schema for the metadata that the server receives from the client
    * during the handshake.
    */
   schema: MetadataSchema;
+
+  /**
+   * Application-defined rejection codes that {@link validate} may return.
+   * They travel in the handshake response's `code` field and are fatal like
+   * the built-in custom-handler codes. Clients must register the same codes
+   * in {@link ClientHandshakeOptions.rejectionCodes} or they reject the
+   * response as malformed.
+   */
+  rejectionCodes?: ReadonlyArray<ApplicationErrorCode>;
 
   /**
    * Parses the metadata sent by the client during the handshake into the
@@ -67,7 +92,11 @@ export interface ServerHandshakeOptions<
    *   confirm the presented id is the one the metadata authorizes before
    *   returning parsed metadata.
    */
-  validate: ValidateHandshake<MetadataSchema, ParsedMetadata>;
+  validate: ValidateHandshake<
+    MetadataSchema,
+    ParsedMetadata,
+    ApplicationErrorCode
+  >;
 
   /**
    * When the credential expires (or undefined if it never does). The server
@@ -84,21 +113,33 @@ export interface ServerHandshakeOptions<
 
 export function createClientHandshakeOptions<
   MetadataSchema extends TSchema = TSchema,
+  ApplicationErrorCode extends string = never,
 >(
   schema: MetadataSchema,
   construct: ConstructHandshake<MetadataSchema>,
   eager?: boolean,
-): ClientHandshakeOptions<MetadataSchema> {
-  return { schema, construct, eager };
+  rejectionCodes?: ReadonlyArray<ApplicationErrorCode>,
+): ClientHandshakeOptions<MetadataSchema, ApplicationErrorCode> {
+  return { schema, construct, eager, rejectionCodes };
 }
 
 export function createServerHandshakeOptions<
   MetadataSchema extends TSchema = TSchema,
   ParsedMetadata extends object = object,
+  ApplicationErrorCode extends string = never,
 >(
   schema: MetadataSchema,
-  validate: ValidateHandshake<MetadataSchema, ParsedMetadata>,
+  validate: ValidateHandshake<
+    MetadataSchema,
+    ParsedMetadata,
+    ApplicationErrorCode
+  >,
   expiry?: (parsedMetadata: ParsedMetadata) => Date | undefined,
-): ServerHandshakeOptions<MetadataSchema, ParsedMetadata> {
-  return { schema, validate, expiry };
+  rejectionCodes?: ReadonlyArray<ApplicationErrorCode>,
+): ServerHandshakeOptions<
+  MetadataSchema,
+  ParsedMetadata,
+  ApplicationErrorCode
+> {
+  return { schema, validate, expiry, rejectionCodes };
 }

--- a/router/server.ts
+++ b/router/server.ts
@@ -29,6 +29,7 @@ import {
   cancelMessage,
   ProtocolVersion,
   TransportClientId,
+  type ApplicationErrorCodeSchemas,
 } from '../transport/message';
 import { ProcedureHandlerContext } from './context';
 import { Logger } from '../logging/log';
@@ -112,14 +113,14 @@ class RiverServer<
   MetadataSchema extends TSchema,
   ParsedMetadata extends object,
   Services extends AnyServiceSchemaMap<Context>,
-  ApplicationErrorCode extends string = never,
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
 > implements Server<Context, ParsedMetadata, Services>
 {
   private transport: ServerTransport<
     Connection,
     MetadataSchema,
     ParsedMetadata,
-    ApplicationErrorCode
+    RejectionCodeSchemas
   >;
 
   private contextMap: Map<AnyService, Context & { state: object }>;
@@ -151,13 +152,13 @@ class RiverServer<
       Connection,
       MetadataSchema,
       ParsedMetadata,
-      ApplicationErrorCode
+      RejectionCodeSchemas
     >,
     services: Services,
     handshakeOptions?: ServerHandshakeOptions<
       MetadataSchema,
       ParsedMetadata,
-      ApplicationErrorCode
+      RejectionCodeSchemas
     >,
     extendedContext?: Context,
     maxCancelledStreamTombstonesPerSession = 200,
@@ -1178,20 +1179,20 @@ export function createServer<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Services extends AnyServiceSchemaMap<any>,
   Context extends MaybeDisposable = MaybeDisposable,
-  ApplicationErrorCode extends string = never,
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
 >(
   transport: ServerTransport<
     Connection,
     MetadataSchema,
     ParsedMetadata,
-    ApplicationErrorCode
+    RejectionCodeSchemas
   >,
   services: Services,
   providedServerOptions?: Partial<{
     handshakeOptions?: ServerHandshakeOptions<
       MetadataSchema,
       ParsedMetadata,
-      ApplicationErrorCode
+      RejectionCodeSchemas
     >;
     extendedContext?: Context;
     /**

--- a/router/server.ts
+++ b/router/server.ts
@@ -112,12 +112,14 @@ class RiverServer<
   MetadataSchema extends TSchema,
   ParsedMetadata extends object,
   Services extends AnyServiceSchemaMap<Context>,
+  ApplicationErrorCode extends string = never,
 > implements Server<Context, ParsedMetadata, Services>
 {
   private transport: ServerTransport<
     Connection,
     MetadataSchema,
-    ParsedMetadata
+    ParsedMetadata,
+    ApplicationErrorCode
   >;
 
   private contextMap: Map<AnyService, Context & { state: object }>;
@@ -145,9 +147,18 @@ class RiverServer<
   private unregisterTransportListeners: () => void;
 
   constructor(
-    transport: ServerTransport<Connection, MetadataSchema, ParsedMetadata>,
+    transport: ServerTransport<
+      Connection,
+      MetadataSchema,
+      ParsedMetadata,
+      ApplicationErrorCode
+    >,
     services: Services,
-    handshakeOptions?: ServerHandshakeOptions<MetadataSchema, ParsedMetadata>,
+    handshakeOptions?: ServerHandshakeOptions<
+      MetadataSchema,
+      ParsedMetadata,
+      ApplicationErrorCode
+    >,
     extendedContext?: Context,
     maxCancelledStreamTombstonesPerSession = 200,
     middlewares: Array<Middleware> = [],
@@ -1167,11 +1178,21 @@ export function createServer<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Services extends AnyServiceSchemaMap<any>,
   Context extends MaybeDisposable = MaybeDisposable,
+  ApplicationErrorCode extends string = never,
 >(
-  transport: ServerTransport<Connection, MetadataSchema, ParsedMetadata>,
+  transport: ServerTransport<
+    Connection,
+    MetadataSchema,
+    ParsedMetadata,
+    ApplicationErrorCode
+  >,
   services: Services,
   providedServerOptions?: Partial<{
-    handshakeOptions?: ServerHandshakeOptions<MetadataSchema, ParsedMetadata>;
+    handshakeOptions?: ServerHandshakeOptions<
+      MetadataSchema,
+      ParsedMetadata,
+      ApplicationErrorCode
+    >;
     extendedContext?: Context;
     /**
      * Maximum number of cancelled streams to keep track of to avoid

--- a/router/server.ts
+++ b/router/server.ts
@@ -29,7 +29,7 @@ import {
   cancelMessage,
   ProtocolVersion,
   TransportClientId,
-  type ApplicationErrorCodeSchemas,
+  type CustomHandshakeErrorCodeSchema,
 } from '../transport/message';
 import { ProcedureHandlerContext } from './context';
 import { Logger } from '../logging/log';
@@ -113,14 +113,14 @@ class RiverServer<
   MetadataSchema extends TSchema,
   ParsedMetadata extends object,
   Services extends AnyServiceSchemaMap<Context>,
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema,
 > implements Server<Context, ParsedMetadata, Services>
 {
   private transport: ServerTransport<
     Connection,
     MetadataSchema,
     ParsedMetadata,
-    RejectionCodeSchemas
+    RejectionCodeSchema
   >;
 
   private contextMap: Map<AnyService, Context & { state: object }>;
@@ -152,13 +152,13 @@ class RiverServer<
       Connection,
       MetadataSchema,
       ParsedMetadata,
-      RejectionCodeSchemas
+      RejectionCodeSchema
     >,
     services: Services,
     handshakeOptions?: ServerHandshakeOptions<
       MetadataSchema,
       ParsedMetadata,
-      RejectionCodeSchemas
+      RejectionCodeSchema
     >,
     extendedContext?: Context,
     maxCancelledStreamTombstonesPerSession = 200,
@@ -1179,20 +1179,20 @@ export function createServer<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Services extends AnyServiceSchemaMap<any>,
   Context extends MaybeDisposable = MaybeDisposable,
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema = never,
 >(
   transport: ServerTransport<
     Connection,
     MetadataSchema,
     ParsedMetadata,
-    RejectionCodeSchemas
+    RejectionCodeSchema
   >,
   services: Services,
   providedServerOptions?: Partial<{
     handshakeOptions?: ServerHandshakeOptions<
       MetadataSchema,
       ParsedMetadata,
-      RejectionCodeSchemas
+      RejectionCodeSchema
     >;
     extendedContext?: Context;
     /**

--- a/testUtil/fixtures/cleanup.ts
+++ b/testUtil/fixtures/cleanup.ts
@@ -8,9 +8,10 @@ import {
 import { Server } from '../../router';
 import { AnyServiceSchemaMap, MaybeDisposable } from '../../router/services';
 import { numberOfConnections, testingSessionOptions } from '..';
+import type { TSchema } from 'typebox';
 import { Value } from 'typebox/value';
 import {
-  type ApplicationErrorCodeSchemas,
+  type CustomHandshakeErrorCodeSchema,
   ControlMessageAckSchema,
 } from '../../transport/message';
 
@@ -40,8 +41,8 @@ export async function advanceFakeTimersByConnectionBackoff() {
 }
 
 export async function ensureTransportIsClean<
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
->(t: Transport<Connection, RejectionCodeSchemas>) {
+  HandshakeFailureCode extends string,
+>(t: Transport<Connection, HandshakeFailureCode>) {
   await advanceFakeTimersBySessionGrace();
   await waitFor(() =>
     expect(
@@ -62,8 +63,8 @@ export function waitFor<T>(cb: () => T | Promise<T>) {
 }
 
 export async function ensureTransportBuffersAreEventuallyEmpty<
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
->(t: Transport<Connection, RejectionCodeSchemas>) {
+  HandshakeFailureCode extends string,
+>(t: Transport<Connection, HandshakeFailureCode>) {
   // wait for send buffers to be flushed
   // ignore heartbeat messages
   await waitFor(() =>
@@ -104,8 +105,8 @@ export async function ensureServerIsClean(
 
 export async function cleanupTransports<
   ConnType extends Connection,
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
->(transports: Array<Transport<ConnType, RejectionCodeSchemas>>) {
+  HandshakeFailureCode extends string,
+>(transports: Array<Transport<ConnType, HandshakeFailureCode>>) {
   for (const t of transports) {
     if (t.getStatus() !== 'closed') {
       t.log?.info('*** end of test cleanup ***', { clientId: t.clientId });
@@ -115,17 +116,21 @@ export async function cleanupTransports<
 }
 
 export async function testFinishesCleanly<
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+  MetadataSchema extends TSchema,
+  ParsedMetadata extends object,
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema,
 >({
   clientTransports,
   serverTransport,
   server,
 }: Partial<{
-  clientTransports: Array<ClientTransport<Connection, RejectionCodeSchemas>>;
-  // MetadataSchema and ParsedMetadata are not used in this test,
-  // so we can safely use any here
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  serverTransport: ServerTransport<Connection, any, any, RejectionCodeSchemas>;
+  clientTransports: Array<ClientTransport<Connection, RejectionCodeSchema>>;
+  serverTransport: ServerTransport<
+    Connection,
+    MetadataSchema,
+    ParsedMetadata,
+    RejectionCodeSchema
+  >;
   server: Server<MaybeDisposable, object, AnyServiceSchemaMap>;
 }>) {
   // pre-close invariants

--- a/testUtil/fixtures/cleanup.ts
+++ b/testUtil/fixtures/cleanup.ts
@@ -9,7 +9,10 @@ import { Server } from '../../router';
 import { AnyServiceSchemaMap, MaybeDisposable } from '../../router/services';
 import { numberOfConnections, testingSessionOptions } from '..';
 import { Value } from 'typebox/value';
-import { ControlMessageAckSchema } from '../../transport/message';
+import {
+  type ApplicationErrorCodeSchemas,
+  ControlMessageAckSchema,
+} from '../../transport/message';
 
 const waitUntilOptions = {
   timeout: 500, // account for possibility of conn backoff
@@ -37,8 +40,8 @@ export async function advanceFakeTimersByConnectionBackoff() {
 }
 
 export async function ensureTransportIsClean<
-  ApplicationErrorCode extends string = never,
->(t: Transport<Connection, ApplicationErrorCode>) {
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+>(t: Transport<Connection, RejectionCodeSchemas>) {
   await advanceFakeTimersBySessionGrace();
   await waitFor(() =>
     expect(
@@ -59,8 +62,8 @@ export function waitFor<T>(cb: () => T | Promise<T>) {
 }
 
 export async function ensureTransportBuffersAreEventuallyEmpty<
-  ApplicationErrorCode extends string = never,
->(t: Transport<Connection, ApplicationErrorCode>) {
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+>(t: Transport<Connection, RejectionCodeSchemas>) {
   // wait for send buffers to be flushed
   // ignore heartbeat messages
   await waitFor(() =>
@@ -101,8 +104,8 @@ export async function ensureServerIsClean(
 
 export async function cleanupTransports<
   ConnType extends Connection,
-  ApplicationErrorCode extends string = never,
->(transports: Array<Transport<ConnType, ApplicationErrorCode>>) {
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+>(transports: Array<Transport<ConnType, RejectionCodeSchemas>>) {
   for (const t of transports) {
     if (t.getStatus() !== 'closed') {
       t.log?.info('*** end of test cleanup ***', { clientId: t.clientId });
@@ -112,17 +115,17 @@ export async function cleanupTransports<
 }
 
 export async function testFinishesCleanly<
-  ApplicationErrorCode extends string = never,
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
 >({
   clientTransports,
   serverTransport,
   server,
 }: Partial<{
-  clientTransports: Array<ClientTransport<Connection, ApplicationErrorCode>>;
+  clientTransports: Array<ClientTransport<Connection, RejectionCodeSchemas>>;
   // MetadataSchema and ParsedMetadata are not used in this test,
   // so we can safely use any here
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  serverTransport: ServerTransport<Connection, any, any, ApplicationErrorCode>;
+  serverTransport: ServerTransport<Connection, any, any, RejectionCodeSchemas>;
   server: Server<MaybeDisposable, object, AnyServiceSchemaMap>;
 }>) {
   // pre-close invariants

--- a/testUtil/fixtures/cleanup.ts
+++ b/testUtil/fixtures/cleanup.ts
@@ -36,7 +36,9 @@ export async function advanceFakeTimersByConnectionBackoff() {
   await vi.advanceTimersByTimeAsync(500);
 }
 
-export async function ensureTransportIsClean(t: Transport<Connection>) {
+export async function ensureTransportIsClean<
+  ApplicationErrorCode extends string = never,
+>(t: Transport<Connection, ApplicationErrorCode>) {
   await advanceFakeTimersBySessionGrace();
   await waitFor(() =>
     expect(
@@ -56,9 +58,9 @@ export function waitFor<T>(cb: () => T | Promise<T>) {
   return vi.waitFor(cb, waitUntilOptions);
 }
 
-export async function ensureTransportBuffersAreEventuallyEmpty(
-  t: Transport<Connection>,
-) {
+export async function ensureTransportBuffersAreEventuallyEmpty<
+  ApplicationErrorCode extends string = never,
+>(t: Transport<Connection, ApplicationErrorCode>) {
   // wait for send buffers to be flushed
   // ignore heartbeat messages
   await waitFor(() =>
@@ -97,9 +99,10 @@ export async function ensureServerIsClean(
   );
 }
 
-export async function cleanupTransports<ConnType extends Connection>(
-  transports: Array<Transport<ConnType>>,
-) {
+export async function cleanupTransports<
+  ConnType extends Connection,
+  ApplicationErrorCode extends string = never,
+>(transports: Array<Transport<ConnType, ApplicationErrorCode>>) {
   for (const t of transports) {
     if (t.getStatus() !== 'closed') {
       t.log?.info('*** end of test cleanup ***', { clientId: t.clientId });
@@ -108,16 +111,18 @@ export async function cleanupTransports<ConnType extends Connection>(
   }
 }
 
-export async function testFinishesCleanly({
+export async function testFinishesCleanly<
+  ApplicationErrorCode extends string = never,
+>({
   clientTransports,
   serverTransport,
   server,
 }: Partial<{
-  clientTransports: Array<ClientTransport<Connection>>;
+  clientTransports: Array<ClientTransport<Connection, ApplicationErrorCode>>;
   // MetadataSchema and ParsedMetadata are not used in this test,
   // so we can safely use any here
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  serverTransport: ServerTransport<Connection, any, any>;
+  serverTransport: ServerTransport<Connection, any, any, ApplicationErrorCode>;
   server: Server<MaybeDisposable, object, AnyServiceSchemaMap>;
 }>) {
   // pre-close invariants

--- a/testUtil/fixtures/mockTransport.ts
+++ b/testUtil/fixtures/mockTransport.ts
@@ -1,5 +1,5 @@
 import { Transport, TransportClientId } from '../../transport';
-import type { ApplicationErrorCodeSchemas } from '../../transport/message';
+import type { CustomHandshakeErrorCodeSchema } from '../../transport/message';
 import { ClientTransport } from '../../transport/client';
 import { Connection } from '../../transport/connection';
 import { ServerTransport } from '../../transport/server';
@@ -75,12 +75,10 @@ export function createMockTransportNetwork(
   // conn id -> [client->server, server->client]
   const connections = new Observable<Record<string, BidiConnection>>({});
 
-  const transports: Array<
-    Transport<InMemoryConnection, ApplicationErrorCodeSchemas>
-  > = [];
+  const transports: Array<Transport<InMemoryConnection, string>> = [];
   class MockClientTransport<
-    RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
-  > extends ClientTransport<InMemoryConnection, RejectionCodeSchemas> {
+    RejectionCodeSchema extends CustomHandshakeErrorCodeSchema,
+  > extends ClientTransport<InMemoryConnection, RejectionCodeSchema> {
     async createNewOutgoingConnection(
       to: TransportClientId,
     ): Promise<InMemoryConnection> {
@@ -105,14 +103,14 @@ export function createMockTransportNetwork(
   }
 
   class MockServerTransport<
-    MetadataSchema extends TSchema = TSchema,
-    ParsedMetadata extends object = object,
-    RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+    MetadataSchema extends TSchema,
+    ParsedMetadata extends object,
+    RejectionCodeSchema extends CustomHandshakeErrorCodeSchema,
   > extends ServerTransport<
     InMemoryConnection,
     MetadataSchema,
     ParsedMetadata,
-    RejectionCodeSchemas
+    RejectionCodeSchema
   > {
     subscribeCleanup: () => void;
 
@@ -146,12 +144,12 @@ export function createMockTransportNetwork(
 
   return {
     getClientTransport: <
-      RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+      RejectionCodeSchema extends CustomHandshakeErrorCodeSchema,
     >(
       id: TransportClientId,
-      handshakeOptions?: ClientHandshakeOptions<TSchema, RejectionCodeSchemas>,
+      handshakeOptions?: ClientHandshakeOptions<TSchema, RejectionCodeSchema>,
     ) => {
-      const clientTransport = new MockClientTransport<RejectionCodeSchemas>(
+      const clientTransport = new MockClientTransport<RejectionCodeSchema>(
         id,
         opts?.client,
       );
@@ -164,23 +162,23 @@ export function createMockTransportNetwork(
       return clientTransport;
     },
     getServerTransport: <
-      MetadataSchema extends TSchema = TSchema,
-      ParsedMetadata extends object = object,
-      RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+      MetadataSchema extends TSchema,
+      ParsedMetadata extends object,
+      RejectionCodeSchema extends CustomHandshakeErrorCodeSchema,
     >(
       id = 'SERVER',
       handshakeOptions:
         | ServerHandshakeOptions<
             MetadataSchema,
             ParsedMetadata,
-            RejectionCodeSchemas
+            RejectionCodeSchema
           >
         | undefined,
     ) => {
       const serverTransport = new MockServerTransport<
         MetadataSchema,
         ParsedMetadata,
-        RejectionCodeSchemas
+        RejectionCodeSchema
       >(id, opts?.server);
       if (handshakeOptions) {
         serverTransport.extendHandshake(handshakeOptions);

--- a/testUtil/fixtures/mockTransport.ts
+++ b/testUtil/fixtures/mockTransport.ts
@@ -142,7 +142,7 @@ export function createMockTransportNetwork(
   }
 
   return {
-    getClientTransport: <ApplicationErrorCode extends string = never>(
+    getClientTransport: <const ApplicationErrorCode extends string = never>(
       id: TransportClientId,
       handshakeOptions?: ClientHandshakeOptions<TSchema, ApplicationErrorCode>,
     ) => {
@@ -161,7 +161,7 @@ export function createMockTransportNetwork(
     getServerTransport: <
       MetadataSchema extends TSchema = TSchema,
       ParsedMetadata extends object = object,
-      ApplicationErrorCode extends string = never,
+      const ApplicationErrorCode extends string = never,
     >(
       id = 'SERVER',
       handshakeOptions:

--- a/testUtil/fixtures/mockTransport.ts
+++ b/testUtil/fixtures/mockTransport.ts
@@ -9,7 +9,10 @@ import { Duplex } from 'node:stream';
 import { duplexPair } from '../duplex/duplexPair';
 import { nanoid } from 'nanoid';
 import type { TSchema } from 'typebox';
-import { ServerHandshakeOptions } from '../../router/handshake';
+import {
+  ClientHandshakeOptions,
+  ServerHandshakeOptions,
+} from '../../router/handshake';
 
 export class InMemoryConnection extends Connection {
   conn: Duplex;
@@ -71,8 +74,10 @@ export function createMockTransportNetwork(
   // conn id -> [client->server, server->client]
   const connections = new Observable<Record<string, BidiConnection>>({});
 
-  const transports: Array<Transport<InMemoryConnection>> = [];
-  class MockClientTransport extends ClientTransport<InMemoryConnection> {
+  const transports: Array<Transport<InMemoryConnection, string>> = [];
+  class MockClientTransport<
+    ApplicationErrorCode extends string = never,
+  > extends ClientTransport<InMemoryConnection, ApplicationErrorCode> {
     async createNewOutgoingConnection(
       to: TransportClientId,
     ): Promise<InMemoryConnection> {
@@ -99,10 +104,12 @@ export function createMockTransportNetwork(
   class MockServerTransport<
     MetadataSchema extends TSchema = TSchema,
     ParsedMetadata extends object = object,
+    ApplicationErrorCode extends string = never,
   > extends ServerTransport<
     InMemoryConnection,
     MetadataSchema,
-    ParsedMetadata
+    ParsedMetadata,
+    ApplicationErrorCode
   > {
     subscribeCleanup: () => void;
 
@@ -135,8 +142,14 @@ export function createMockTransportNetwork(
   }
 
   return {
-    getClientTransport: (id, handshakeOptions) => {
-      const clientTransport = new MockClientTransport(id, opts?.client);
+    getClientTransport: <ApplicationErrorCode extends string = never>(
+      id: TransportClientId,
+      handshakeOptions?: ClientHandshakeOptions<TSchema, ApplicationErrorCode>,
+    ) => {
+      const clientTransport = new MockClientTransport<ApplicationErrorCode>(
+        id,
+        opts?.client,
+      );
       if (handshakeOptions) {
         clientTransport.extendHandshake(handshakeOptions);
       }
@@ -148,15 +161,21 @@ export function createMockTransportNetwork(
     getServerTransport: <
       MetadataSchema extends TSchema = TSchema,
       ParsedMetadata extends object = object,
+      ApplicationErrorCode extends string = never,
     >(
       id = 'SERVER',
       handshakeOptions:
-        | ServerHandshakeOptions<MetadataSchema, ParsedMetadata>
+        | ServerHandshakeOptions<
+            MetadataSchema,
+            ParsedMetadata,
+            ApplicationErrorCode
+          >
         | undefined,
     ) => {
       const serverTransport = new MockServerTransport<
         MetadataSchema,
-        ParsedMetadata
+        ParsedMetadata,
+        ApplicationErrorCode
       >(id, opts?.server);
       if (handshakeOptions) {
         serverTransport.extendHandshake(handshakeOptions);

--- a/testUtil/fixtures/mockTransport.ts
+++ b/testUtil/fixtures/mockTransport.ts
@@ -1,4 +1,5 @@
 import { Transport, TransportClientId } from '../../transport';
+import type { ApplicationErrorCodeSchemas } from '../../transport/message';
 import { ClientTransport } from '../../transport/client';
 import { Connection } from '../../transport/connection';
 import { ServerTransport } from '../../transport/server';
@@ -74,10 +75,12 @@ export function createMockTransportNetwork(
   // conn id -> [client->server, server->client]
   const connections = new Observable<Record<string, BidiConnection>>({});
 
-  const transports: Array<Transport<InMemoryConnection, string>> = [];
+  const transports: Array<
+    Transport<InMemoryConnection, ApplicationErrorCodeSchemas>
+  > = [];
   class MockClientTransport<
-    ApplicationErrorCode extends string = never,
-  > extends ClientTransport<InMemoryConnection, ApplicationErrorCode> {
+    RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+  > extends ClientTransport<InMemoryConnection, RejectionCodeSchemas> {
     async createNewOutgoingConnection(
       to: TransportClientId,
     ): Promise<InMemoryConnection> {
@@ -104,12 +107,12 @@ export function createMockTransportNetwork(
   class MockServerTransport<
     MetadataSchema extends TSchema = TSchema,
     ParsedMetadata extends object = object,
-    ApplicationErrorCode extends string = never,
+    RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
   > extends ServerTransport<
     InMemoryConnection,
     MetadataSchema,
     ParsedMetadata,
-    ApplicationErrorCode
+    RejectionCodeSchemas
   > {
     subscribeCleanup: () => void;
 
@@ -142,11 +145,13 @@ export function createMockTransportNetwork(
   }
 
   return {
-    getClientTransport: <const ApplicationErrorCode extends string = never>(
+    getClientTransport: <
+      RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+    >(
       id: TransportClientId,
-      handshakeOptions?: ClientHandshakeOptions<TSchema, ApplicationErrorCode>,
+      handshakeOptions?: ClientHandshakeOptions<TSchema, RejectionCodeSchemas>,
     ) => {
-      const clientTransport = new MockClientTransport<ApplicationErrorCode>(
+      const clientTransport = new MockClientTransport<RejectionCodeSchemas>(
         id,
         opts?.client,
       );
@@ -161,21 +166,21 @@ export function createMockTransportNetwork(
     getServerTransport: <
       MetadataSchema extends TSchema = TSchema,
       ParsedMetadata extends object = object,
-      const ApplicationErrorCode extends string = never,
+      RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
     >(
       id = 'SERVER',
       handshakeOptions:
         | ServerHandshakeOptions<
             MetadataSchema,
             ParsedMetadata,
-            ApplicationErrorCode
+            RejectionCodeSchemas
           >
         | undefined,
     ) => {
       const serverTransport = new MockServerTransport<
         MetadataSchema,
         ParsedMetadata,
-        ApplicationErrorCode
+        RejectionCodeSchemas
       >(id, opts?.server);
       if (handshakeOptions) {
         serverTransport.extendHandshake(handshakeOptions);

--- a/testUtil/fixtures/transports.ts
+++ b/testUtil/fixtures/transports.ts
@@ -30,14 +30,14 @@ export interface TestTransportOptions {
 }
 
 export interface TestSetupHelpers {
-  getClientTransport: <ApplicationErrorCode extends string = never>(
+  getClientTransport: <const ApplicationErrorCode extends string = never>(
     id: TransportClientId,
     handshakeOptions?: ClientHandshakeOptions<TSchema, ApplicationErrorCode>,
   ) => ClientTransport<Connection, ApplicationErrorCode>;
   getServerTransport: <
     MetadataSchema extends TSchema = TSchema,
     ParsedMetadata extends object = object,
-    ApplicationErrorCode extends string = never,
+    const ApplicationErrorCode extends string = never,
   >(
     id?: TransportClientId,
     handshakeOptions?: ServerHandshakeOptions<
@@ -83,7 +83,7 @@ export const transports: Array<TransportMatrixEntry> = [
             }
           }
         },
-        getClientTransport: <ApplicationErrorCode extends string = never>(
+        getClientTransport: <const ApplicationErrorCode extends string = never>(
           id: TransportClientId,
           handshakeOptions?: ClientHandshakeOptions<
             TSchema,
@@ -117,7 +117,7 @@ export const transports: Array<TransportMatrixEntry> = [
         getServerTransport: <
           MetadataSchema extends TSchema,
           ParsedMetadata extends object,
-          ApplicationErrorCode extends string = never,
+          const ApplicationErrorCode extends string = never,
         >(
           id = 'SERVER',
           handshakeOptions:

--- a/testUtil/fixtures/transports.ts
+++ b/testUtil/fixtures/transports.ts
@@ -17,7 +17,7 @@ import {
   ProvidedServerTransportOptions,
 } from '../../transport/options';
 import {
-  type ApplicationErrorCodeSchemas,
+  type CustomHandshakeErrorCodeSchema,
   TransportClientId,
 } from '../../transport/message';
 import { ClientTransport } from '../../transport/client';
@@ -34,27 +34,27 @@ export interface TestTransportOptions {
 
 export interface TestSetupHelpers {
   getClientTransport: <
-    RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+    RejectionCodeSchema extends CustomHandshakeErrorCodeSchema = never,
   >(
     id: TransportClientId,
-    handshakeOptions?: ClientHandshakeOptions<TSchema, RejectionCodeSchemas>,
-  ) => ClientTransport<Connection, RejectionCodeSchemas>;
+    handshakeOptions?: ClientHandshakeOptions<TSchema, RejectionCodeSchema>,
+  ) => ClientTransport<Connection, RejectionCodeSchema>;
   getServerTransport: <
     MetadataSchema extends TSchema = TSchema,
     ParsedMetadata extends object = object,
-    RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+    RejectionCodeSchema extends CustomHandshakeErrorCodeSchema = never,
   >(
     id?: TransportClientId,
     handshakeOptions?: ServerHandshakeOptions<
       MetadataSchema,
       ParsedMetadata,
-      RejectionCodeSchemas
+      RejectionCodeSchema
     >,
   ) => ServerTransport<
     Connection,
     MetadataSchema,
     ParsedMetadata,
-    RejectionCodeSchemas
+    RejectionCodeSchema
   >;
   simulatePhantomDisconnect: () => void;
   restartServer: () => Promise<void>;
@@ -89,16 +89,16 @@ export const transports: Array<TransportMatrixEntry> = [
           }
         },
         getClientTransport: <
-          RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+          RejectionCodeSchema extends CustomHandshakeErrorCodeSchema,
         >(
           id: TransportClientId,
           handshakeOptions?: ClientHandshakeOptions<
             TSchema,
-            RejectionCodeSchemas
+            RejectionCodeSchema
           >,
         ) => {
           const clientTransport =
-            new WebSocketClientTransport<RejectionCodeSchemas>(
+            new WebSocketClientTransport<RejectionCodeSchema>(
               () => Promise.resolve(createLocalWebSocketClient(port)),
               id,
               opts?.client,
@@ -124,21 +124,21 @@ export const transports: Array<TransportMatrixEntry> = [
         getServerTransport: <
           MetadataSchema extends TSchema,
           ParsedMetadata extends object,
-          RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+          RejectionCodeSchema extends CustomHandshakeErrorCodeSchema,
         >(
           id = 'SERVER',
           handshakeOptions:
             | ServerHandshakeOptions<
                 MetadataSchema,
                 ParsedMetadata,
-                RejectionCodeSchemas
+                RejectionCodeSchema
               >
             | undefined,
         ) => {
           const serverTransport = new WebSocketServerTransport<
             MetadataSchema,
             ParsedMetadata,
-            RejectionCodeSchemas
+            RejectionCodeSchema
           >(wss, id, opts?.server);
 
           serverTransport.bindLogger((msg, ctx, level) => {
@@ -160,7 +160,7 @@ export const transports: Array<TransportMatrixEntry> = [
             Connection,
             MetadataSchema,
             ParsedMetadata,
-            RejectionCodeSchemas
+            RejectionCodeSchema
           >;
         },
         async restartServer() {

--- a/testUtil/fixtures/transports.ts
+++ b/testUtil/fixtures/transports.ts
@@ -16,7 +16,10 @@ import {
   ProvidedClientTransportOptions,
   ProvidedServerTransportOptions,
 } from '../../transport/options';
-import { TransportClientId } from '../../transport/message';
+import {
+  type ApplicationErrorCodeSchemas,
+  TransportClientId,
+} from '../../transport/message';
 import { ClientTransport } from '../../transport/client';
 import { Connection } from '../../transport/connection';
 import { ServerTransport } from '../../transport/server';
@@ -30,26 +33,28 @@ export interface TestTransportOptions {
 }
 
 export interface TestSetupHelpers {
-  getClientTransport: <const ApplicationErrorCode extends string = never>(
+  getClientTransport: <
+    RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+  >(
     id: TransportClientId,
-    handshakeOptions?: ClientHandshakeOptions<TSchema, ApplicationErrorCode>,
-  ) => ClientTransport<Connection, ApplicationErrorCode>;
+    handshakeOptions?: ClientHandshakeOptions<TSchema, RejectionCodeSchemas>,
+  ) => ClientTransport<Connection, RejectionCodeSchemas>;
   getServerTransport: <
     MetadataSchema extends TSchema = TSchema,
     ParsedMetadata extends object = object,
-    const ApplicationErrorCode extends string = never,
+    RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
   >(
     id?: TransportClientId,
     handshakeOptions?: ServerHandshakeOptions<
       MetadataSchema,
       ParsedMetadata,
-      ApplicationErrorCode
+      RejectionCodeSchemas
     >,
   ) => ServerTransport<
     Connection,
     MetadataSchema,
     ParsedMetadata,
-    ApplicationErrorCode
+    RejectionCodeSchemas
   >;
   simulatePhantomDisconnect: () => void;
   restartServer: () => Promise<void>;
@@ -83,15 +88,17 @@ export const transports: Array<TransportMatrixEntry> = [
             }
           }
         },
-        getClientTransport: <const ApplicationErrorCode extends string = never>(
+        getClientTransport: <
+          RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+        >(
           id: TransportClientId,
           handshakeOptions?: ClientHandshakeOptions<
             TSchema,
-            ApplicationErrorCode
+            RejectionCodeSchemas
           >,
         ) => {
           const clientTransport =
-            new WebSocketClientTransport<ApplicationErrorCode>(
+            new WebSocketClientTransport<RejectionCodeSchemas>(
               () => Promise.resolve(createLocalWebSocketClient(port)),
               id,
               opts?.client,
@@ -117,21 +124,21 @@ export const transports: Array<TransportMatrixEntry> = [
         getServerTransport: <
           MetadataSchema extends TSchema,
           ParsedMetadata extends object,
-          const ApplicationErrorCode extends string = never,
+          RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
         >(
           id = 'SERVER',
           handshakeOptions:
             | ServerHandshakeOptions<
                 MetadataSchema,
                 ParsedMetadata,
-                ApplicationErrorCode
+                RejectionCodeSchemas
               >
             | undefined,
         ) => {
           const serverTransport = new WebSocketServerTransport<
             MetadataSchema,
             ParsedMetadata,
-            ApplicationErrorCode
+            RejectionCodeSchemas
           >(wss, id, opts?.server);
 
           serverTransport.bindLogger((msg, ctx, level) => {
@@ -153,7 +160,7 @@ export const transports: Array<TransportMatrixEntry> = [
             Connection,
             MetadataSchema,
             ParsedMetadata,
-            ApplicationErrorCode
+            RejectionCodeSchemas
           >;
         },
         async restartServer() {

--- a/testUtil/fixtures/transports.ts
+++ b/testUtil/fixtures/transports.ts
@@ -30,17 +30,27 @@ export interface TestTransportOptions {
 }
 
 export interface TestSetupHelpers {
-  getClientTransport: (
+  getClientTransport: <ApplicationErrorCode extends string = never>(
     id: TransportClientId,
-    handshakeOptions?: ClientHandshakeOptions,
-  ) => ClientTransport<Connection>;
+    handshakeOptions?: ClientHandshakeOptions<TSchema, ApplicationErrorCode>,
+  ) => ClientTransport<Connection, ApplicationErrorCode>;
   getServerTransport: <
     MetadataSchema extends TSchema = TSchema,
     ParsedMetadata extends object = object,
+    ApplicationErrorCode extends string = never,
   >(
     id?: TransportClientId,
-    handshakeOptions?: ServerHandshakeOptions<MetadataSchema, ParsedMetadata>,
-  ) => ServerTransport<Connection, MetadataSchema, ParsedMetadata>;
+    handshakeOptions?: ServerHandshakeOptions<
+      MetadataSchema,
+      ParsedMetadata,
+      ApplicationErrorCode
+    >,
+  ) => ServerTransport<
+    Connection,
+    MetadataSchema,
+    ParsedMetadata,
+    ApplicationErrorCode
+  >;
   simulatePhantomDisconnect: () => void;
   restartServer: () => Promise<void>;
   cleanup: () => Promise<void> | void;
@@ -59,10 +69,11 @@ export const transports: Array<TransportMatrixEntry> = [
       const port = await onWsServerReady(server);
       let wss = createWebSocketServer(server);
 
+      /* eslint-disable @typescript-eslint/no-explicit-any */
       const transports: Array<
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        WebSocketClientTransport | WebSocketServerTransport<any, any>
+        WebSocketClientTransport<any> | WebSocketServerTransport<any, any, any>
       > = [];
+      /* eslint-enable @typescript-eslint/no-explicit-any */
 
       return {
         simulatePhantomDisconnect() {
@@ -72,12 +83,19 @@ export const transports: Array<TransportMatrixEntry> = [
             }
           }
         },
-        getClientTransport: (id, handshakeOptions) => {
-          const clientTransport = new WebSocketClientTransport(
-            () => Promise.resolve(createLocalWebSocketClient(port)),
-            id,
-            opts?.client,
-          );
+        getClientTransport: <ApplicationErrorCode extends string = never>(
+          id: TransportClientId,
+          handshakeOptions?: ClientHandshakeOptions<
+            TSchema,
+            ApplicationErrorCode
+          >,
+        ) => {
+          const clientTransport =
+            new WebSocketClientTransport<ApplicationErrorCode>(
+              () => Promise.resolve(createLocalWebSocketClient(port)),
+              id,
+              opts?.client,
+            );
 
           if (handshakeOptions) {
             clientTransport.extendHandshake(handshakeOptions);
@@ -99,15 +117,21 @@ export const transports: Array<TransportMatrixEntry> = [
         getServerTransport: <
           MetadataSchema extends TSchema,
           ParsedMetadata extends object,
+          ApplicationErrorCode extends string = never,
         >(
           id = 'SERVER',
           handshakeOptions:
-            | ServerHandshakeOptions<MetadataSchema, ParsedMetadata>
+            | ServerHandshakeOptions<
+                MetadataSchema,
+                ParsedMetadata,
+                ApplicationErrorCode
+              >
             | undefined,
         ) => {
           const serverTransport = new WebSocketServerTransport<
             MetadataSchema,
-            ParsedMetadata
+            ParsedMetadata,
+            ApplicationErrorCode
           >(wss, id, opts?.server);
 
           serverTransport.bindLogger((msg, ctx, level) => {
@@ -128,7 +152,8 @@ export const transports: Array<TransportMatrixEntry> = [
           return serverTransport as ServerTransport<
             Connection,
             MetadataSchema,
-            ParsedMetadata
+            ParsedMetadata,
+            ApplicationErrorCode
           >;
         },
         async restartServer() {

--- a/testUtil/index.ts
+++ b/testUtil/index.ts
@@ -2,6 +2,7 @@ import NodeWs, { WebSocketServer } from 'ws';
 import http from 'node:http';
 import type { Static } from 'typebox';
 import {
+  type CustomHandshakeErrorCodeSchema,
   OpaqueTransportMessage,
   PartialTransportMessage,
   currentProtocolVersion,
@@ -18,7 +19,6 @@ import { SessionState } from '../transport/sessionStateMachine/common';
 import { SessionStateGraph } from '../transport/sessionStateMachine/transitions';
 import { BaseErrorSchemaType } from '../router/errors';
 import { ClientTransport } from '../transport/client';
-import { ServerTransport } from '../transport/server';
 import { getTracer } from '../tracing';
 
 export {
@@ -194,9 +194,11 @@ export function dummySession() {
   );
 }
 
-export function getClientSendFn(
-  clientTransport: ClientTransport<Connection>,
-  serverTransport: ServerTransport<Connection>,
+export function getClientSendFn<
+  ClientRejectionCodeSchema extends CustomHandshakeErrorCodeSchema,
+>(
+  clientTransport: ClientTransport<Connection, ClientRejectionCodeSchema>,
+  serverTransport: { clientId: string },
 ) {
   const session =
     clientTransport.sessions.get(serverTransport.clientId) ??
@@ -208,9 +210,9 @@ export function getClientSendFn(
   );
 }
 
-export function getServerSendFn(
-  serverTransport: ServerTransport<Connection>,
-  clientTransport: ClientTransport<Connection>,
+export function getServerSendFn<HandshakeFailureCode extends string>(
+  serverTransport: Transport<Connection, HandshakeFailureCode>,
+  clientTransport: { clientId: string },
 ) {
   const session = serverTransport.sessions.get(clientTransport.clientId);
   if (!session) {
@@ -223,9 +225,10 @@ export function getServerSendFn(
   );
 }
 
-export function getTransportConnections<ConnType extends Connection>(
-  transport: Transport<ConnType>,
-): Array<ConnType> {
+export function getTransportConnections<
+  ConnType extends Connection,
+  HandshakeFailureCode extends string,
+>(transport: Transport<ConnType, HandshakeFailureCode>): Array<ConnType> {
   const connections = [];
   for (const session of transport.sessions.values()) {
     if (session.state === SessionState.Connected) {
@@ -236,15 +239,17 @@ export function getTransportConnections<ConnType extends Connection>(
   return connections;
 }
 
-export function numberOfConnections<ConnType extends Connection>(
-  transport: Transport<ConnType>,
-): number {
+export function numberOfConnections<
+  ConnType extends Connection,
+  HandshakeFailureCode extends string,
+>(transport: Transport<ConnType, HandshakeFailureCode>): number {
   return getTransportConnections(transport).length;
 }
 
-export function closeAllConnections<ConnType extends Connection>(
-  transport: Transport<ConnType>,
-) {
+export function closeAllConnections<
+  ConnType extends Connection,
+  HandshakeFailureCode extends string,
+>(transport: Transport<ConnType, HandshakeFailureCode>) {
   for (const conn of getTransportConnections(transport)) {
     conn.close();
   }

--- a/transport/client.ts
+++ b/transport/client.ts
@@ -3,7 +3,9 @@ import { ClientHandshakeOptions } from '../router/handshake';
 import { validationErrorToRiverErrors } from '../router/errors';
 import {
   ControlMessageHandshakeResponseSchema,
+  ControlMessageHandshakeResponseSchemaWithCodes,
   ControlMessageRehandshakeRequestSchema,
+  type HandshakeErrorCode,
   HandshakeErrorRetriableResponseCodes,
   OpaqueTransportMessage,
   TransportClientId,
@@ -11,6 +13,8 @@ import {
   handshakeRequestMessage,
   rehandshakeResponseMessage,
 } from './message';
+
+import type { TSchema } from 'typebox';
 import {
   ClientTransportOptions,
   ProvidedClientTransportOptions,
@@ -50,7 +54,8 @@ type ConstructedHandshakeMetadata =
 
 export abstract class ClientTransport<
   ConnType extends Connection,
-> extends Transport<ConnType> {
+  ApplicationErrorCode extends string = never,
+> extends Transport<ConnType, ApplicationErrorCode> {
   /**
    * The options for this transport.
    */
@@ -69,7 +74,16 @@ export abstract class ClientTransport<
   /**
    * Optional handshake options for this client.
    */
-  handshakeExtensions?: ClientHandshakeOptions;
+  handshakeExtensions?: ClientHandshakeOptions<TSchema, ApplicationErrorCode>;
+
+  /**
+   * Handshake response schema extended with the application-defined
+   * rejection codes, when any are registered.
+   */
+  protected handshakeResponseSchema:
+    | typeof ControlMessageHandshakeResponseSchema
+    | ReturnType<typeof ControlMessageHandshakeResponseSchemaWithCodes> =
+    ControlMessageHandshakeResponseSchema;
 
   /**
    * Handshake-metadata constructions prefetched when a connection attempt begins
@@ -98,8 +112,14 @@ export abstract class ClientTransport<
     this.retryBudget = new LeakyBucketRateLimit(this.options);
   }
 
-  extendHandshake(options: ClientHandshakeOptions) {
+  extendHandshake(
+    options: ClientHandshakeOptions<TSchema, ApplicationErrorCode>,
+  ) {
     this.handshakeExtensions = options;
+    if (options.rejectionCodes?.length) {
+      this.handshakeResponseSchema =
+        ControlMessageHandshakeResponseSchemaWithCodes(options.rejectionCodes);
+    }
   }
 
   protected handleRehandshakeMessage(message: OpaqueTransportMessage): void {
@@ -355,13 +375,13 @@ export abstract class ClientTransport<
     msg: OpaqueTransportMessage,
   ) {
     // invariant: msg is a handshake response
-    if (!Value.Check(ControlMessageHandshakeResponseSchema, msg.payload)) {
+    if (!Value.Check(this.handshakeResponseSchema, msg.payload)) {
       const reason = `received invalid handshake response`;
       this.rejectHandshakeResponse(session, reason, {
         ...session.loggingMetadata,
         transportMessage: msg,
         validationErrors: Value.Errors(
-          ControlMessageHandshakeResponseSchema,
+          this.handshakeResponseSchema,
           msg.payload,
         ).flatMap(validationErrorToRiverErrors),
       });
@@ -388,7 +408,8 @@ export abstract class ClientTransport<
       } else {
         this.protocolError({
           type: ProtocolError.HandshakeFailed,
-          code: msg.payload.status.code,
+          code: msg.payload.status
+            .code as HandshakeErrorCode<ApplicationErrorCode>,
           message: reason,
         });
       }

--- a/transport/client.ts
+++ b/transport/client.ts
@@ -115,9 +115,11 @@ export abstract class ClientTransport<
     options: ClientHandshakeOptions<TSchema, ApplicationErrorCode>,
   ) {
     this.handshakeExtensions = options;
-    if (options.rejectionCodes?.length) {
+    if (options.rejectionCodeSchemas?.length) {
       this.handshakeResponseSchema =
-        ControlMessageHandshakeResponseSchemaWithCodes(options.rejectionCodes);
+        ControlMessageHandshakeResponseSchemaWithCodes(
+          options.rejectionCodeSchemas,
+        );
     }
   }
 

--- a/transport/client.ts
+++ b/transport/client.ts
@@ -5,7 +5,7 @@ import {
   ControlMessageHandshakeResponseSchema,
   ControlMessageHandshakeResponseSchemaWithCodes,
   ControlMessageRehandshakeRequestSchema,
-  type ApplicationErrorCodeSchemas,
+  type CustomHandshakeErrorCodeSchema,
   type HandshakeErrorCode,
   HandshakeErrorRetriableResponseCodes,
   OpaqueTransportMessage,
@@ -54,8 +54,8 @@ type ConstructedHandshakeMetadata =
 
 export abstract class ClientTransport<
   ConnType extends Connection,
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
-> extends Transport<ConnType, RejectionCodeSchemas> {
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema = never,
+> extends Transport<ConnType, HandshakeErrorCode<RejectionCodeSchema>> {
   /**
    * The options for this transport.
    */
@@ -74,10 +74,10 @@ export abstract class ClientTransport<
   /**
    * Optional handshake options for this client.
    */
-  handshakeExtensions?: ClientHandshakeOptions<TSchema, RejectionCodeSchemas>;
+  handshakeExtensions?: ClientHandshakeOptions<TSchema, RejectionCodeSchema>;
 
   /**
-   * Handshake response schema extended with the application-defined
+   * Handshake response schema extended with the custom
    * rejection codes, when any are registered.
    */
   protected handshakeResponseSchema:
@@ -112,17 +112,17 @@ export abstract class ClientTransport<
     this.retryBudget = new LeakyBucketRateLimit(this.options);
   }
 
-  extendHandshake(
-    options: ClientHandshakeOptions<TSchema, RejectionCodeSchemas>,
-  ) {
+  extendHandshake = (
+    options: ClientHandshakeOptions<TSchema, RejectionCodeSchema>,
+  ) => {
     this.handshakeExtensions = options;
-    if (options.rejectionCodeSchemas?.length) {
+    if (options.rejectionCodeSchema) {
       this.handshakeResponseSchema =
         ControlMessageHandshakeResponseSchemaWithCodes(
-          options.rejectionCodeSchemas,
+          options.rejectionCodeSchema,
         );
     }
-  }
+  };
 
   protected handleRehandshakeMessage(message: OpaqueTransportMessage): void {
     if (!Value.Check(ControlMessageRehandshakeRequestSchema, message.payload)) {
@@ -411,7 +411,7 @@ export abstract class ClientTransport<
         this.protocolError({
           type: ProtocolError.HandshakeFailed,
           code: msg.payload.status
-            .code as HandshakeErrorCode<RejectionCodeSchemas>,
+            .code as HandshakeErrorCode<RejectionCodeSchema>,
           message: reason,
         });
       }

--- a/transport/client.ts
+++ b/transport/client.ts
@@ -13,7 +13,6 @@ import {
   handshakeRequestMessage,
   rehandshakeResponseMessage,
 } from './message';
-
 import type { TSchema } from 'typebox';
 import {
   ClientTransportOptions,

--- a/transport/client.ts
+++ b/transport/client.ts
@@ -5,6 +5,7 @@ import {
   ControlMessageHandshakeResponseSchema,
   ControlMessageHandshakeResponseSchemaWithCodes,
   ControlMessageRehandshakeRequestSchema,
+  type ApplicationErrorCodeSchemas,
   type HandshakeErrorCode,
   HandshakeErrorRetriableResponseCodes,
   OpaqueTransportMessage,
@@ -53,8 +54,8 @@ type ConstructedHandshakeMetadata =
 
 export abstract class ClientTransport<
   ConnType extends Connection,
-  ApplicationErrorCode extends string = never,
-> extends Transport<ConnType, ApplicationErrorCode> {
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+> extends Transport<ConnType, RejectionCodeSchemas> {
   /**
    * The options for this transport.
    */
@@ -73,7 +74,7 @@ export abstract class ClientTransport<
   /**
    * Optional handshake options for this client.
    */
-  handshakeExtensions?: ClientHandshakeOptions<TSchema, ApplicationErrorCode>;
+  handshakeExtensions?: ClientHandshakeOptions<TSchema, RejectionCodeSchemas>;
 
   /**
    * Handshake response schema extended with the application-defined
@@ -112,7 +113,7 @@ export abstract class ClientTransport<
   }
 
   extendHandshake(
-    options: ClientHandshakeOptions<TSchema, ApplicationErrorCode>,
+    options: ClientHandshakeOptions<TSchema, RejectionCodeSchemas>,
   ) {
     this.handshakeExtensions = options;
     if (options.rejectionCodeSchemas?.length) {
@@ -410,7 +411,7 @@ export abstract class ClientTransport<
         this.protocolError({
           type: ProtocolError.HandshakeFailed,
           code: msg.payload.status
-            .code as HandshakeErrorCode<ApplicationErrorCode>,
+            .code as HandshakeErrorCode<RejectionCodeSchemas>,
           message: reason,
         });
       }

--- a/transport/events.ts
+++ b/transport/events.ts
@@ -89,7 +89,7 @@ export class EventDispatcher<
       this.eventListeners[eventType] = new Set();
     }
 
-    this.eventListeners[eventType].add(handler);
+    this.eventListeners[eventType]?.add(handler);
   }
 
   removeEventListener<K extends T>(

--- a/transport/events.ts
+++ b/transport/events.ts
@@ -1,7 +1,6 @@
 import { Connection } from './connection';
 import type {
-  ApplicationErrorCodeSchemas,
-  HandshakeErrorCode,
+  BuiltInHandshakeErrorCode,
   OpaqueTransportMessage,
 } from './message';
 import { Session, SessionState } from './sessionStateMachine';
@@ -19,8 +18,12 @@ export const ProtocolError = {
 export type ProtocolErrorType =
   (typeof ProtocolError)[keyof typeof ProtocolError];
 
+/**
+ * Transport events. `HandshakeFailureCode` is the full set of codes observable
+ * on handshake-failed protocol errors, including built-in and custom codes.
+ */
 export interface EventMap<
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+  HandshakeFailureCode extends string = BuiltInHandshakeErrorCode,
 > {
   message: OpaqueTransportMessage;
   sessionStatus:
@@ -41,7 +44,7 @@ export interface EventMap<
   protocolError:
     | {
         type: (typeof ProtocolError)['HandshakeFailed'];
-        code: HandshakeErrorCode<RejectionCodeSchemas>;
+        code: HandshakeFailureCode;
         message: string;
       }
     | {
@@ -59,15 +62,15 @@ export interface EventMap<
 export type EventTypes = keyof EventMap;
 export type EventHandler<
   K extends EventTypes,
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
-> = (event: EventMap<RejectionCodeSchemas>[K]) => unknown;
+  HandshakeFailureCode extends string = BuiltInHandshakeErrorCode,
+> = (event: EventMap<HandshakeFailureCode>[K]) => unknown;
 
 export class EventDispatcher<
   T extends EventTypes,
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+  HandshakeFailureCode extends string,
 > {
   private eventListeners: {
-    [K in T]?: Set<EventHandler<K, RejectionCodeSchemas>>;
+    [K in T]?: Set<EventHandler<K, HandshakeFailureCode>>;
   } = {};
 
   removeAllListeners() {
@@ -80,18 +83,18 @@ export class EventDispatcher<
 
   addEventListener<K extends T>(
     eventType: K,
-    handler: EventHandler<K, RejectionCodeSchemas>,
+    handler: EventHandler<K, HandshakeFailureCode>,
   ) {
     if (!this.eventListeners[eventType]) {
       this.eventListeners[eventType] = new Set();
     }
 
-    this.eventListeners[eventType]?.add(handler);
+    this.eventListeners[eventType].add(handler);
   }
 
   removeEventListener<K extends T>(
     eventType: K,
-    handler: EventHandler<K, RejectionCodeSchemas>,
+    handler: EventHandler<K, HandshakeFailureCode>,
   ) {
     const handlers = this.eventListeners[eventType];
     if (handlers) {
@@ -101,7 +104,7 @@ export class EventDispatcher<
 
   dispatchEvent<K extends T>(
     eventType: K,
-    event: EventMap<RejectionCodeSchemas>[K],
+    event: EventMap<HandshakeFailureCode>[K],
   ) {
     const handlers = this.eventListeners[eventType];
     if (handlers) {

--- a/transport/events.ts
+++ b/transport/events.ts
@@ -1,6 +1,5 @@
-import type { Static } from 'typebox';
 import { Connection } from './connection';
-import { OpaqueTransportMessage, HandshakeErrorResponseCodes } from './message';
+import { OpaqueTransportMessage, HandshakeErrorCode } from './message';
 import { Session, SessionState } from './sessionStateMachine';
 import { SessionId } from './sessionStateMachine/common';
 import { TransportStatus } from './transport';
@@ -16,7 +15,7 @@ export const ProtocolError = {
 export type ProtocolErrorType =
   (typeof ProtocolError)[keyof typeof ProtocolError];
 
-export interface EventMap {
+export interface EventMap<ApplicationErrorCode extends string = never> {
   message: OpaqueTransportMessage;
   sessionStatus:
     | {
@@ -36,7 +35,7 @@ export interface EventMap {
   protocolError:
     | {
         type: (typeof ProtocolError)['HandshakeFailed'];
-        code: Static<typeof HandshakeErrorResponseCodes>;
+        code: HandshakeErrorCode<ApplicationErrorCode>;
         message: string;
       }
     | {
@@ -52,12 +51,18 @@ export interface EventMap {
 }
 
 export type EventTypes = keyof EventMap;
-export type EventHandler<K extends EventTypes> = (
-  event: EventMap[K],
-) => unknown;
+export type EventHandler<
+  K extends EventTypes,
+  ApplicationErrorCode extends string = never,
+> = (event: EventMap<ApplicationErrorCode>[K]) => unknown;
 
-export class EventDispatcher<T extends EventTypes> {
-  private eventListeners: { [K in T]?: Set<EventHandler<K>> } = {};
+export class EventDispatcher<
+  T extends EventTypes,
+  ApplicationErrorCode extends string = never,
+> {
+  private eventListeners: {
+    [K in T]?: Set<EventHandler<K, ApplicationErrorCode>>;
+  } = {};
 
   removeAllListeners() {
     this.eventListeners = {};
@@ -67,7 +72,10 @@ export class EventDispatcher<T extends EventTypes> {
     return this.eventListeners[eventType]?.size ?? 0;
   }
 
-  addEventListener<K extends T>(eventType: K, handler: EventHandler<K>) {
+  addEventListener<K extends T>(
+    eventType: K,
+    handler: EventHandler<K, ApplicationErrorCode>,
+  ) {
     if (!this.eventListeners[eventType]) {
       this.eventListeners[eventType] = new Set();
     }
@@ -75,14 +83,20 @@ export class EventDispatcher<T extends EventTypes> {
     this.eventListeners[eventType]?.add(handler);
   }
 
-  removeEventListener<K extends T>(eventType: K, handler: EventHandler<K>) {
+  removeEventListener<K extends T>(
+    eventType: K,
+    handler: EventHandler<K, ApplicationErrorCode>,
+  ) {
     const handlers = this.eventListeners[eventType];
     if (handlers) {
       this.eventListeners[eventType]?.delete(handler);
     }
   }
 
-  dispatchEvent<K extends T>(eventType: K, event: EventMap[K]) {
+  dispatchEvent<K extends T>(
+    eventType: K,
+    event: EventMap<ApplicationErrorCode>[K],
+  ) {
     const handlers = this.eventListeners[eventType];
     if (handlers) {
       // copying ensures that adding more listeners in a handler doesn't

--- a/transport/events.ts
+++ b/transport/events.ts
@@ -85,11 +85,13 @@ export class EventDispatcher<
     eventType: K,
     handler: EventHandler<K, HandshakeFailureCode>,
   ) {
-    if (!this.eventListeners[eventType]) {
-      this.eventListeners[eventType] = new Set();
+    let listeners = this.eventListeners[eventType];
+    if (!listeners) {
+      listeners = new Set();
+      this.eventListeners[eventType] = listeners;
     }
 
-    this.eventListeners[eventType]?.add(handler);
+    listeners.add(handler);
   }
 
   removeEventListener<K extends T>(

--- a/transport/events.ts
+++ b/transport/events.ts
@@ -1,5 +1,9 @@
 import { Connection } from './connection';
-import { OpaqueTransportMessage, HandshakeErrorCode } from './message';
+import type {
+  ApplicationErrorCodeSchemas,
+  HandshakeErrorCode,
+  OpaqueTransportMessage,
+} from './message';
 import { Session, SessionState } from './sessionStateMachine';
 import { SessionId } from './sessionStateMachine/common';
 import { TransportStatus } from './transport';
@@ -15,7 +19,9 @@ export const ProtocolError = {
 export type ProtocolErrorType =
   (typeof ProtocolError)[keyof typeof ProtocolError];
 
-export interface EventMap<ApplicationErrorCode extends string = never> {
+export interface EventMap<
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+> {
   message: OpaqueTransportMessage;
   sessionStatus:
     | {
@@ -35,7 +41,7 @@ export interface EventMap<ApplicationErrorCode extends string = never> {
   protocolError:
     | {
         type: (typeof ProtocolError)['HandshakeFailed'];
-        code: HandshakeErrorCode<ApplicationErrorCode>;
+        code: HandshakeErrorCode<RejectionCodeSchemas>;
         message: string;
       }
     | {
@@ -53,15 +59,15 @@ export interface EventMap<ApplicationErrorCode extends string = never> {
 export type EventTypes = keyof EventMap;
 export type EventHandler<
   K extends EventTypes,
-  ApplicationErrorCode extends string = never,
-> = (event: EventMap<ApplicationErrorCode>[K]) => unknown;
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+> = (event: EventMap<RejectionCodeSchemas>[K]) => unknown;
 
 export class EventDispatcher<
   T extends EventTypes,
-  ApplicationErrorCode extends string = never,
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
 > {
   private eventListeners: {
-    [K in T]?: Set<EventHandler<K, ApplicationErrorCode>>;
+    [K in T]?: Set<EventHandler<K, RejectionCodeSchemas>>;
   } = {};
 
   removeAllListeners() {
@@ -74,7 +80,7 @@ export class EventDispatcher<
 
   addEventListener<K extends T>(
     eventType: K,
-    handler: EventHandler<K, ApplicationErrorCode>,
+    handler: EventHandler<K, RejectionCodeSchemas>,
   ) {
     if (!this.eventListeners[eventType]) {
       this.eventListeners[eventType] = new Set();
@@ -85,7 +91,7 @@ export class EventDispatcher<
 
   removeEventListener<K extends T>(
     eventType: K,
-    handler: EventHandler<K, ApplicationErrorCode>,
+    handler: EventHandler<K, RejectionCodeSchemas>,
   ) {
     const handlers = this.eventListeners[eventType];
     if (handlers) {
@@ -95,7 +101,7 @@ export class EventDispatcher<
 
   dispatchEvent<K extends T>(
     eventType: K,
-    event: EventMap<ApplicationErrorCode>[K],
+    event: EventMap<RejectionCodeSchemas>[K],
   ) {
     const handlers = this.eventListeners[eventType];
     if (handlers) {

--- a/transport/impls/ws/client.ts
+++ b/transport/impls/ws/client.ts
@@ -1,6 +1,6 @@
 import { ClientTransport } from '../../client';
 import {
-  type ApplicationErrorCodeSchemas,
+  type CustomHandshakeErrorCodeSchema,
   TransportClientId,
 } from '../../message';
 import { ProvidedClientTransportOptions } from '../../options';
@@ -13,8 +13,8 @@ import { WsLike } from './wslike';
  * @extends Transport
  */
 export class WebSocketClientTransport<
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
-> extends ClientTransport<WebSocketConnection, RejectionCodeSchemas> {
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema = never,
+> extends ClientTransport<WebSocketConnection, RejectionCodeSchema> {
   /**
    * A function that returns a Promise that resolves to a websocket URL.
    */

--- a/transport/impls/ws/client.ts
+++ b/transport/impls/ws/client.ts
@@ -9,7 +9,9 @@ import { WsLike } from './wslike';
  * @class
  * @extends Transport
  */
-export class WebSocketClientTransport extends ClientTransport<WebSocketConnection> {
+export class WebSocketClientTransport<
+  ApplicationErrorCode extends string = never,
+> extends ClientTransport<WebSocketConnection, ApplicationErrorCode> {
   /**
    * A function that returns a Promise that resolves to a websocket URL.
    */

--- a/transport/impls/ws/client.ts
+++ b/transport/impls/ws/client.ts
@@ -1,5 +1,8 @@
 import { ClientTransport } from '../../client';
-import { TransportClientId } from '../../message';
+import {
+  type ApplicationErrorCodeSchemas,
+  TransportClientId,
+} from '../../message';
 import { ProvidedClientTransportOptions } from '../../options';
 import { WebSocketConnection } from './connection';
 import { WsLike } from './wslike';
@@ -10,8 +13,8 @@ import { WsLike } from './wslike';
  * @extends Transport
  */
 export class WebSocketClientTransport<
-  ApplicationErrorCode extends string = never,
-> extends ClientTransport<WebSocketConnection, ApplicationErrorCode> {
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+> extends ClientTransport<WebSocketConnection, RejectionCodeSchemas> {
   /**
    * A function that returns a Promise that resolves to a websocket URL.
    */

--- a/transport/impls/ws/server.ts
+++ b/transport/impls/ws/server.ts
@@ -1,5 +1,5 @@
 import {
-  type ApplicationErrorCodeSchemas,
+  type CustomHandshakeErrorCodeSchema,
   TransportClientId,
 } from '../../message';
 import { WebSocketServer } from 'ws';
@@ -28,12 +28,12 @@ function cleanHeaders(
 export class WebSocketServerTransport<
   MetadataSchema extends TSchema = TSchema,
   ParsedMetadata extends object = object,
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema = never,
 > extends ServerTransport<
   WebSocketConnection,
   MetadataSchema,
   ParsedMetadata,
-  RejectionCodeSchemas
+  RejectionCodeSchema
 > {
   wss: WebSocketServer;
 

--- a/transport/impls/ws/server.ts
+++ b/transport/impls/ws/server.ts
@@ -1,4 +1,7 @@
-import { TransportClientId } from '../../message';
+import {
+  type ApplicationErrorCodeSchemas,
+  TransportClientId,
+} from '../../message';
 import { WebSocketServer } from 'ws';
 import { WebSocketConnection } from './connection';
 import { WsLike } from './wslike';
@@ -25,12 +28,12 @@ function cleanHeaders(
 export class WebSocketServerTransport<
   MetadataSchema extends TSchema = TSchema,
   ParsedMetadata extends object = object,
-  ApplicationErrorCode extends string = never,
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
 > extends ServerTransport<
   WebSocketConnection,
   MetadataSchema,
   ParsedMetadata,
-  ApplicationErrorCode
+  RejectionCodeSchemas
 > {
   wss: WebSocketServer;
 

--- a/transport/impls/ws/server.ts
+++ b/transport/impls/ws/server.ts
@@ -25,7 +25,13 @@ function cleanHeaders(
 export class WebSocketServerTransport<
   MetadataSchema extends TSchema = TSchema,
   ParsedMetadata extends object = object,
-> extends ServerTransport<WebSocketConnection, MetadataSchema, ParsedMetadata> {
+  ApplicationErrorCode extends string = never,
+> extends ServerTransport<
+  WebSocketConnection,
+  MetadataSchema,
+  ParsedMetadata,
+  ApplicationErrorCode
+> {
   wss: WebSocketServer;
 
   constructor(

--- a/transport/impls/ws/ws.test.ts
+++ b/transport/impls/ws/ws.test.ts
@@ -1,5 +1,6 @@
 import http from 'node:http';
 import { describe, test, expect, beforeEach } from 'vitest';
+import { Type } from 'typebox';
 import {
   createWebSocketServer,
   onWsServerReady,
@@ -23,6 +24,7 @@ import {
 import { PartialTransportMessage } from '../../message';
 import type NodeWs from 'ws';
 import { createPostTestCleanups } from '../../../testUtil/fixtures/cleanup';
+import { createClientHandshakeOptions } from '../../../router/handshake';
 
 describe('sending and receiving across websockets works', async () => {
   let server: http.Server;
@@ -40,6 +42,33 @@ describe('sending and receiving across websockets works', async () => {
       wss.close();
       server.close();
     };
+  });
+
+  test('custom handshake codes require an explicit transport type', () => {
+    const rejectionCodeSchema = Type.Union([Type.Literal('TOKEN_EXPIRED')]);
+    const handshakeOptions = createClientHandshakeOptions(
+      Type.Object({}),
+      () => ({}),
+      undefined,
+      rejectionCodeSchema,
+    );
+    const getWs = () => {
+      throw new Error('not called');
+    };
+    const defaultTransport = new WebSocketClientTransport(getWs, 'client');
+
+    // @ts-expect-error a default transport cannot be widened to custom codes
+    const widenedTransport: WebSocketClientTransport<
+      typeof rejectionCodeSchema
+    > = defaultTransport;
+
+    const typedTransport = new WebSocketClientTransport<
+      typeof rejectionCodeSchema
+    >(getWs, 'client');
+    typedTransport.extendHandshake(handshakeOptions);
+
+    expect(typedTransport.handshakeExtensions).toBe(handshakeOptions);
+    expect(widenedTransport).toBe(defaultTransport);
   });
 
   test('basic send/receive', async () => {

--- a/transport/index.ts
+++ b/transport/index.ts
@@ -28,6 +28,7 @@ export {
   isStreamClose,
 } from './message';
 export type {
+  HandshakeErrorCode,
   TransportMessage,
   OpaqueTransportMessage,
   TransportClientId,

--- a/transport/index.ts
+++ b/transport/index.ts
@@ -28,7 +28,6 @@ export {
   isStreamClose,
 } from './message';
 export type {
-  HandshakeErrorCode,
   TransportMessage,
   OpaqueTransportMessage,
   TransportClientId,

--- a/transport/message.test.ts
+++ b/transport/message.test.ts
@@ -10,6 +10,7 @@ import {
   isStreamOpen,
 } from './message';
 import { describe, test, expect } from 'vitest';
+import { Type } from 'typebox';
 import { Value } from 'typebox/value';
 
 const msg = (
@@ -110,8 +111,8 @@ describe('message helpers', () => {
 
   test('handshake response schema with application codes', () => {
     const extended = ControlMessageHandshakeResponseSchemaWithCodes([
-      'REPL_NOT_FOUND',
-      'TOKEN_EXPIRED',
+      Type.Literal('REPL_NOT_FOUND'),
+      Type.Literal('TOKEN_EXPIRED'),
     ] as const);
     const rejection = {
       type: 'HANDSHAKE_RESP',

--- a/transport/message.test.ts
+++ b/transport/message.test.ts
@@ -1,6 +1,8 @@
 import { TransportMessage } from '.';
 import {
   ControlFlags,
+  ControlMessageHandshakeResponseSchema,
+  ControlMessageHandshakeResponseSchemaWithCodes,
   handshakeRequestMessage,
   handshakeResponseMessage,
   isAck,
@@ -8,6 +10,7 @@ import {
   isStreamOpen,
 } from './message';
 import { describe, test, expect } from 'vitest';
+import { Value } from 'typebox/value';
 
 const msg = (
   to: string,
@@ -103,6 +106,49 @@ describe('message helpers', () => {
     expect(mFail.from).toBe('a');
     expect(mFail.to).toBe('b');
     expect(mFail.payload.status.ok).toBe(false);
+  });
+
+  test('handshake response schema with application codes', () => {
+    const extended = ControlMessageHandshakeResponseSchemaWithCodes([
+      'REPL_NOT_FOUND',
+      'TOKEN_EXPIRED',
+    ] as const);
+    const rejection = {
+      type: 'HANDSHAKE_RESP',
+      status: {
+        ok: false,
+        reason: 'rejected by handshake handler',
+        code: 'REPL_NOT_FOUND',
+      },
+    };
+    const protocolFailure = {
+      type: 'HANDSHAKE_RESP',
+      status: {
+        ok: false,
+        reason: 'bad',
+        code: 'SESSION_STATE_MISMATCH',
+      },
+    };
+    const unknownCode = {
+      type: 'HANDSHAKE_RESP',
+      status: {
+        ok: false,
+        reason: 'bad',
+        code: 'NOT_A_REGISTERED_CODE',
+      },
+    };
+
+    expect(Value.Check(extended, rejection)).toBe(true);
+    expect(Value.Check(extended, protocolFailure)).toBe(true);
+    expect(Value.Check(extended, unknownCode)).toBe(false);
+
+    // the base schema only knows the protocol-level codes
+    expect(Value.Check(ControlMessageHandshakeResponseSchema, rejection)).toBe(
+      false,
+    );
+    expect(
+      Value.Check(ControlMessageHandshakeResponseSchema, protocolFailure),
+    ).toBe(true);
   });
 
   test('default message has no control flags set', () => {

--- a/transport/message.test.ts
+++ b/transport/message.test.ts
@@ -109,11 +109,13 @@ describe('message helpers', () => {
     expect(mFail.payload.status.ok).toBe(false);
   });
 
-  test('handshake response schema with application codes', () => {
-    const extended = ControlMessageHandshakeResponseSchemaWithCodes([
-      Type.Literal('REPL_NOT_FOUND'),
-      Type.Literal('TOKEN_EXPIRED'),
-    ] as const);
+  test('handshake response schema with custom error codes', () => {
+    const extended = ControlMessageHandshakeResponseSchemaWithCodes(
+      Type.Union([
+        Type.Literal('REPL_NOT_FOUND'),
+        Type.Literal('TOKEN_EXPIRED'),
+      ]),
+    );
     const rejection = {
       type: 'HANDSHAKE_RESP',
       status: {

--- a/transport/message.ts
+++ b/transport/message.ts
@@ -123,13 +123,21 @@ export const HandshakeErrorResponseCodes = Type.Union([
   HandshakeErrorFatalResponseCodes,
 ]);
 
+export type LiteralErrorCode<Code extends string> = string extends Code
+  ? never
+  : Code;
+
+export type LiteralErrorCodes<Code extends string> = ReadonlyArray<
+  LiteralErrorCode<Code>
+>;
+
 /**
  * The protocol-level handshake error codes plus any application-defined
  * rejection codes the application registered in its handshake options.
  */
 export type HandshakeErrorCode<ApplicationErrorCode extends string = never> =
   | Static<typeof HandshakeErrorResponseCodes>
-  | ApplicationErrorCode;
+  | LiteralErrorCode<ApplicationErrorCode>;
 
 export const ControlMessageHandshakeResponseSchema = Type.Object({
   type: Type.Literal('HANDSHAKE_RESP'),

--- a/transport/message.ts
+++ b/transport/message.ts
@@ -151,20 +151,25 @@ export type HandshakeErrorCode<
   | Static<typeof HandshakeErrorResponseCodes>
   | ApplicationErrorCode<RejectionCodeSchemas>;
 
-export const ControlMessageHandshakeResponseSchema = Type.Object({
-  type: Type.Literal('HANDSHAKE_RESP'),
-  status: Type.Union([
-    Type.Object({
-      ok: Type.Literal(true),
-      sessionId: Type.String(),
-    }),
-    Type.Object({
-      ok: Type.Literal(false),
-      reason: Type.String(),
-      code: HandshakeErrorResponseCodes,
-    }),
-  ]),
-});
+const handshakeResponseSchema = <Code extends TSchema>(code: Code) =>
+  Type.Object({
+    type: Type.Literal('HANDSHAKE_RESP'),
+    status: Type.Union([
+      Type.Object({
+        ok: Type.Literal(true),
+        sessionId: Type.String(),
+      }),
+      Type.Object({
+        ok: Type.Literal(false),
+        reason: Type.String(),
+        code,
+      }),
+    ]),
+  });
+
+export const ControlMessageHandshakeResponseSchema = handshakeResponseSchema(
+  HandshakeErrorResponseCodes,
+);
 
 /**
  * A handshake response schema that additionally accepts application-defined
@@ -176,23 +181,9 @@ export const ControlMessageHandshakeResponseSchemaWithCodes = <
 >(
   rejectionCodeSchemas: RejectionCodeSchemas,
 ) =>
-  Type.Object({
-    type: Type.Literal('HANDSHAKE_RESP'),
-    status: Type.Union([
-      Type.Object({
-        ok: Type.Literal(true),
-        sessionId: Type.String(),
-      }),
-      Type.Object({
-        ok: Type.Literal(false),
-        reason: Type.String(),
-        code: Type.Union([
-          HandshakeErrorResponseCodes,
-          ...rejectionCodeSchemas,
-        ]),
-      }),
-    ]),
-  });
+  handshakeResponseSchema(
+    Type.Union([HandshakeErrorResponseCodes, ...rejectionCodeSchemas]),
+  );
 
 /**
  * Reserved stream id for the follow-up handshake (re-handshake) control

--- a/transport/message.ts
+++ b/transport/message.ts
@@ -127,8 +127,8 @@ export type LiteralErrorCode<Code extends string> = string extends Code
   ? never
   : Code;
 
-export type LiteralErrorCodes<Code extends string> = ReadonlyArray<
-  LiteralErrorCode<Code>
+export type LiteralErrorCodeSchemas<Code extends string> = ReadonlyArray<
+  TLiteral<LiteralErrorCode<Code>>
 >;
 
 /**
@@ -160,9 +160,9 @@ export const ControlMessageHandshakeResponseSchema = Type.Object({
  * unconfigured peer rejects an application code as a malformed response.
  */
 export const ControlMessageHandshakeResponseSchemaWithCodes = <
-  const ApplicationErrorCodes extends readonly string[],
+  const ApplicationErrorCodeSchemas extends ReadonlyArray<TLiteral<string>>,
 >(
-  applicationErrorCodes: ApplicationErrorCodes,
+  applicationErrorCodeSchemas: ApplicationErrorCodeSchemas,
 ) =>
   Type.Object({
     type: Type.Literal('HANDSHAKE_RESP'),
@@ -176,11 +176,7 @@ export const ControlMessageHandshakeResponseSchemaWithCodes = <
         reason: Type.String(),
         code: Type.Union([
           HandshakeErrorResponseCodes,
-          Type.Union(
-            applicationErrorCodes.map(
-              (code) => Type.Literal(code) as TLiteral<typeof code>,
-            ),
-          ),
+          Type.Union([...applicationErrorCodeSchemas]),
         ]),
       }),
     ]),

--- a/transport/message.ts
+++ b/transport/message.ts
@@ -123,21 +123,33 @@ export const HandshakeErrorResponseCodes = Type.Union([
   HandshakeErrorFatalResponseCodes,
 ]);
 
-export type LiteralErrorCode<Code extends string> = string extends Code
-  ? never
-  : Code;
+/**
+ * A tuple of TypeBox literal schemas declaring the application-defined
+ * handshake rejection codes, e.g.
+ * `[Type.Literal('REPL_NOT_FOUND'), Type.Literal('TOKEN_EXPIRED')] as const`.
+ */
+export type ApplicationErrorCodeSchemas = ReadonlyArray<TLiteral<string>>;
 
-export type LiteralErrorCodeSchemas<Code extends string> = ReadonlyArray<
-  TLiteral<LiteralErrorCode<Code>>
->;
+/**
+ * The union of codes declared by a tuple of rejection code schemas.
+ * Widened schemas (`TLiteral<string>` rather than a specific literal)
+ * contribute no codes.
+ */
+export type ApplicationErrorCode<
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas,
+> = string extends Static<RejectionCodeSchemas[number]>
+  ? never
+  : Static<RejectionCodeSchemas[number]>;
 
 /**
  * The protocol-level handshake error codes plus any application-defined
  * rejection codes the application registered in its handshake options.
  */
-export type HandshakeErrorCode<ApplicationErrorCode extends string = never> =
+export type HandshakeErrorCode<
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+> =
   | Static<typeof HandshakeErrorResponseCodes>
-  | LiteralErrorCode<ApplicationErrorCode>;
+  | ApplicationErrorCode<RejectionCodeSchemas>;
 
 export const ControlMessageHandshakeResponseSchema = Type.Object({
   type: Type.Literal('HANDSHAKE_RESP'),
@@ -160,9 +172,9 @@ export const ControlMessageHandshakeResponseSchema = Type.Object({
  * unconfigured peer rejects an application code as a malformed response.
  */
 export const ControlMessageHandshakeResponseSchemaWithCodes = <
-  const ApplicationErrorCodeSchemas extends ReadonlyArray<TLiteral<string>>,
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas,
 >(
-  applicationErrorCodeSchemas: ApplicationErrorCodeSchemas,
+  rejectionCodeSchemas: RejectionCodeSchemas,
 ) =>
   Type.Object({
     type: Type.Literal('HANDSHAKE_RESP'),
@@ -176,7 +188,7 @@ export const ControlMessageHandshakeResponseSchemaWithCodes = <
         reason: Type.String(),
         code: Type.Union([
           HandshakeErrorResponseCodes,
-          Type.Union([...applicationErrorCodeSchemas]),
+          ...rejectionCodeSchemas,
         ]),
       }),
     ]),
@@ -301,7 +313,9 @@ export function handshakeRequestMessage({
  */
 export const SESSION_STATE_MISMATCH = 'session state mismatch';
 
-export function handshakeResponseMessage({
+export function handshakeResponseMessage<
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+>({
   from,
   to,
   status,
@@ -312,7 +326,11 @@ export function handshakeResponseMessage({
   // known to peers that registered it in their handshake options
   status:
     | { ok: true; sessionId: string }
-    | { ok: false; reason: string; code: string };
+    | {
+        ok: false;
+        reason: string;
+        code: HandshakeErrorCode<RejectionCodeSchemas>;
+      };
 }): TransportMessage<Static<typeof ControlMessageHandshakeResponseSchema>> {
   return {
     id: generateId(),

--- a/transport/message.ts
+++ b/transport/message.ts
@@ -1,4 +1,10 @@
-import { Type, type TLiteral, type TSchema, type Static } from 'typebox';
+import {
+  Type,
+  type TLiteral,
+  type TSchema,
+  type TUnion,
+  type Static,
+} from 'typebox';
 import { PropagationContext } from '../tracing';
 import { generateId } from './id';
 // type-only: a value import closes a transport <-> router require cycle
@@ -124,32 +130,36 @@ export const HandshakeErrorResponseCodes = Type.Union([
 ]);
 
 /**
- * A tuple of TypeBox literal schemas declaring the application-defined
- * handshake rejection codes, e.g.
- * `[Type.Literal('REPL_NOT_FOUND'), Type.Literal('TOKEN_EXPIRED')] as const`.
+ * A TypeBox union of literals declaring the custom handshake rejection codes.
  */
-export type ApplicationErrorCodeSchemas = ReadonlyArray<TLiteral<string>>;
+export type CustomHandshakeErrorCodeSchema = TUnion<Array<TLiteral<string>>>;
 
 /**
- * The union of codes declared by a tuple of rejection code schemas.
- * Widened schemas (`TLiteral<string>` rather than a specific literal)
- * contribute no codes.
+ * The union of codes declared by a rejection code schema. Widened literal
+ * schemas (`TLiteral<string>` rather than a specific literal) contribute no
+ * codes.
  */
-export type ApplicationErrorCode<
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas,
-> = string extends Static<RejectionCodeSchemas[number]>
+export type CustomHandshakeErrorCode<
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema,
+> = string extends Static<RejectionCodeSchema>
   ? never
-  : Static<RejectionCodeSchemas[number]>;
+  : Static<RejectionCodeSchema>;
 
 /**
- * The protocol-level handshake error codes plus any application-defined
- * rejection codes the application registered in its handshake options.
+ * The protocol-level handshake error codes River can emit without any custom
+ * rejection codes.
+ */
+export type BuiltInHandshakeErrorCode = Static<
+  typeof HandshakeErrorResponseCodes
+>;
+
+/**
+ * The protocol-level handshake error codes plus any custom rejection codes
+ * registered in the handshake options.
  */
 export type HandshakeErrorCode<
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
-> =
-  | Static<typeof HandshakeErrorResponseCodes>
-  | ApplicationErrorCode<RejectionCodeSchemas>;
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema,
+> = BuiltInHandshakeErrorCode | CustomHandshakeErrorCode<RejectionCodeSchema>;
 
 const handshakeResponseSchema = <Code extends TSchema>(code: Code) =>
   Type.Object({
@@ -172,17 +182,17 @@ export const ControlMessageHandshakeResponseSchema = handshakeResponseSchema(
 );
 
 /**
- * A handshake response schema that additionally accepts application-defined
+ * A handshake response schema that additionally accepts custom
  * rejection codes. Both peers must be configured with the same codes: an
- * unconfigured peer rejects an application code as a malformed response.
+ * unconfigured peer rejects a custom code as a malformed response.
  */
 export const ControlMessageHandshakeResponseSchemaWithCodes = <
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas,
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema,
 >(
-  rejectionCodeSchemas: RejectionCodeSchemas,
+  rejectionCodeSchema: RejectionCodeSchema,
 ) =>
   handshakeResponseSchema(
-    Type.Union([HandshakeErrorResponseCodes, ...rejectionCodeSchemas]),
+    Type.Union([HandshakeErrorResponseCodes, rejectionCodeSchema]),
   );
 
 /**
@@ -305,7 +315,7 @@ export function handshakeRequestMessage({
 export const SESSION_STATE_MISMATCH = 'session state mismatch';
 
 export function handshakeResponseMessage<
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema,
 >({
   from,
   to,
@@ -313,14 +323,14 @@ export function handshakeResponseMessage<
 }: {
   from: TransportClientId;
   to: TransportClientId;
-  // the code may be an application-defined rejection code, which is only
+  // the code may be a custom rejection code, which is only
   // known to peers that registered it in their handshake options
   status:
     | { ok: true; sessionId: string }
     | {
         ok: false;
         reason: string;
-        code: HandshakeErrorCode<RejectionCodeSchemas>;
+        code: HandshakeErrorCode<RejectionCodeSchema>;
       };
 }): TransportMessage<Static<typeof ControlMessageHandshakeResponseSchema>> {
   return {

--- a/transport/message.ts
+++ b/transport/message.ts
@@ -1,4 +1,4 @@
-import { Type, type TSchema, type Static } from 'typebox';
+import { Type, type TLiteral, type TSchema, type Static } from 'typebox';
 import { PropagationContext } from '../tracing';
 import { generateId } from './id';
 // type-only: a value import closes a transport <-> router require cycle
@@ -123,6 +123,14 @@ export const HandshakeErrorResponseCodes = Type.Union([
   HandshakeErrorFatalResponseCodes,
 ]);
 
+/**
+ * The protocol-level handshake error codes plus any application-defined
+ * rejection codes the application registered in its handshake options.
+ */
+export type HandshakeErrorCode<ApplicationErrorCode extends string = never> =
+  | Static<typeof HandshakeErrorResponseCodes>
+  | ApplicationErrorCode;
+
 export const ControlMessageHandshakeResponseSchema = Type.Object({
   type: Type.Literal('HANDSHAKE_RESP'),
   status: Type.Union([
@@ -137,6 +145,38 @@ export const ControlMessageHandshakeResponseSchema = Type.Object({
     }),
   ]),
 });
+
+/**
+ * A handshake response schema that additionally accepts application-defined
+ * rejection codes. Both peers must be configured with the same codes: an
+ * unconfigured peer rejects an application code as a malformed response.
+ */
+export const ControlMessageHandshakeResponseSchemaWithCodes = <
+  const ApplicationErrorCodes extends readonly string[],
+>(
+  applicationErrorCodes: ApplicationErrorCodes,
+) =>
+  Type.Object({
+    type: Type.Literal('HANDSHAKE_RESP'),
+    status: Type.Union([
+      Type.Object({
+        ok: Type.Literal(true),
+        sessionId: Type.String(),
+      }),
+      Type.Object({
+        ok: Type.Literal(false),
+        reason: Type.String(),
+        code: Type.Union([
+          HandshakeErrorResponseCodes,
+          Type.Union(
+            applicationErrorCodes.map(
+              (code) => Type.Literal(code) as TLiteral<typeof code>,
+            ),
+          ),
+        ]),
+      }),
+    ]),
+  });
 
 /**
  * Reserved stream id for the follow-up handshake (re-handshake) control
@@ -264,7 +304,11 @@ export function handshakeResponseMessage({
 }: {
   from: TransportClientId;
   to: TransportClientId;
-  status: Static<typeof ControlMessageHandshakeResponseSchema>['status'];
+  // the code may be an application-defined rejection code, which is only
+  // known to peers that registered it in their handshake options
+  status:
+    | { ok: true; sessionId: string }
+    | { ok: false; reason: string; code: string };
 }): TransportMessage<Static<typeof ControlMessageHandshakeResponseSchema>> {
   return {
     id: generateId(),
@@ -276,8 +320,10 @@ export function handshakeResponseMessage({
     controlFlags: 0,
     payload: {
       type: 'HANDSHAKE_RESP',
-      status,
-    } satisfies Static<typeof ControlMessageHandshakeResponseSchema>,
+      status: status as Static<
+        typeof ControlMessageHandshakeResponseSchema
+      >['status'],
+    },
   };
 }
 

--- a/transport/server.ts
+++ b/transport/server.ts
@@ -6,6 +6,7 @@ import {
   ControlMessageRehandshakeResponseSchema,
   HandshakeErrorCustomHandlerFatalResponseCodes,
   type HandshakeErrorCode,
+  type LiteralErrorCode,
   OpaqueTransportMessage,
   acceptedProtocolVersions,
   TransportClientId,
@@ -88,11 +89,11 @@ export abstract class ServerTransport<
 
   private isApplicationRejectionCode(
     value: unknown,
-  ): value is ApplicationErrorCode {
+  ): value is LiteralErrorCode<ApplicationErrorCode> {
     return (
       typeof value === 'string' &&
       (this.handshakeExtensions?.rejectionCodes?.includes(
-        value as ApplicationErrorCode,
+        value as LiteralErrorCode<ApplicationErrorCode>,
       ) ??
         false)
     );

--- a/transport/server.ts
+++ b/transport/server.ts
@@ -22,7 +22,7 @@ import {
 } from './options';
 import { DeleteSessionOptions, Transport } from './transport';
 import { coerceErrorString } from './stringifyError';
-import type { TSchema } from 'typebox';
+import type { Static, TSchema } from 'typebox';
 import { Value } from 'typebox/value';
 import { ProtocolError } from './events';
 import { Connection } from './connection';
@@ -88,13 +88,17 @@ export abstract class ServerTransport<
     this.handshakeExtensions = options;
   }
 
-  private isApplicationRejectionCode(
+  private isRejectionCode(
     value: unknown,
-  ): value is ApplicationErrorCode<RejectionCodeSchemas> {
+  ): value is
+    | Static<typeof HandshakeErrorCustomHandlerFatalResponseCodes>
+    | ApplicationErrorCode<RejectionCodeSchemas> {
     return (
-      this.handshakeExtensions?.rejectionCodeSchemas?.some((schema) =>
+      Value.Check(HandshakeErrorCustomHandlerFatalResponseCodes, value) ||
+      (this.handshakeExtensions?.rejectionCodeSchemas?.some((schema) =>
         Value.Check(schema, value),
-      ) ?? false
+      ) ??
+        false)
     );
   }
 
@@ -225,17 +229,11 @@ export abstract class ServerTransport<
       return;
     }
 
-    if (
-      Value.Check(
-        HandshakeErrorCustomHandlerFatalResponseCodes,
-        parsedMetadataOrFailureCode,
-      ) ||
-      this.isApplicationRejectionCode(parsedMetadataOrFailureCode)
-    ) {
+    if (this.isRejectionCode(parsedMetadataOrFailureCode)) {
       this.teardownForFailedRehandshake(
         session,
         're-handshake metadata rejected by handshake handler',
-        parsedMetadataOrFailureCode as HandshakeErrorCode<RejectionCodeSchemas>,
+        parsedMetadataOrFailureCode,
       );
 
       return;
@@ -521,18 +519,12 @@ export abstract class ServerTransport<
       }
 
       // handler rejected the connection
-      if (
-        Value.Check(
-          HandshakeErrorCustomHandlerFatalResponseCodes,
-          parsedMetadataOrFailureCode,
-        ) ||
-        this.isApplicationRejectionCode(parsedMetadataOrFailureCode)
-      ) {
+      if (this.isRejectionCode(parsedMetadataOrFailureCode)) {
         this.rejectHandshakeRequest(
           session,
           msg.from,
           'rejected by handshake handler',
-          parsedMetadataOrFailureCode as HandshakeErrorCode<RejectionCodeSchemas>,
+          parsedMetadataOrFailureCode,
           {
             ...session.loggingMetadata,
             connectedTo: msg.from,

--- a/transport/server.ts
+++ b/transport/server.ts
@@ -5,8 +5,9 @@ import {
   ControlMessageHandshakeRequestSchema,
   ControlMessageRehandshakeResponseSchema,
   HandshakeErrorCustomHandlerFatalResponseCodes,
+  type ApplicationErrorCode,
+  type ApplicationErrorCodeSchemas,
   type HandshakeErrorCode,
-  type LiteralErrorCode,
   OpaqueTransportMessage,
   acceptedProtocolVersions,
   TransportClientId,
@@ -37,8 +38,8 @@ export abstract class ServerTransport<
   ConnType extends Connection,
   MetadataSchema extends TSchema = TSchema,
   ParsedMetadata extends object = object,
-  ApplicationErrorCode extends string = never,
-> extends Transport<ConnType, ApplicationErrorCode> {
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+> extends Transport<ConnType, RejectionCodeSchemas> {
   /**
    * The options for this transport.
    */
@@ -50,7 +51,7 @@ export abstract class ServerTransport<
   handshakeExtensions?: ServerHandshakeOptions<
     MetadataSchema,
     ParsedMetadata,
-    ApplicationErrorCode
+    RejectionCodeSchemas
   >;
 
   /**
@@ -81,7 +82,7 @@ export abstract class ServerTransport<
     options: ServerHandshakeOptions<
       MetadataSchema,
       ParsedMetadata,
-      ApplicationErrorCode
+      RejectionCodeSchemas
     >,
   ) {
     this.handshakeExtensions = options;
@@ -89,7 +90,7 @@ export abstract class ServerTransport<
 
   private isApplicationRejectionCode(
     value: unknown,
-  ): value is LiteralErrorCode<ApplicationErrorCode> {
+  ): value is ApplicationErrorCode<RejectionCodeSchemas> {
     return (
       this.handshakeExtensions?.rejectionCodeSchemas?.some((schema) =>
         Value.Check(schema, value),
@@ -234,7 +235,7 @@ export abstract class ServerTransport<
       this.teardownForFailedRehandshake(
         session,
         're-handshake metadata rejected by handshake handler',
-        parsedMetadataOrFailureCode as HandshakeErrorCode<ApplicationErrorCode>,
+        parsedMetadataOrFailureCode as HandshakeErrorCode<RejectionCodeSchemas>,
       );
 
       return;
@@ -268,7 +269,7 @@ export abstract class ServerTransport<
   private teardownForFailedRehandshake(
     session: ServerSession<ConnType>,
     reason: string,
-    code: HandshakeErrorCode<ApplicationErrorCode> = 'REJECTED_BY_CUSTOM_HANDLER',
+    code: HandshakeErrorCode<RejectionCodeSchemas> = 'REJECTED_BY_CUSTOM_HANDLER',
   ) {
     if (session._isConsumed) {
       return;
@@ -377,7 +378,7 @@ export abstract class ServerTransport<
     session: SessionWaitingForHandshake<ConnType>,
     to: TransportClientId,
     reason: string,
-    code: HandshakeErrorCode<ApplicationErrorCode>,
+    code: HandshakeErrorCode<RejectionCodeSchemas>,
     metadata: MessageMetadata,
   ) {
     session.conn.telemetry?.span.setStatus({
@@ -531,7 +532,7 @@ export abstract class ServerTransport<
           session,
           msg.from,
           'rejected by handshake handler',
-          parsedMetadataOrFailureCode as HandshakeErrorCode<ApplicationErrorCode>,
+          parsedMetadataOrFailureCode as HandshakeErrorCode<RejectionCodeSchemas>,
           {
             ...session.loggingMetadata,
             connectedTo: msg.from,

--- a/transport/server.ts
+++ b/transport/server.ts
@@ -5,7 +5,7 @@ import {
   ControlMessageHandshakeRequestSchema,
   ControlMessageRehandshakeResponseSchema,
   HandshakeErrorCustomHandlerFatalResponseCodes,
-  HandshakeErrorResponseCodes,
+  type HandshakeErrorCode,
   OpaqueTransportMessage,
   acceptedProtocolVersions,
   TransportClientId,
@@ -20,7 +20,7 @@ import {
 } from './options';
 import { DeleteSessionOptions, Transport } from './transport';
 import { coerceErrorString } from './stringifyError';
-import type { Static, TSchema } from 'typebox';
+import type { TSchema } from 'typebox';
 import { Value } from 'typebox/value';
 import { ProtocolError } from './events';
 import { Connection } from './connection';
@@ -36,7 +36,8 @@ export abstract class ServerTransport<
   ConnType extends Connection,
   MetadataSchema extends TSchema = TSchema,
   ParsedMetadata extends object = object,
-> extends Transport<ConnType> {
+  ApplicationErrorCode extends string = never,
+> extends Transport<ConnType, ApplicationErrorCode> {
   /**
    * The options for this transport.
    */
@@ -45,7 +46,11 @@ export abstract class ServerTransport<
   /**
    * Optional handshake options for the server.
    */
-  handshakeExtensions?: ServerHandshakeOptions<MetadataSchema, ParsedMetadata>;
+  handshakeExtensions?: ServerHandshakeOptions<
+    MetadataSchema,
+    ParsedMetadata,
+    ApplicationErrorCode
+  >;
 
   /**
    * A map of session handshake data for each session.
@@ -72,9 +77,25 @@ export abstract class ServerTransport<
   }
 
   extendHandshake(
-    options: ServerHandshakeOptions<MetadataSchema, ParsedMetadata>,
+    options: ServerHandshakeOptions<
+      MetadataSchema,
+      ParsedMetadata,
+      ApplicationErrorCode
+    >,
   ) {
     this.handshakeExtensions = options;
+  }
+
+  private isApplicationRejectionCode(
+    value: unknown,
+  ): value is ApplicationErrorCode {
+    return (
+      typeof value === 'string' &&
+      (this.handshakeExtensions?.rejectionCodes?.includes(
+        value as ApplicationErrorCode,
+      ) ??
+        false)
+    );
   }
 
   protected deletePendingSession(
@@ -208,11 +229,13 @@ export abstract class ServerTransport<
       Value.Check(
         HandshakeErrorCustomHandlerFatalResponseCodes,
         parsedMetadataOrFailureCode,
-      )
+      ) ||
+      this.isApplicationRejectionCode(parsedMetadataOrFailureCode)
     ) {
       this.teardownForFailedRehandshake(
         session,
         're-handshake metadata rejected by handshake handler',
+        parsedMetadataOrFailureCode as HandshakeErrorCode<ApplicationErrorCode>,
       );
 
       return;
@@ -246,6 +269,7 @@ export abstract class ServerTransport<
   private teardownForFailedRehandshake(
     session: ServerSession<ConnType>,
     reason: string,
+    code: HandshakeErrorCode<ApplicationErrorCode> = 'REJECTED_BY_CUSTOM_HANDLER',
   ) {
     if (session._isConsumed) {
       return;
@@ -263,7 +287,7 @@ export abstract class ServerTransport<
 
     this.protocolError({
       type: ProtocolError.HandshakeFailed,
-      code: 'REJECTED_BY_CUSTOM_HANDLER',
+      code,
       message: reason,
     });
     this.deleteSession(session, { unhealthy: true });
@@ -354,7 +378,7 @@ export abstract class ServerTransport<
     session: SessionWaitingForHandshake<ConnType>,
     to: TransportClientId,
     reason: string,
-    code: Static<typeof HandshakeErrorResponseCodes>,
+    code: HandshakeErrorCode<ApplicationErrorCode>,
     metadata: MessageMetadata,
   ) {
     session.conn.telemetry?.span.setStatus({
@@ -501,13 +525,14 @@ export abstract class ServerTransport<
         Value.Check(
           HandshakeErrorCustomHandlerFatalResponseCodes,
           parsedMetadataOrFailureCode,
-        )
+        ) ||
+        this.isApplicationRejectionCode(parsedMetadataOrFailureCode)
       ) {
         this.rejectHandshakeRequest(
           session,
           msg.from,
           'rejected by handshake handler',
-          parsedMetadataOrFailureCode,
+          parsedMetadataOrFailureCode as HandshakeErrorCode<ApplicationErrorCode>,
           {
             ...session.loggingMetadata,
             connectedTo: msg.from,

--- a/transport/server.ts
+++ b/transport/server.ts
@@ -91,11 +91,9 @@ export abstract class ServerTransport<
     value: unknown,
   ): value is LiteralErrorCode<ApplicationErrorCode> {
     return (
-      typeof value === 'string' &&
-      (this.handshakeExtensions?.rejectionCodes?.includes(
-        value as LiteralErrorCode<ApplicationErrorCode>,
-      ) ??
-        false)
+      this.handshakeExtensions?.rejectionCodeSchemas?.some((schema) =>
+        Value.Check(schema, value),
+      ) ?? false
     );
   }
 

--- a/transport/server.ts
+++ b/transport/server.ts
@@ -5,8 +5,8 @@ import {
   ControlMessageHandshakeRequestSchema,
   ControlMessageRehandshakeResponseSchema,
   HandshakeErrorCustomHandlerFatalResponseCodes,
-  type ApplicationErrorCode,
-  type ApplicationErrorCodeSchemas,
+  type CustomHandshakeErrorCode,
+  type CustomHandshakeErrorCodeSchema,
   type HandshakeErrorCode,
   OpaqueTransportMessage,
   acceptedProtocolVersions,
@@ -38,8 +38,8 @@ export abstract class ServerTransport<
   ConnType extends Connection,
   MetadataSchema extends TSchema = TSchema,
   ParsedMetadata extends object = object,
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
-> extends Transport<ConnType, RejectionCodeSchemas> {
+  RejectionCodeSchema extends CustomHandshakeErrorCodeSchema = never,
+> extends Transport<ConnType, HandshakeErrorCode<RejectionCodeSchema>> {
   /**
    * The options for this transport.
    */
@@ -51,7 +51,7 @@ export abstract class ServerTransport<
   handshakeExtensions?: ServerHandshakeOptions<
     MetadataSchema,
     ParsedMetadata,
-    RejectionCodeSchemas
+    RejectionCodeSchema
   >;
 
   /**
@@ -78,27 +78,26 @@ export abstract class ServerTransport<
     });
   }
 
-  extendHandshake(
+  extendHandshake = (
     options: ServerHandshakeOptions<
       MetadataSchema,
       ParsedMetadata,
-      RejectionCodeSchemas
+      RejectionCodeSchema
     >,
-  ) {
+  ) => {
     this.handshakeExtensions = options;
-  }
+  };
 
   private isRejectionCode(
     value: unknown,
   ): value is
     | Static<typeof HandshakeErrorCustomHandlerFatalResponseCodes>
-    | ApplicationErrorCode<RejectionCodeSchemas> {
+    | CustomHandshakeErrorCode<RejectionCodeSchema> {
     return (
       Value.Check(HandshakeErrorCustomHandlerFatalResponseCodes, value) ||
-      (this.handshakeExtensions?.rejectionCodeSchemas?.some((schema) =>
-        Value.Check(schema, value),
-      ) ??
-        false)
+      (this.handshakeExtensions?.rejectionCodeSchema
+        ? Value.Check(this.handshakeExtensions.rejectionCodeSchema, value)
+        : false)
     );
   }
 
@@ -267,7 +266,7 @@ export abstract class ServerTransport<
   private teardownForFailedRehandshake(
     session: ServerSession<ConnType>,
     reason: string,
-    code: HandshakeErrorCode<RejectionCodeSchemas> = 'REJECTED_BY_CUSTOM_HANDLER',
+    code: HandshakeErrorCode<RejectionCodeSchema> = 'REJECTED_BY_CUSTOM_HANDLER',
   ) {
     if (session._isConsumed) {
       return;
@@ -376,7 +375,7 @@ export abstract class ServerTransport<
     session: SessionWaitingForHandshake<ConnType>,
     to: TransportClientId,
     reason: string,
-    code: HandshakeErrorCode<RejectionCodeSchemas>,
+    code: HandshakeErrorCode<RejectionCodeSchema>,
     metadata: MessageMetadata,
   ) {
     session.conn.telemetry?.span.setStatus({

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -1968,7 +1968,7 @@ describe.each(testMatrix())(
         createServerHandshakeOptions<
           typeof schema,
           ParsedMetadata,
-          ApplicationErrorCode
+          typeof rejectionCodeSchemas
         >(
           schema,
           // @ts-expect-error only declared rejection codes may be returned
@@ -1982,11 +1982,15 @@ describe.each(testMatrix())(
       const broadCodeSchemas = [Type.Literal(broadCode)];
 
       expect(
-        createServerHandshakeOptions<typeof schema, ParsedMetadata, string>(
+        createServerHandshakeOptions<
+          typeof schema,
+          ParsedMetadata,
+          typeof broadCodeSchemas
+        >(
           schema,
-          async () => ({ foo: 'foo' }),
+          // @ts-expect-error widened literal schemas contribute no codes
+          async () => broadCode,
           undefined,
-          // @ts-expect-error application error schemas must use literals
           broadCodeSchemas,
         ),
       ).toBeDefined();
@@ -1997,7 +2001,7 @@ describe.each(testMatrix())(
       const serverTransport = getServerTransport<
         typeof schema,
         ParsedMetadata,
-        ApplicationErrorCode
+        typeof rejectionCodeSchemas
       >('SERVER', {
         schema,
         validate: parse,
@@ -2056,9 +2060,9 @@ describe.each(testMatrix())(
         foo: Type.String(),
       });
 
-      const rejectionCodeSchema = Type.Literal('REPL_NOT_FOUND');
+      const rejectionCodeSchemas = [Type.Literal('REPL_NOT_FOUND')] as const;
 
-      type ApplicationErrorCode = Static<typeof rejectionCodeSchema>;
+      type ApplicationErrorCode = Static<(typeof rejectionCodeSchemas)[number]>;
 
       interface ParsedMetadata {
         foo: string;
@@ -2067,11 +2071,11 @@ describe.each(testMatrix())(
       const serverTransport = getServerTransport<
         typeof schema,
         ParsedMetadata,
-        ApplicationErrorCode
+        typeof rejectionCodeSchemas
       >('SERVER', {
         schema,
         validate: async (): Promise<ApplicationErrorCode> => 'REPL_NOT_FOUND',
-        rejectionCodeSchemas: [rejectionCodeSchema],
+        rejectionCodeSchemas,
       });
 
       // the client did not register the application code: it must treat the
@@ -2100,7 +2104,9 @@ describe.each(testMatrix())(
       expect(clientHandshakeFailed).not.toHaveBeenCalled();
 
       await testFinishesCleanly({ clientTransports: [clientTransport] });
-      await testFinishesCleanly<ApplicationErrorCode>({ serverTransport });
+      await testFinishesCleanly<typeof rejectionCodeSchemas>({
+        serverTransport,
+      });
     });
   },
 );

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -1947,17 +1947,17 @@ describe.each(testMatrix())(
       });
     });
 
-    test('custom handler can reject with an application-defined code', async () => {
+    test('custom handler can reject with a registered handshake error code', async () => {
       const schema = Type.Object({
         foo: Type.String(),
       });
 
-      const rejectionCodeSchemas = [
+      const rejectionCodeSchema = Type.Union([
         Type.Literal('REPL_NOT_FOUND'),
         Type.Literal('TOKEN_EXPIRED'),
-      ] as const;
+      ]);
 
-      type ApplicationErrorCode = Static<(typeof rejectionCodeSchemas)[number]>;
+      type CustomHandshakeErrorCode = Static<typeof rejectionCodeSchema>;
 
       interface ParsedMetadata {
         foo: string;
@@ -1968,50 +1968,50 @@ describe.each(testMatrix())(
         createServerHandshakeOptions<
           typeof schema,
           ParsedMetadata,
-          typeof rejectionCodeSchemas
+          typeof rejectionCodeSchema
         >(
           schema,
           // @ts-expect-error only declared rejection codes may be returned
           async () => 'SOME_OTHER_CODE',
           undefined,
-          rejectionCodeSchemas,
+          rejectionCodeSchema,
         ),
       ).toBeDefined();
 
       const broadCode = String('REPL_NOT_FOUND');
-      const broadCodeSchemas = [Type.Literal(broadCode)];
+      const broadCodeSchema = Type.Union([Type.Literal(broadCode)]);
 
       expect(
         createServerHandshakeOptions<
           typeof schema,
           ParsedMetadata,
-          typeof broadCodeSchemas
+          typeof broadCodeSchema
         >(
           schema,
           // @ts-expect-error widened literal schemas contribute no codes
           async () => broadCode,
           undefined,
-          broadCodeSchemas,
+          broadCodeSchema,
         ),
       ).toBeDefined();
 
-      const parse = vi.fn(async (): Promise<ApplicationErrorCode> => {
+      const parse = vi.fn(async (): Promise<CustomHandshakeErrorCode> => {
         return 'REPL_NOT_FOUND';
       });
       const serverTransport = getServerTransport<
         typeof schema,
         ParsedMetadata,
-        typeof rejectionCodeSchemas
+        typeof rejectionCodeSchema
       >('SERVER', {
         schema,
         validate: parse,
-        rejectionCodeSchemas,
+        rejectionCodeSchema,
       });
 
       const clientTransport = getClientTransport('client', {
         schema,
         construct: async () => ({ foo: 'foo' }),
-        rejectionCodeSchemas,
+        rejectionCodeSchema,
       });
 
       const clientHandshakeFailed = vi.fn();
@@ -2055,14 +2055,14 @@ describe.each(testMatrix())(
       });
     });
 
-    test('an application code is rejected by an unconfigured client', async () => {
+    test('an unregistered handshake error code is rejected by an unconfigured client', async () => {
       const schema = Type.Object({
         foo: Type.String(),
       });
 
-      const rejectionCodeSchemas = [Type.Literal('REPL_NOT_FOUND')] as const;
+      const rejectionCodeSchema = Type.Union([Type.Literal('REPL_NOT_FOUND')]);
 
-      type ApplicationErrorCode = Static<(typeof rejectionCodeSchemas)[number]>;
+      type CustomHandshakeErrorCode = Static<typeof rejectionCodeSchema>;
 
       interface ParsedMetadata {
         foo: string;
@@ -2071,14 +2071,15 @@ describe.each(testMatrix())(
       const serverTransport = getServerTransport<
         typeof schema,
         ParsedMetadata,
-        typeof rejectionCodeSchemas
+        typeof rejectionCodeSchema
       >('SERVER', {
         schema,
-        validate: async (): Promise<ApplicationErrorCode> => 'REPL_NOT_FOUND',
-        rejectionCodeSchemas,
+        validate: async (): Promise<CustomHandshakeErrorCode> =>
+          'REPL_NOT_FOUND',
+        rejectionCodeSchema,
       });
 
-      // the client did not register the application code: it must treat the
+      // the client did not register the custom code: it must treat the
       // response as malformed rather than accept an unknown code
       const clientTransport = getClientTransport('client', {
         schema,
@@ -2104,9 +2105,7 @@ describe.each(testMatrix())(
       expect(clientHandshakeFailed).not.toHaveBeenCalled();
 
       await testFinishesCleanly({ clientTransports: [clientTransport] });
-      await testFinishesCleanly<typeof rejectionCodeSchemas>({
-        serverTransport,
-      });
+      await testFinishesCleanly({ serverTransport });
     });
   },
 );

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -21,7 +21,7 @@ import {
 } from '../testUtil/fixtures/cleanup';
 import { testMatrix } from '../testUtil/fixtures/matrix';
 import { PartialTransportMessage } from './message';
-import { Type } from 'typebox';
+import { Type, type Static } from 'typebox';
 import { TestSetupHelpers } from '../testUtil/fixtures/transports';
 import { createPostTestCleanups } from '../testUtil/fixtures/cleanup';
 import { SessionState } from './sessionStateMachine';
@@ -1952,8 +1952,13 @@ describe.each(testMatrix())(
         foo: Type.String(),
       });
 
-      const rejectionCodes = ['REPL_NOT_FOUND', 'TOKEN_EXPIRED'] as const;
-      type ApplicationErrorCode = (typeof rejectionCodes)[number];
+      const rejectionCodeSchemas = [
+        Type.Literal('REPL_NOT_FOUND'),
+        Type.Literal('TOKEN_EXPIRED'),
+      ] as const;
+
+      type ApplicationErrorCode = Static<(typeof rejectionCodeSchemas)[number]>;
+
       interface ParsedMetadata {
         foo: string;
       }
@@ -1969,18 +1974,20 @@ describe.each(testMatrix())(
           // @ts-expect-error only declared rejection codes may be returned
           async () => 'SOME_OTHER_CODE',
           undefined,
-          rejectionCodes,
+          rejectionCodeSchemas,
         ),
       ).toBeDefined();
 
-      const broadCodes: string[] = ['REPL_NOT_FOUND'];
+      const broadCode: string = 'REPL_NOT_FOUND';
+      const broadCodeSchemas = [Type.Literal(broadCode)];
+
       expect(
         createServerHandshakeOptions<typeof schema, ParsedMetadata, string>(
           schema,
           async () => ({ foo: 'foo' }),
           undefined,
-          // @ts-expect-error application error codes must be string literals
-          broadCodes,
+          // @ts-expect-error application error schemas must use literals
+          broadCodeSchemas,
         ),
       ).toBeDefined();
 
@@ -1994,13 +2001,13 @@ describe.each(testMatrix())(
       >('SERVER', {
         schema,
         validate: parse,
-        rejectionCodes,
+        rejectionCodeSchemas,
       });
 
       const clientTransport = getClientTransport('client', {
         schema,
         construct: async () => ({ foo: 'foo' }),
-        rejectionCodes,
+        rejectionCodeSchemas,
       });
 
       const clientHandshakeFailed = vi.fn();
@@ -2061,7 +2068,7 @@ describe.each(testMatrix())(
       >('SERVER', {
         schema,
         validate: async (): Promise<ApplicationErrorCode> => 'REPL_NOT_FOUND',
-        rejectionCodes: ['REPL_NOT_FOUND'],
+        rejectionCodeSchemas: [Type.Literal('REPL_NOT_FOUND')],
       });
 
       // the client did not register the application code: it must treat the

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -1978,7 +1978,7 @@ describe.each(testMatrix())(
         ),
       ).toBeDefined();
 
-      const broadCode: string = 'REPL_NOT_FOUND';
+      const broadCode = String('REPL_NOT_FOUND');
       const broadCodeSchemas = [Type.Literal(broadCode)];
 
       expect(
@@ -2056,7 +2056,10 @@ describe.each(testMatrix())(
         foo: Type.String(),
       });
 
-      type ApplicationErrorCode = 'REPL_NOT_FOUND';
+      const rejectionCodeSchema = Type.Literal('REPL_NOT_FOUND');
+
+      type ApplicationErrorCode = Static<typeof rejectionCodeSchema>;
+
       interface ParsedMetadata {
         foo: string;
       }
@@ -2068,7 +2071,7 @@ describe.each(testMatrix())(
       >('SERVER', {
         schema,
         validate: async (): Promise<ApplicationErrorCode> => 'REPL_NOT_FOUND',
-        rejectionCodeSchemas: [Type.Literal('REPL_NOT_FOUND')],
+        rejectionCodeSchemas: [rejectionCodeSchema],
       });
 
       // the client did not register the application code: it must treat the

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -25,6 +25,7 @@ import { Type } from 'typebox';
 import { TestSetupHelpers } from '../testUtil/fixtures/transports';
 import { createPostTestCleanups } from '../testUtil/fixtures/cleanup';
 import { SessionState } from './sessionStateMachine';
+import { createServerHandshakeOptions } from '../router/handshake';
 import {
   ProvidedClientTransportOptions,
   ProvidedTransportOptions,
@@ -1939,6 +1940,145 @@ describe.each(testMatrix())(
           message: 'rejected by handshake handler',
         });
       });
+
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+      });
+    });
+
+    test('custom handler can reject with an application-defined code', async () => {
+      const schema = Type.Object({
+        foo: Type.String(),
+      });
+
+      type ApplicationErrorCode = 'REPL_NOT_FOUND' | 'TOKEN_EXPIRED';
+      const rejectionCodes: ReadonlyArray<ApplicationErrorCode> = [
+        'REPL_NOT_FOUND',
+        'TOKEN_EXPIRED',
+      ];
+      interface ParsedMetadata {
+        foo: string;
+      }
+
+      // compile-time: undeclared codes cannot be returned by validate
+      expect(
+        createServerHandshakeOptions<
+          typeof schema,
+          ParsedMetadata,
+          ApplicationErrorCode
+        >(
+          schema,
+          // @ts-expect-error only declared rejection codes may be returned
+          async () => 'SOME_OTHER_CODE',
+          undefined,
+          rejectionCodes,
+        ),
+      ).toBeDefined();
+
+      const parse = vi.fn(async (): Promise<ApplicationErrorCode> => {
+        return 'REPL_NOT_FOUND';
+      });
+      const serverTransport = getServerTransport<
+        typeof schema,
+        ParsedMetadata,
+        ApplicationErrorCode
+      >('SERVER', {
+        schema,
+        validate: parse,
+        rejectionCodes,
+      });
+
+      const clientTransport = getClientTransport('client', {
+        schema,
+        construct: async () => ({ foo: 'foo' }),
+        rejectionCodes,
+      });
+
+      const clientHandshakeFailed = vi.fn();
+      clientTransport.addEventListener('protocolError', clientHandshakeFailed);
+      const serverRejectedConnection = vi.fn();
+      serverTransport.addEventListener(
+        'protocolError',
+        serverRejectedConnection,
+      );
+      clientTransport.connect(serverTransport.clientId);
+
+      addPostTestCleanup(async () => {
+        clientTransport.removeEventListener(
+          'protocolError',
+          clientHandshakeFailed,
+        );
+        serverTransport.removeEventListener(
+          'protocolError',
+          serverRejectedConnection,
+        );
+        await cleanupTransports([clientTransport, serverTransport]);
+      });
+
+      await waitFor(() => {
+        expect(clientHandshakeFailed).toHaveBeenCalledTimes(1);
+        expect(clientHandshakeFailed).toHaveBeenCalledWith({
+          type: ProtocolError.HandshakeFailed,
+          code: 'REPL_NOT_FOUND',
+          message: 'handshake failed: rejected by handshake handler',
+        });
+        expect(serverRejectedConnection).toHaveBeenCalledWith({
+          type: ProtocolError.HandshakeFailed,
+          code: 'REPL_NOT_FOUND',
+          message: 'rejected by handshake handler',
+        });
+      });
+
+      await testFinishesCleanly({
+        clientTransports: [clientTransport],
+        serverTransport,
+      });
+    });
+
+    test('an application code is rejected by an unconfigured client', async () => {
+      const schema = Type.Object({
+        foo: Type.String(),
+      });
+
+      type ApplicationErrorCode = 'REPL_NOT_FOUND';
+      interface ParsedMetadata {
+        foo: string;
+      }
+
+      const serverTransport = getServerTransport<
+        typeof schema,
+        ParsedMetadata,
+        ApplicationErrorCode
+      >('SERVER', {
+        schema,
+        validate: async () => 'REPL_NOT_FOUND',
+        rejectionCodes: ['REPL_NOT_FOUND'],
+      });
+
+      // the client did not register the application code: it must treat the
+      // response as malformed rather than accept an unknown code
+      const clientTransport = getClientTransport('client', {
+        schema,
+        construct: async () => ({ foo: 'foo' }),
+      });
+
+      const clientHandshakeFailed = vi.fn();
+      clientTransport.addEventListener('protocolError', clientHandshakeFailed);
+      clientTransport.connect(serverTransport.clientId);
+
+      addPostTestCleanup(async () => {
+        clientTransport.removeEventListener(
+          'protocolError',
+          clientHandshakeFailed,
+        );
+        await cleanupTransports([clientTransport, serverTransport]);
+      });
+
+      await waitFor(() => {
+        expect(clientTransport.sessions.size).toBe(0);
+      });
+      expect(clientHandshakeFailed).not.toHaveBeenCalled();
 
       await testFinishesCleanly({
         clientTransports: [clientTransport],

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -1952,11 +1952,8 @@ describe.each(testMatrix())(
         foo: Type.String(),
       });
 
-      type ApplicationErrorCode = 'REPL_NOT_FOUND' | 'TOKEN_EXPIRED';
-      const rejectionCodes: ReadonlyArray<ApplicationErrorCode> = [
-        'REPL_NOT_FOUND',
-        'TOKEN_EXPIRED',
-      ];
+      const rejectionCodes = ['REPL_NOT_FOUND', 'TOKEN_EXPIRED'] as const;
+      type ApplicationErrorCode = (typeof rejectionCodes)[number];
       interface ParsedMetadata {
         foo: string;
       }
@@ -1973,6 +1970,17 @@ describe.each(testMatrix())(
           async () => 'SOME_OTHER_CODE',
           undefined,
           rejectionCodes,
+        ),
+      ).toBeDefined();
+
+      const broadCodes: string[] = ['REPL_NOT_FOUND'];
+      expect(
+        createServerHandshakeOptions<typeof schema, ParsedMetadata, string>(
+          schema,
+          async () => ({ foo: 'foo' }),
+          undefined,
+          // @ts-expect-error application error codes must be string literals
+          broadCodes,
         ),
       ).toBeDefined();
 
@@ -2072,7 +2080,8 @@ describe.each(testMatrix())(
           'protocolError',
           clientHandshakeFailed,
         );
-        await cleanupTransports([clientTransport, serverTransport]);
+        await cleanupTransports([clientTransport]);
+        await cleanupTransports([serverTransport]);
       });
 
       await waitFor(() => {
@@ -2080,10 +2089,8 @@ describe.each(testMatrix())(
       });
       expect(clientHandshakeFailed).not.toHaveBeenCalled();
 
-      await testFinishesCleanly({
-        clientTransports: [clientTransport],
-        serverTransport,
-      });
+      await testFinishesCleanly({ clientTransports: [clientTransport] });
+      await testFinishesCleanly<ApplicationErrorCode>({ serverTransport });
     });
   },
 );

--- a/transport/transport.test.ts
+++ b/transport/transport.test.ts
@@ -2052,7 +2052,7 @@ describe.each(testMatrix())(
         ApplicationErrorCode
       >('SERVER', {
         schema,
-        validate: async () => 'REPL_NOT_FOUND',
+        validate: async (): Promise<ApplicationErrorCode> => 'REPL_NOT_FOUND',
         rejectionCodes: ['REPL_NOT_FOUND'],
       });
 

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -1,5 +1,5 @@
 import {
-  type ApplicationErrorCodeSchemas,
+  type BuiltInHandshakeErrorCode,
   OpaqueTransportMessage,
   PartialTransportMessage,
   TransportClientId,
@@ -82,7 +82,7 @@ export interface SessionBackpressure {
  */
 export abstract class Transport<
   ConnType extends Connection,
-  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
+  HandshakeFailureCode extends string = BuiltInHandshakeErrorCode,
 > {
   /**
    * The status of the transport.
@@ -97,7 +97,7 @@ export abstract class Transport<
   /**
    * The event dispatcher for handling events of type EventTypes.
    */
-  eventDispatcher: EventDispatcher<EventTypes, RejectionCodeSchemas>;
+  eventDispatcher: EventDispatcher<EventTypes, HandshakeFailureCode>;
 
   /**
    * The options for this transport.
@@ -118,7 +118,10 @@ export abstract class Transport<
     providedOptions?: ProvidedTransportOptions,
   ) {
     this.options = { ...defaultTransportOptions, ...providedOptions };
-    this.eventDispatcher = new EventDispatcher();
+    this.eventDispatcher = new EventDispatcher<
+      EventTypes,
+      HandshakeFailureCode
+    >();
     this.clientId = clientId;
     this.status = 'open';
     this.sessions = new Map();
@@ -155,7 +158,7 @@ export abstract class Transport<
    */
   addEventListener<
     K extends EventTypes,
-    T extends EventHandler<K, RejectionCodeSchemas>,
+    T extends EventHandler<K, HandshakeFailureCode>,
   >(type: K, handler: T): void {
     this.eventDispatcher.addEventListener(type, handler);
   }
@@ -167,13 +170,13 @@ export abstract class Transport<
    */
   removeEventListener<
     K extends EventTypes,
-    T extends EventHandler<K, RejectionCodeSchemas>,
+    T extends EventHandler<K, HandshakeFailureCode>,
   >(type: K, handler: T): void {
     this.eventDispatcher.removeEventListener(type, handler);
   }
 
   protected protocolError(
-    message: EventMap<RejectionCodeSchemas>['protocolError'],
+    message: EventMap<HandshakeFailureCode>['protocolError'],
   ) {
     this.eventDispatcher.dispatchEvent('protocolError', message);
   }

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -1,4 +1,5 @@
 import {
+  type ApplicationErrorCodeSchemas,
   OpaqueTransportMessage,
   PartialTransportMessage,
   TransportClientId,
@@ -81,7 +82,7 @@ export interface SessionBackpressure {
  */
 export abstract class Transport<
   ConnType extends Connection,
-  ApplicationErrorCode extends string = never,
+  RejectionCodeSchemas extends ApplicationErrorCodeSchemas = [],
 > {
   /**
    * The status of the transport.
@@ -96,7 +97,7 @@ export abstract class Transport<
   /**
    * The event dispatcher for handling events of type EventTypes.
    */
-  eventDispatcher: EventDispatcher<EventTypes, ApplicationErrorCode>;
+  eventDispatcher: EventDispatcher<EventTypes, RejectionCodeSchemas>;
 
   /**
    * The options for this transport.
@@ -154,7 +155,7 @@ export abstract class Transport<
    */
   addEventListener<
     K extends EventTypes,
-    T extends EventHandler<K, ApplicationErrorCode>,
+    T extends EventHandler<K, RejectionCodeSchemas>,
   >(type: K, handler: T): void {
     this.eventDispatcher.addEventListener(type, handler);
   }
@@ -166,13 +167,13 @@ export abstract class Transport<
    */
   removeEventListener<
     K extends EventTypes,
-    T extends EventHandler<K, ApplicationErrorCode>,
+    T extends EventHandler<K, RejectionCodeSchemas>,
   >(type: K, handler: T): void {
     this.eventDispatcher.removeEventListener(type, handler);
   }
 
   protected protocolError(
-    message: EventMap<ApplicationErrorCode>['protocolError'],
+    message: EventMap<RejectionCodeSchemas>['protocolError'],
   ) {
     this.eventDispatcher.dispatchEvent('protocolError', message);
   }

--- a/transport/transport.ts
+++ b/transport/transport.ts
@@ -79,7 +79,10 @@ export interface SessionBackpressure {
  * ```
  * @abstract
  */
-export abstract class Transport<ConnType extends Connection> {
+export abstract class Transport<
+  ConnType extends Connection,
+  ApplicationErrorCode extends string = never,
+> {
   /**
    * The status of the transport.
    */
@@ -93,7 +96,7 @@ export abstract class Transport<ConnType extends Connection> {
   /**
    * The event dispatcher for handling events of type EventTypes.
    */
-  eventDispatcher: EventDispatcher<EventTypes>;
+  eventDispatcher: EventDispatcher<EventTypes, ApplicationErrorCode>;
 
   /**
    * The options for this transport.
@@ -149,10 +152,10 @@ export abstract class Transport<ConnType extends Connection> {
    * @param the type of event to listen for
    * @param handler The message handler to add.
    */
-  addEventListener<K extends EventTypes, T extends EventHandler<K>>(
-    type: K,
-    handler: T,
-  ): void {
+  addEventListener<
+    K extends EventTypes,
+    T extends EventHandler<K, ApplicationErrorCode>,
+  >(type: K, handler: T): void {
     this.eventDispatcher.addEventListener(type, handler);
   }
 
@@ -161,14 +164,16 @@ export abstract class Transport<ConnType extends Connection> {
    * @param the type of event to un-listen on
    * @param handler The message handler to remove.
    */
-  removeEventListener<K extends EventTypes, T extends EventHandler<K>>(
-    type: K,
-    handler: T,
-  ): void {
+  removeEventListener<
+    K extends EventTypes,
+    T extends EventHandler<K, ApplicationErrorCode>,
+  >(type: K, handler: T): void {
     this.eventDispatcher.removeEventListener(type, handler);
   }
 
-  protected protocolError(message: EventMap['protocolError']) {
+  protected protocolError(
+    message: EventMap<ApplicationErrorCode>['protocolError'],
+  ) {
     this.eventDispatcher.dispatchEvent('protocolError', message);
   }
 


### PR DESCRIPTION
## Why

Exploration PR, alternative to https://github.com/replit/river/pull/401. This sketches application-typed handshake rejection codes: applications declare their codes as a tuple of TypeBox literal schemas, `validate` may return them, and they travel in the handshake response's `code` field with compile-time checking on both peers.

The generics are parameterized on the schema tuple itself (`ReadonlyArray<TLiteral<string>>`), never on bare `string` unions — the code type is derived from the schemas, so this shape works end to end:

```ts
const rejectionCodeSchemas = [
  Type.Literal('ASSET_NOT_FOUND'),
  Type.Literal('TOKEN_EXPIRED'),
] as const;

type ApplicationErrorCode = Static<(typeof rejectionCodeSchemas)[number]>;
```

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change
