### PR TITLE
[AGI-1740] Bump River to 0.221.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.220.1",
+  "version": "0.221.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.220.1",
+      "version": "0.221.0",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.220.1",
+  "version": "0.221.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/replit/river.git"


### PR DESCRIPTION
## Why

River 0.221.0 includes the new application-typed handshake rejection code API from #403.

## What changed

Bumps the `@replit/river` package version from 0.220.1 to 0.221.0. This prepares the package metadata for the next minor npm release.

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

