### PR TITLE
Bump River to 0.222.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/river",
-  "version": "0.221.0",
+  "version": "0.222.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/river",
-      "version": "0.221.0",
+      "version": "0.222.0",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/river",
   "description": "It's like tRPC but... with JSON Schema Support, duplex streaming and support for service multiplexing. Transport agnostic!",
-  "version": "0.221.0",
+  "version": "0.222.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/replit/river.git"


### PR DESCRIPTION
## Why

River 0.222.0 includes the WebSocket connection extras API from https://github.com/replit/river/pull/406. This prepares that change for publication to npm.

Original conversation: https://replit.slack.com/archives/D0AEJNMGCSG/p1788333765717319

## What changed

Bumps the `@replit/river` package version from 0.221.0 to 0.222.0 in `package.json` and `package-lock.json`. This PR does not change source code or dependencies.

## Test plan

- `npm run check`
- `npm run test:single` (785 passed, 1 skipped)
- `npm run build`

## Versioning

- [ ] Breaking protocol change
- [ ] Breaking ts/js API change

~ written by Zerg :space_invader: ([volatile-queen-8e97](https://zerg.zergrush.dev/chat?id=volatile-queen-8e97))